### PR TITLE
Add workflow instance model and document title

### DIFF
--- a/documents/admin.py
+++ b/documents/admin.py
@@ -15,6 +15,7 @@ class DocumentAdmin(admin.ModelAdmin):
     """Admin configuration for :class:`Document`."""
 
     list_display = (
+        "title",
         "type",
         "project",
         "organization",

--- a/documents/migrations/0003_document_title.py
+++ b/documents/migrations/0003_document_title.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("documents", "0002_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="document",
+            name="title",
+            field=models.CharField(max_length=255, default=""),
+            preserve_default=False,
+        ),
+    ]

--- a/documents/models.py
+++ b/documents/models.py
@@ -28,6 +28,7 @@ class Document(TimestampedModel):
         (STATUS_COMPLETED, "abgeschlossen"),
     ]
 
+    title = models.CharField(max_length=255)
     file = models.FileField(upload_to="documents/")
     status = models.CharField(
         max_length=20, choices=STATUS_CHOICES, default=STATUS_UPLOADED

--- a/documents/tests/factories.py
+++ b/documents/tests/factories.py
@@ -18,6 +18,7 @@ class DocumentFactory(DjangoModelFactory):
     class Meta:
         model = Document
 
+    title = factory.Sequence(lambda n: f"Document {n}")
     file = FileField(filename="test.txt")
     type = factory.SubFactory(DocumentTypeFactory)
     project = factory.SubFactory(ProjectFactory)

--- a/documents/tests/test_models.py
+++ b/documents/tests/test_models.py
@@ -14,3 +14,4 @@ def test_document_factory_creates_document():
     document = DocumentFactory()
     assert document.project is not None
     assert document.owner is not None
+    assert document.title != ""

--- a/organizations/tests/test_query.py
+++ b/organizations/tests/test_query.py
@@ -1,10 +1,12 @@
 import pytest
 
 from organizations.tests.factories import OrganizationFactory
-from projects.tests.factories import ProjectFactory, WorkflowInstanceFactory
+from projects.tests.factories import ProjectFactory
+from workflows.tests.factories import WorkflowInstanceFactory
 from documents.tests.factories import DocumentFactory
 from organizations.utils import set_current_organization
-from projects.models import Project, WorkflowInstance
+from projects.models import Project
+from workflows.models import WorkflowInstance
 from documents.models import Document
 
 

--- a/projects/admin.py
+++ b/projects/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Project, WorkflowInstance
+from .models import Project
 
 
 @admin.register(Project)
@@ -16,21 +16,3 @@ class ProjectAdmin(admin.ModelAdmin):
         "updated_at",
     )
     list_filter = ("organization", "status")
-
-
-@admin.register(WorkflowInstance)
-class WorkflowInstanceAdmin(admin.ModelAdmin):
-    """Admin configuration for :class:`WorkflowInstance`."""
-
-    list_display = (
-        "project",
-        "organization",
-        "template",
-        "created_at",
-        "updated_at",
-    )
-    list_filter = ("project__organization", "template")
-
-    @staticmethod
-    def organization(obj):
-        return obj.project.organization

--- a/projects/migrations/0003_delete_workflowinstance.py
+++ b/projects/migrations/0003_delete_workflowinstance.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("projects", "0002_project_organization"),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name="WorkflowInstance",
+        ),
+    ]

--- a/projects/models.py
+++ b/projects/models.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.db import models
 
 from common.models import TimestampedModel
-from workflows.models import WorkflowTemplate
 from organizations.query import OrganizationManager
 
 
@@ -36,19 +35,3 @@ class Project(TimestampedModel):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name
-
-
-class WorkflowInstance(TimestampedModel):
-    """Concrete workflow state for a specific :class:`Project`."""
-
-    project = models.OneToOneField(
-        Project, related_name="workflow", on_delete=models.CASCADE
-    )
-    template = models.ForeignKey(
-        WorkflowTemplate, related_name="instances", on_delete=models.CASCADE
-    )
-    state = models.JSONField(default=dict, blank=True)
-    objects = OrganizationManager(organization_field="project__organization")
-
-    def __str__(self) -> str:  # pragma: no cover - simple representation
-        return f"Workflow for {self.project}"

--- a/projects/tests/factories.py
+++ b/projects/tests/factories.py
@@ -1,9 +1,8 @@
 import factory
 from factory.django import DjangoModelFactory
 
