### PR TITLE
Add tests for organization scoping and migrations

### DIFF
--- a/organizations/tests/test_guards.py
+++ b/organizations/tests/test_guards.py
@@ -49,3 +49,12 @@ def test_non_member_cannot_read(client):
     with set_current_organization(org):
         response = client.get("/sample/")
     assert response.status_code == 403
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.django_db
+def test_requires_org_denies_without_active_org(client):
+    user = UserFactory()
+    client.force_login(user)
+    response = client.get("/sample/")
+    assert response.status_code == 403

--- a/organizations/tests/test_query.py
+++ b/organizations/tests/test_query.py
@@ -25,6 +25,14 @@ def test_project_wrong_org_returns_empty():
 
 
 @pytest.mark.django_db
+def test_project_correct_org_returns_result():
+    org = OrganizationFactory()
+    project = ProjectFactory(organization=org)
+    with set_current_organization(org):
+        assert list(Project.objects.all()) == [project]
+
+
+@pytest.mark.django_db
 def test_document_missing_org_returns_empty():
     org = OrganizationFactory()
     DocumentFactory(project__organization=org)
@@ -41,6 +49,14 @@ def test_document_wrong_org_returns_empty():
 
 
 @pytest.mark.django_db
+def test_document_correct_org_returns_result():
+    org = OrganizationFactory()
+    document = DocumentFactory(project__organization=org)
+    with set_current_organization(org):
+        assert list(Document.objects.all()) == [document]
+
+
+@pytest.mark.django_db
 def test_workflowinstance_missing_org_returns_empty():
     org = OrganizationFactory()
     WorkflowInstanceFactory(project__organization=org)
@@ -54,3 +70,11 @@ def test_workflowinstance_wrong_org_returns_empty():
     WorkflowInstanceFactory(project__organization=org1)
     with set_current_organization(org2):
         assert list(WorkflowInstance.objects.all()) == []
+
+
+@pytest.mark.django_db
+def test_workflowinstance_correct_org_returns_result():
+    org = OrganizationFactory()
+    instance = WorkflowInstanceFactory(project__organization=org)
+    with set_current_organization(org):
+        assert list(WorkflowInstance.objects.all()) == [instance]

--- a/projects/tests/test_migrations.py
+++ b/projects/tests/test_migrations.py
@@ -1,0 +1,50 @@
+import pytest
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.utils.text import slugify
+
+
+@pytest.mark.django_db(transaction=True)
+def test_project_organization_data_migration():
+    executor = MigrationExecutor(connection)
+    executor.migrate([("organizations", "0001_initial"), ("projects", "0001_initial")])
+    old_apps = executor.loader.project_state(
+        [("organizations", "0001_initial"), ("projects", "0001_initial")]
+    ).apps
+
+    User = old_apps.get_model("users", "User")
+    Project = old_apps.get_model("projects", "Project")
+
+    user = User.objects.create(username="u")
+    project = Project.objects.create(name="Legacy", description="desc", owner=user)
+    project_id = project.pk
+
+    executor = MigrationExecutor(connection)
+    executor.migrate(
+        [("organizations", "0001_initial"), ("projects", "0002_project_organization")]
+    )
+    new_apps = executor.loader.project_state(
+        [("organizations", "0001_initial"), ("projects", "0002_project_organization")]
+    ).apps
+
+    Project = new_apps.get_model("projects", "Project")
+    Organization = new_apps.get_model("organizations", "Organization")
+    project = Project.objects.get(pk=project_id)
+    assert project.organization.name == f"Legacy Org {project_id}"
+    assert project.organization.slug == slugify(f"legacy-org-{project_id}")
+    assert Organization.objects.count() == 1
+
+    executor = MigrationExecutor(connection)
+    executor.migrate([("organizations", "0001_initial"), ("projects", "0001_initial")])
+    rev_apps = executor.loader.project_state(
+        [("organizations", "0001_initial"), ("projects", "0001_initial")]
+    ).apps
+
+    Project = rev_apps.get_model("projects", "Project")
+    Organization = rev_apps.get_model("organizations", "Organization")
+    project = Project.objects.get(pk=project_id)
+    assert not hasattr(project, "organization")
+    assert Organization.objects.count() == 0
+
+    executor = MigrationExecutor(connection)
+    executor.migrate(executor.loader.graph.leaf_nodes())

--- a/projects/tests/test_models.py
+++ b/projects/tests/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+from django.db import IntegrityError
 
 from .factories import ProjectFactory, WorkflowInstanceFactory
 
@@ -14,3 +15,10 @@ def test_project_factory_creates_project():
 def test_workflow_instance_factory_creates_instance():
     instance = WorkflowInstanceFactory()
     assert instance.project.workflow == instance
+
+
+@pytest.mark.django_db
+def test_workflow_instance_unique_constraint():
+    instance = WorkflowInstanceFactory()
+    with pytest.raises(IntegrityError):
+        WorkflowInstanceFactory(project=instance.project)


### PR DESCRIPTION
## Summary
- test manager filtering returns results for active organization
- ensure guards deny access without active organization
- verify WorkflowInstance uniqueness and project organization migration

## Testing
- `ruff check --fix .`
- `black .`
- `pytest -q --cov=noesis2`
- `pip-compile --quiet --dry-run requirements.in`
- `pip-compile --quiet --dry-run requirements-dev.in`


------
https://chatgpt.com/codex/tasks/task_e_68c03f884fe4832b8400fb0a0ebc663c