### PR TITLE
Add homepage and admin registrations

### DIFF
--- a/documents/admin.py
+++ b/documents/admin.py
@@ -1,3 +1,19 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Document, DocumentType
+
+
+@admin.register(DocumentType)
+class DocumentTypeAdmin(admin.ModelAdmin):
+    """Admin configuration for :class:`DocumentType`."""
+
+    list_display = ("name", "workflow", "created_at", "updated_at")
+
+
+@admin.register(Document)
+class DocumentAdmin(admin.ModelAdmin):
+    """Admin configuration for :class:`Document`."""
+
+    list_display = ("type", "owner", "status", "created_at", "updated_at")
+    list_filter = ("status", "type")
+

--- a/noesis2/urls.py
+++ b/noesis2/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
+    path('', include('theme.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/theme/templates/theme/home.html
+++ b/theme/templates/theme/home.html
@@ -1,0 +1,6 @@
+{% extends 'theme/base.html' %}
+
+{% block content %}
+<h1 class="text-3xl font-bold text-blue-600">Willkommen bei NOESIS 2</h1>
+{% endblock %}
+

--- a/theme/urls.py
+++ b/theme/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('', views.home, name='home'),
+]

--- a/theme/views.py
+++ b/theme/views.py
@@ -1,3 +1,7 @@
 from django.shortcuts import render
 
-# Create your views here.
+
+def home(request):
+    """Render the homepage."""
+
+    return render(request, "theme/home.html")

--- a/workflows/admin.py
+++ b/workflows/admin.py
@@ -1,3 +1,19 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Workflow, WorkflowStep
+
+
+@admin.register(Workflow)
+class WorkflowAdmin(admin.ModelAdmin):
+    """Admin configuration for :class:`Workflow`."""
+
+    list_display = ("name", "created_at", "updated_at")
+
+
+@admin.register(WorkflowStep)
+class WorkflowStepAdmin(admin.ModelAdmin):
+    """Admin configuration for :class:`WorkflowStep`."""
+
+    list_display = ("workflow", "order", "created_at", "updated_at")
+    list_filter = ("workflow",)
+


### PR DESCRIPTION
## Summary
- register document and workflow models with the Django admin
- add simple `home` view with template and URL wiring

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bebc3f4584832b9f95815b55a23e81