-from projects.models import Project, WorkflowInstance
+from projects.models import Project
 from users.tests.factories import UserFactory
-from workflows.tests.factories import WorkflowTemplateFactory
 from organizations.tests.factories import OrganizationFactory
 
 
@@ -15,12 +14,3 @@ class ProjectFactory(DjangoModelFactory):
     description = factory.Faker("sentence")
     owner = factory.SubFactory(UserFactory)
     organization = factory.SubFactory(OrganizationFactory)
-
-
-class WorkflowInstanceFactory(DjangoModelFactory):
-    class Meta:
-        model = WorkflowInstance
-
-    project = factory.SubFactory(ProjectFactory)
-    template = factory.SubFactory(WorkflowTemplateFactory)
-    state = factory.LazyFunction(dict)

--- a/projects/tests/test_admin.py
+++ b/projects/tests/test_admin.py
@@ -1,16 +1,10 @@
 from django.contrib import admin
 
-from projects.admin import ProjectAdmin, WorkflowInstanceAdmin
-from projects.models import Project, WorkflowInstance
+from projects.admin import ProjectAdmin
+from projects.models import Project
 
 
 def test_project_admin_displays_and_filters_organization():
     admin_instance = ProjectAdmin(Project, admin.site)
     assert "organization" in admin_instance.list_display
     assert "organization" in admin_instance.list_filter
-
-
-def test_workflowinstance_admin_displays_and_filters_organization():
-    admin_instance = WorkflowInstanceAdmin(WorkflowInstance, admin.site)
-    assert "organization" in admin_instance.list_display
-    assert "project__organization" in admin_instance.list_filter

--- a/projects/tests/test_models.py
+++ b/projects/tests/test_models.py
@@ -1,7 +1,6 @@
 import pytest
-from django.db import IntegrityError
 
-from .factories import ProjectFactory, WorkflowInstanceFactory
+from .factories import ProjectFactory
 
 
 @pytest.mark.django_db
@@ -9,16 +8,3 @@ def test_project_factory_creates_project():
     project = ProjectFactory()
     assert project.pk is not None
     assert project.organization is not None
-
-
-@pytest.mark.django_db
-def test_workflow_instance_factory_creates_instance():
-    instance = WorkflowInstanceFactory()
-    assert instance.project.workflow == instance
-
-
-@pytest.mark.django_db
-def test_workflow_instance_unique_constraint():
-    instance = WorkflowInstanceFactory()
-    with pytest.raises(IntegrityError):
-        WorkflowInstanceFactory(project=instance.project)

--- a/workflows/admin.py
+++ b/workflows/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import WorkflowTemplate, WorkflowStep
+from .models import WorkflowTemplate, WorkflowStep, WorkflowInstance
 
 
 @admin.register(WorkflowTemplate)
@@ -16,3 +16,21 @@ class WorkflowStepAdmin(admin.ModelAdmin):
 
     list_display = ("template", "order", "created_at", "updated_at")
     list_filter = ("template",)
+
+
+@admin.register(WorkflowInstance)
+class WorkflowInstanceAdmin(admin.ModelAdmin):
+    """Admin configuration for :class:`WorkflowInstance`."""
+
+    list_display = (
+        "project",
+        "organization",
+        "status",
+        "created_at",
+        "updated_at",
+    )
+    list_filter = ("project__organization", "status")
+
+    @staticmethod
+    def organization(obj):
+        return obj.project.organization

--- a/workflows/migrations/0002_workflowinstance.py
+++ b/workflows/migrations/0002_workflowinstance.py
@@ -1,0 +1,50 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("workflows", "0001_initial"),
+        ("projects", "0002_project_organization"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="WorkflowInstance",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("draft", "Draft"),
+                            ("review", "Review"),
+                            ("final", "Final"),
+                        ],
+                        default="draft",
+                        max_length=10,
+                    ),
+                ),
+                (
+                    "project",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="workflows",
+                        to="projects.project",
+                    ),
+                ),
+            ],
+            options={"abstract": False},
+        ),
+    ]

--- a/workflows/models.py
+++ b/workflows/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 
 from common.models import TimestampedModel
+from projects.models import Project
+from organizations.query import OrganizationManager
 
 
 class WorkflowTemplate(TimestampedModel):
