### PR TITLE
Refactor logging configuration and admin email settings

### DIFF
--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -7,7 +7,9 @@ Split into base/development/production. Development and production import * from
 from pathlib import Path
 import io
 from urllib.parse import quote
+import copy
 import environ
+from django.utils.log import DEFAULT_LOGGING
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 # This file is at noesis2/settings/base.py, so project root is three parents up
@@ -142,29 +144,26 @@ CELERY_BROKER_URL = 'redis://localhost:6379/0'
 CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'verbose': {
-            'format': '[%(asctime)s] %(levelname)s %(module)s %(message)s',
-        },
-        'json': {
-            '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-        },
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'verbose',
-        },
-        'json_console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'json',
-        },
-    },
-    'root': {
-        'handlers': ['console'],
-        'level': 'INFO',
-    },
+ADMINS = [(
+    env('ADMIN_NAME', default='Admin'),
+    env('ADMIN_EMAIL', default='admin@example.com'),
+)]
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+LOGGING = copy.deepcopy(DEFAULT_LOGGING)
+LOGGING['formatters']['verbose'] = {
+    'format': '[%(asctime)s] %(levelname)s %(module)s %(message)s',
+}
+LOGGING['formatters']['json'] = {
+    '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+}
+LOGGING['handlers']['json_console'] = {
+    'class': 'logging.StreamHandler',
+    'formatter': 'json',
+}
+LOGGING['handlers']['console']['formatter'] = 'verbose'
+LOGGING['root'] = {
+    'handlers': ['console'],
+    'level': 'INFO',
 }

--- a/noesis2/settings/production.py
+++ b/noesis2/settings/production.py
@@ -5,4 +5,9 @@ DEBUG = False
 
 # Use JSON logging in production
 LOGGING['root']['handlers'] = ['json_console']
+LOGGING['loggers']['django.request'] = {
+    'handlers': ['mail_admins', 'json_console'],
+    'level': 'ERROR',
+    'propagate': False,
+}
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,5 +2,5 @@ celery
 django
 django-environ
 psycopg2-binary
-python-json-logger
+python-json-logger==3.3.0
 redis


### PR DESCRIPTION
## Summary
- load admin contact from environment and default emails to console backend
- base settings now copy Django's `DEFAULT_LOGGING` with JSON handler and verbose console
- production routes request errors to both `mail_admins` and JSON console
- pin `python-json-logger` in requirements to guarantee JSON logging dependency

## Testing
- `pip-compile requirements.in`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Set the SECRET_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bedf484048832b884d3b428455ccf6