### PR TITLE
feat: configure allowed hosts via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 SECRET_KEY=change-me-to-a-strong-random-value
 DEBUG=true
 DJANGO_SETTINGS_MODULE=noesis2.settings.development
+# Comma-separated hostnames that may serve the app
+ALLOWED_HOSTS=example.com
 
 # PostgreSQL database settings
 DB_NAME=noesis2_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - staticfiles:/app/staticfiles
     env_file:
       - .env
+    environment:
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-example.com}
     depends_on:
       - db
       - redis

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -27,7 +27,7 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["example.com"])
 
 
 # Application definition


### PR DESCRIPTION
## Summary
- read `ALLOWED_HOSTS` from environment
- document `ALLOWED_HOSTS` in `.env.example`
- pass `ALLOWED_HOSTS` into docker compose deployment

## Testing
- `npm run lint`
- `pytest -q` *(fails: Unknown pytest.mark.django_db warnings and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bff2b7c1ec832b8adcc4f3407ccf1b