### PR TITLE
Add dev docker-compose and migration entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     DJANGO_SETTINGS_MODULE=noesis2.settings.production \
-    PORT=8080
+    PORT=8000
 
 WORKDIR /app
 
@@ -85,13 +85,15 @@ COPY --from=builder /app/users /app/users
 COPY --from=builder /app/common /app/common
 COPY --from=builder /app/theme /app/theme
 COPY --from=builder /app/staticfiles /app/staticfiles
+COPY --from=builder /app/entrypoint.sh /app/entrypoint.sh
 
 # Ensure correct ownership (optional, improves security)
-RUN chown -R appuser:appuser /app
+RUN chown -R appuser:appuser /app && chmod +x /app/entrypoint.sh
 
 USER appuser
 
-EXPOSE 8080
+EXPOSE 8000
 
+ENTRYPOINT ["/app/entrypoint.sh"]
 # Start via gunicorn (honors $PORT environment variable)
-CMD ["sh", "-c", "python manage.py collectstatic --noinput && gunicorn noesis2.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]
+CMD ["sh", "-c", "gunicorn noesis2.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ KI-gestützte SaaS-Plattform zur prozessualen Unterstützung der betrieblichen M
 ## Docker Quickstart
 ```bash
 copy .env.example .env   # Linux/macOS: cp .env.example .env
-docker-compose build
-docker-compose up
+docker compose -f docker-compose.yml -f docker-compose.dev.yml build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 ```
 
 ---
@@ -81,10 +81,10 @@ npm run dev
 
 ## Anwendung ausführen mit Docker
 
-- `docker-compose up`: Startet die gesamte Anwendung im Vordergrund (Logs im Terminal).
-- `docker-compose up -d`: Startet die Anwendung im Hintergrund (detached mode).
-- `docker-compose down`: Stoppt und entfernt die Container (Volumes wie Datenbankdaten bleiben erhalten).
-- `docker-compose exec web python manage.py <befehl>`: Führt einen `manage.py`-Befehl (z. B. `createsuperuser`) im laufenden `web`-Container aus.
+- `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`: Startet die gesamte Anwendung im Vordergrund (Logs im Terminal).
+- `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d`: Startet die Anwendung im Hintergrund (detached mode).
+- `docker compose -f docker-compose.yml -f docker-compose.dev.yml down`: Stoppt und entfernt die Container (Volumes wie Datenbankdaten bleiben erhalten).
+- `docker compose -f docker-compose.yml -f docker-compose.dev.yml exec web python manage.py <befehl>`: Führt einen `manage.py`-Befehl (z. B. `createsuperuser`) im laufenden `web`-Container aus.
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,10 +26,11 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: noesis2_web
-    command: gunicorn noesis2.wsgi:application --bind 0.0.0.0:8000
+    command: python manage.py runserver 0.0.0.0:8000
     ports:
       - "8000:8000"
     volumes:
+      - .:/app
       - staticfiles:/app/staticfiles
     env_file:
       - .env
@@ -44,6 +45,8 @@ services:
       dockerfile: Dockerfile
     container_name: noesis2_worker
     command: celery -A noesis2 worker -l info
+    volumes:
+      - .:/app
     env_file:
       - .env
     depends_on:
@@ -55,4 +58,3 @@ volumes:
     driver: local
   staticfiles:
     driver: local
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+python manage.py migrate --noinput
+
+exec "$@"


### PR DESCRIPTION
## Summary
- use docker-compose.yml as production template without source volume mounts
- add docker-compose.dev.yml for local development with code volumes and runserver command
- add entrypoint.sh to run migrations before starting services and wire it into Dockerfile
- document new compose usage in README

## Testing
- `npm run lint`
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe79b9254832ba33e8f71d5aaaf65