### PR TITLE
refactor: build CSS in separate node stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
 # syntax=docker/dockerfile:1
 
 ########################################
-# Builder stage
+# CSS builder stage
+########################################
+FROM node:20 AS css-builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY postcss.config.js tailwind.config.js ./
+COPY theme ./theme
+
+RUN npm run build:css
+
+########################################
+# Python builder stage
 ########################################
 FROM python:3.12-slim-bookworm AS builder
 
@@ -11,22 +26,21 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
-# System deps and Node.js for PostCSS build
+# System deps only
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        build-essential \
-       nodejs npm \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy dependency manifests and install Python + Node deps
+# Copy dependency manifests and install Python deps
 COPY requirements*.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY package*.json ./
-RUN npm ci
-
 # Copy application source
 COPY . .
+
+# Copy built CSS from node builder
+COPY --from=css-builder /app/theme/static/css ./theme/static/css
 
 # Minimal env for Django settings during build (collectstatic)
 ENV DJANGO_SETTINGS_MODULE=noesis2.settings.production \
@@ -37,9 +51,8 @@ ENV DJANGO_SETTINGS_MODULE=noesis2.settings.production \
     DB_HOST=localhost \
     DB_PORT=5432
 
-# Build CSS once (no watch) and collect static files
-RUN npm run build:css \
-    && python manage.py collectstatic --noinput
+# Collect static files
+RUN python manage.py collectstatic --noinput
 
 ########################################
 # Runner stage


### PR DESCRIPTION
## Summary
- build CSS in dedicated Node.js 20 stage
- install Node deps with `npm ci --omit=dev`
- copy only generated CSS into Python builder before collecting static files

## Testing
- `npm run lint` *(fails: unused import errors)*
- `pytest -q` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdad1ff98832b92e105a634c0d9eb