### PR TITLE
Collect static files at dev server startup

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: noesis2_web
-    command: python manage.py runserver 0.0.0.0:8000
+    command: sh -c "python manage.py collectstatic --noinput && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
## Summary
- Run `collectstatic` and `migrate` before launching the development server so `/app/staticfiles` is populated

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*
- `docker compose -f docker-compose.dev.yml down` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeb381f64832bb1f3644f88ee0b83