### PR TITLE
Add organization membership guard and tests

### DIFF
--- a/organizations/guards.py
+++ b/organizations/guards.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable
+
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest, HttpResponse
+from django.utils.decorators import method_decorator
+
+from .models import OrgMembership
+from .utils import current_organization
+
+
+ViewFunc = Callable[..., HttpResponse]
+
+
+def require_org_member(view_func: ViewFunc) -> ViewFunc:
+    """Ensure the user is a member of the active organization.
+
+    This guard verifies that ``request.user`` has a membership for the
+    organization returned by :func:`~organizations.utils.current_organization`.
+    It can be applied to function-based views as a decorator or to
+    class-based views using ``RequireOrgMember``::
+
+        @require_org_member
+        def my_view(request):
+            ...
+
+        class MyView(RequireOrgMember, View):
+            ...
+
+    The guard applies to *all* HTTP methods, including read-only requests.
+    If no active organization exists or the user is not a member, a
+    :class:`django.core.exceptions.PermissionDenied` exception is raised.
+    """
+
+    @wraps(view_func)
+    def _wrapped_view(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        org = current_organization()
+        if (
+            org is None
+            or not OrgMembership.objects.filter(
+                organization=org, user=request.user
+            ).exists()
+        ):
+            raise PermissionDenied("User is not a member of the active organization")
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped_view
+
+
+class RequireOrgMember:
+    """Mixin applying :func:`require_org_member` to class-based views."""
+
+    @method_decorator(require_org_member)
+    def dispatch(self, *args: Any, **kwargs: Any) -> HttpResponse:
+        return super().dispatch(*args, **kwargs)

--- a/organizations/tests/test_guards.py
+++ b/organizations/tests/test_guards.py
@@ -1,0 +1,51 @@
+import pytest
+from django.http import HttpResponse
+from django.test import override_settings
+from django.urls import path
+
+from organizations.guards import require_org_member
+from organizations.tests.factories import OrgMembershipFactory, OrganizationFactory
+from organizations.utils import set_current_organization
+from users.tests.factories import UserFactory
+
+
+@require_org_member
+def sample_view(request):
+    return HttpResponse("ok")
+
+
+urlpatterns = [path("sample/", sample_view, name="sample")]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.django_db
+def test_member_can_modify(client):
+    org = OrganizationFactory()
+    user = UserFactory()
+    OrgMembershipFactory(organization=org, user=user)
+    client.force_login(user)
+    with set_current_organization(org):
+        response = client.post("/sample/")
+    assert response.status_code == 200
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.django_db
+def test_non_member_receives_403(client):
+    org = OrganizationFactory()
+    user = UserFactory()
+    client.force_login(user)
+    with set_current_organization(org):
+        response = client.post("/sample/")
+    assert response.status_code == 403
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.django_db
+def test_non_member_cannot_read(client):
+    org = OrganizationFactory()
+    user = UserFactory()
+    client.force_login(user)
+    with set_current_organization(org):
+        response = client.get("/sample/")
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- enforce organization membership via `require_org_member` decorator/mixin
- add tests ensuring only members can access views

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0352ec5bc832bb9becdd92fd6673f