### PR TITLE
Scope model queries by organization

### DIFF
--- a/documents/models.py
+++ b/documents/models.py
@@ -3,6 +3,7 @@ from django.db import models
 
 from common.models import TimestampedModel
 from projects.models import Project
+from organizations.query import OrganizationManager
 
 
 class DocumentType(TimestampedModel):
@@ -40,6 +41,7 @@ class Document(TimestampedModel):
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL, related_name="documents", on_delete=models.CASCADE
     )
+    objects = OrganizationManager(organization_field="project__organization")
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.type.name} ({self.get_status_display()})"

--- a/organizations/query.py
+++ b/organizations/query.py
@@ -1,0 +1,32 @@
+from django.db import models
+
+from .utils import current_organization
+
+
+class OrganizationScopedQuerySet(models.QuerySet):
+    """QuerySet that limits results to the active organization."""
+
+    def __init__(self, *args, organization_field: str = "organization", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.organization_field = organization_field
+
+    def for_current(self):
+        """Filter the queryset to the current organization."""
+        org = current_organization()
+        if org is None:
+            return self.none()
+        return self.filter(**{self.organization_field: org})
+
+
+class OrganizationManager(models.Manager.from_queryset(OrganizationScopedQuerySet)):
+    """Manager applying organization scoping to all queries."""
+
+    def __init__(self, *args, organization_field: str = "organization", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.organization_field = organization_field
+
+    def get_queryset(self):
+        qs = OrganizationScopedQuerySet(
+            self.model, using=self._db, organization_field=self.organization_field
+        )
+        return qs.for_current()

--- a/organizations/tests/test_query.py
+++ b/organizations/tests/test_query.py
@@ -1,0 +1,56 @@
+import pytest
+
+from organizations.tests.factories import OrganizationFactory
+from projects.tests.factories import ProjectFactory, WorkflowInstanceFactory
+from documents.tests.factories import DocumentFactory
+from organizations.utils import set_current_organization
+from projects.models import Project, WorkflowInstance
+from documents.models import Document
+
+
+@pytest.mark.django_db
+def test_project_missing_org_returns_empty():
+    org = OrganizationFactory()
+    ProjectFactory(organization=org)
+    assert list(Project.objects.all()) == []
+
+
+@pytest.mark.django_db
+def test_project_wrong_org_returns_empty():
+    org1 = OrganizationFactory()
+    org2 = OrganizationFactory()
+    ProjectFactory(organization=org1)
+    with set_current_organization(org2):
+        assert list(Project.objects.all()) == []
+
+
+@pytest.mark.django_db
+def test_document_missing_org_returns_empty():
+    org = OrganizationFactory()
+    DocumentFactory(project__organization=org)
+    assert list(Document.objects.all()) == []
+
+
+@pytest.mark.django_db
+def test_document_wrong_org_returns_empty():
+    org1 = OrganizationFactory()
+    org2 = OrganizationFactory()
+    DocumentFactory(project__organization=org1)
+    with set_current_organization(org2):
+        assert list(Document.objects.all()) == []
+
+
+@pytest.mark.django_db
+def test_workflowinstance_missing_org_returns_empty():
+    org = OrganizationFactory()
+    WorkflowInstanceFactory(project__organization=org)
+    assert list(WorkflowInstance.objects.all()) == []
+
+
+@pytest.mark.django_db
+def test_workflowinstance_wrong_org_returns_empty():
+    org1 = OrganizationFactory()
+    org2 = OrganizationFactory()
+    WorkflowInstanceFactory(project__organization=org1)
+    with set_current_organization(org2):
+        assert list(WorkflowInstance.objects.all()) == []

--- a/organizations/utils.py
+++ b/organizations/utils.py
@@ -1,0 +1,41 @@
+import contextlib
+import threading
+from typing import Optional
+
+from .models import Organization
+
+_thread_locals = threading.local()
+
+
+def current_organization(request: Optional[object] = None) -> Optional[Organization]:
+    """Return the active :class:`~organizations.models.Organization`.
+
+    The helper checks the given ``request`` for an ``organization`` attribute.
+    Outside of request/response cycles the active organization can be set using
+    :func:`set_current_organization` which stores the value in thread-local
+    storage.
+
+    Usage::
+
+        from organizations.utils import set_current_organization
+        with set_current_organization(my_org):
+            Project.objects.all()  # filtered to ``my_org``
+    """
+    if request is not None:
+        return getattr(request, "organization", None)
+    return getattr(_thread_locals, "organization", None)
+
+
+@contextlib.contextmanager
+def set_current_organization(org: Optional[Organization]):
+    """Context manager to temporarily set the current organization."""
+    previous = getattr(_thread_locals, "organization", None)
+    _thread_locals.organization = org
+    try:
+        yield
+    finally:
+        if previous is None:
+            if hasattr(_thread_locals, "organization"):
+                delattr(_thread_locals, "organization")
+        else:
+            _thread_locals.organization = previous

--- a/projects/models.py
+++ b/projects/models.py
@@ -3,6 +3,7 @@ from django.db import models
 
 from common.models import TimestampedModel
 from workflows.models import WorkflowTemplate
+from organizations.query import OrganizationManager
 
 
 class Project(TimestampedModel):
@@ -31,6 +32,7 @@ class Project(TimestampedModel):
     organization = models.ForeignKey(
         "organizations.Organization", on_delete=models.CASCADE
     )
+    objects = OrganizationManager()
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name
@@ -46,6 +48,7 @@ class WorkflowInstance(TimestampedModel):
         WorkflowTemplate, related_name="instances", on_delete=models.CASCADE
     )
     state = models.JSONField(default=dict, blank=True)
+    objects = OrganizationManager(organization_field="project__organization")
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"Workflow for {self.project}"


### PR DESCRIPTION
## Summary
- add `current_organization` helper and organization-scoped manager
- apply manager to Project, Document and WorkflowInstance
- verify queries without matching organization return no results

## Testing
- `npm run lint`
- `SECRET_KEY=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c033331914832b85cf522d9a74881f