@@ -26,3 +28,28 @@ class WorkflowStep(TimestampedModel):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.template} - step {self.order}"
+
+
+class WorkflowInstance(TimestampedModel):
+    """Tracks the workflow status for a :class:`Project`."""
+
+    STATUS_DRAFT = "draft"
+    STATUS_REVIEW = "review"
+    STATUS_FINAL = "final"
+
+    STATUS_CHOICES = [
+        (STATUS_DRAFT, "Draft"),
+        (STATUS_REVIEW, "Review"),
+        (STATUS_FINAL, "Final"),
+    ]
+
+    project = models.ForeignKey(
+        Project, related_name="workflows", on_delete=models.CASCADE
+    )
+    status = models.CharField(
+        max_length=10, choices=STATUS_CHOICES, default=STATUS_DRAFT
+    )
+    objects = OrganizationManager(organization_field="project__organization")
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"Workflow {self.get_status_display()} for {self.project}"

--- a/workflows/tests/factories.py
+++ b/workflows/tests/factories.py
@@ -1,7 +1,8 @@
 import factory
 from factory.django import DjangoModelFactory
 
-from workflows.models import WorkflowTemplate, WorkflowStep
+from workflows.models import WorkflowTemplate, WorkflowStep, WorkflowInstance
+from projects.tests.factories import ProjectFactory
 
 
 class WorkflowTemplateFactory(DjangoModelFactory):
@@ -18,3 +19,10 @@ class WorkflowStepFactory(DjangoModelFactory):
     template = factory.SubFactory(WorkflowTemplateFactory)
     order = factory.Sequence(lambda n: n)
     instructions = factory.Faker("sentence")
+
+
+class WorkflowInstanceFactory(DjangoModelFactory):
+    class Meta:
+        model = WorkflowInstance
+
+    project = factory.SubFactory(ProjectFactory)

--- a/workflows/tests/test_admin.py
+++ b/workflows/tests/test_admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from workflows.admin import WorkflowInstanceAdmin
+from workflows.models import WorkflowInstance
+
+
+def test_workflowinstance_admin_displays_and_filters_organization():
+    admin_instance = WorkflowInstanceAdmin(WorkflowInstance, admin.site)
+    assert "organization" in admin_instance.list_display
+    assert "project__organization" in admin_instance.list_filter

--- a/workflows/tests/test_models.py
+++ b/workflows/tests/test_models.py
@@ -1,6 +1,10 @@
 import pytest
 
-from .factories import WorkflowStepFactory, WorkflowTemplateFactory
+from .factories import (
+    WorkflowInstanceFactory,
+    WorkflowStepFactory,
+    WorkflowTemplateFactory,
+)
 
 
 @pytest.mark.django_db
@@ -13,3 +17,10 @@ def test_workflow_template_factory():
 def test_workflow_step_factory_creates_step():
     step = WorkflowStepFactory()
     assert step.template.steps.count() == 1
+
+
+@pytest.mark.django_db
+def test_workflow_instance_factory_creates_instance():
+    instance = WorkflowInstanceFactory()
+    assert instance.project is not None
+    assert instance.status == instance.STATUS_DRAFT


### PR DESCRIPTION
## Summary
- add title field to Document model and show it in admin
- move workflow instances into workflows app with status states
- ensure tenant isolation tests cover documents and workflows

## Testing
- `ruff check projects/models.py projects/admin.py documents/models.py documents/admin.py documents/tests/factories.py documents/tests/test_models.py projects/tests/factories.py projects/tests/test_models.py projects/tests/test_admin.py workflows/models.py workflows/admin.py workflows/tests/factories.py workflows/tests/test_models.py workflows/tests/test_admin.py organizations/tests/test_query.py documents/migrations/0003_document_title.py projects/migrations/0003_delete_workflowinstance.py workflows/migrations/0002_workflowinstance.py`
- `black projects/models.py projects/admin.py documents/models.py documents/admin.py documents/tests/factories.py documents/tests/test_models.py projects/tests/factories.py projects/tests/test_models.py projects/tests/test_admin.py workflows/models.py workflows/admin.py workflows/tests/factories.py workflows/tests/test_models.py workflows/tests/test_admin.py organizations/tests/test_query.py documents/migrations/0003_document_title.py projects/migrations/0003_delete_workflowinstance.py workflows/migrations/0002_workflowinstance.py`
- `npm run lint`
- ⚠️ `python manage.py migrate_schemas --tenant` (failed: no such table: customers_tenant)


------
https://chatgpt.com/codex/tasks/task_e_68c1823461d8832b8613107bef0ec24c