### PR TITLE
Show organization in admin and document migration path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ DB_PORT=5432
 # Celery (Redis) broker and result backend
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/0
+
+# Organization settings
+# Currently no organization-specific environment variables are required

--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ Das alte `noesis2/settings.py` wurde entfernt; verwende ausschließlich das modu
 - Production: `noesis2.settings.production`
 - Umstellung per Env-Var: `DJANGO_SETTINGS_MODULE=noesis2.settings.production`
 
+## Datenmigration und Standard-Organisation
+Beim Upgrade auf die mandantenfähige Struktur muss jedem bestehenden Projekt
+eine Organisation zugeordnet werden. Die Migration
+`projects/migrations/0002_project_organization.py` legt für vorhandene Projekte
+automatisch eine Organisation an. Sollten nach dem Deploy noch Projekte ohne
+Organisation existieren (z. B. nach einem manuellen Datenimport), kann der
+Management-Befehl `assign_default_org` genutzt werden:
+
+```bash
+python manage.py assign_default_org
+```
+
+Der Befehl erzeugt für jedes betroffene Projekt eine neue Organisation und
+aktualisiert das Projekt entsprechend.
+
 ## Frontend-Build (Tailwind v4 via PostCSS)
 - Build/Watch: `npm run build:css` (wird in `npm run dev` automatisch gestartet)
 - Konfiguration: `postcss.config.js` mit `@tailwindcss/postcss` und `autoprefixer`

--- a/documents/admin.py
+++ b/documents/admin.py
@@ -14,5 +14,17 @@ class DocumentTypeAdmin(admin.ModelAdmin):
 class DocumentAdmin(admin.ModelAdmin):
     """Admin configuration for :class:`Document`."""
 
-    list_display = ("type", "project", "owner", "status", "created_at", "updated_at")
-    list_filter = ("status", "type", "project")
+    list_display = (
+        "type",
+        "project",
+        "organization",
+        "owner",
+        "status",
+        "created_at",
+        "updated_at",
+    )
+    list_filter = ("status", "type", "project__organization", "project")
+
+    @staticmethod
+    def organization(obj):
+        return obj.project.organization

--- a/documents/tests/test_admin.py
+++ b/documents/tests/test_admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from documents.admin import DocumentAdmin
+from documents.models import Document
+
+
+def test_document_admin_displays_and_filters_organization():
+    admin_instance = DocumentAdmin(Document, admin.site)
+    assert "organization" in admin_instance.list_display
+    assert "project__organization" in admin_instance.list_filter

--- a/projects/admin.py
+++ b/projects/admin.py
@@ -7,12 +7,30 @@ from .models import Project, WorkflowInstance
 class ProjectAdmin(admin.ModelAdmin):
     """Admin configuration for :class:`Project`."""
 
-    list_display = ("name", "status", "owner", "created_at", "updated_at")
-    list_filter = ("status",)
+    list_display = (
+        "name",
+        "organization",
+        "status",
+        "owner",
+        "created_at",
+        "updated_at",
+    )
+    list_filter = ("organization", "status")
 
 
 @admin.register(WorkflowInstance)
 class WorkflowInstanceAdmin(admin.ModelAdmin):
     """Admin configuration for :class:`WorkflowInstance`."""
 
-    list_display = ("project", "template", "created_at", "updated_at")
+    list_display = (
+        "project",
+        "organization",
+        "template",
+        "created_at",
+        "updated_at",
+    )
+    list_filter = ("project__organization", "template")
+
+    @staticmethod
+    def organization(obj):
+        return obj.project.organization

--- a/projects/tests/test_admin.py
+++ b/projects/tests/test_admin.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+
+from projects.admin import ProjectAdmin, WorkflowInstanceAdmin
+from projects.models import Project, WorkflowInstance
+
+
+def test_project_admin_displays_and_filters_organization():
+    admin_instance = ProjectAdmin(Project, admin.site)
+    assert "organization" in admin_instance.list_display
+    assert "organization" in admin_instance.list_filter
+
+
+def test_workflowinstance_admin_displays_and_filters_organization():
+    admin_instance = WorkflowInstanceAdmin(WorkflowInstance, admin.site)
+    assert "organization" in admin_instance.list_display
+    assert "project__organization" in admin_instance.list_filter


### PR DESCRIPTION
## Summary
- Expose organization in project and document admin views and enable filtering
- Document data migration strategy and `assign_default_org` usage
- Clarify that no extra organization env vars are required

## Testing
- `npm run lint:fix`
- `npm run lint`
- `pytest -q` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c03dd907e8832b9c35f4e051fedad4