### PR TITLE
Implement tenant schema guard utilities and middleware

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -1,0 +1,11 @@
+class TenantSchemaMiddleware:
+    """Populate request.tenant_schema from the X-Tenant-Schema header."""
+
+    header_name = "HTTP_X_TENANT_SCHEMA"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request.tenant_schema = request.META.get(self.header_name)
+        return self.get_response(request)

--- a/common/tenants.py
+++ b/common/tenants.py
@@ -1,0 +1,38 @@
+from functools import wraps
+
+from django.db import connection
+from django.http import HttpResponseForbidden
+
+from customers.models import Tenant
+
+
+def get_current_tenant():
+    """Return the tenant for the current connection's schema."""
+    schema = connection.schema_name
+    try:
+        return Tenant.objects.get(schema_name=schema)
+    except Tenant.DoesNotExist:
+        return None
+
+
+def tenant_schema_required(view_func):
+    """Decorator ensuring the request matches the active tenant schema."""
+
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        tenant = get_current_tenant()
+        if not tenant or getattr(request, "tenant_schema", None) != tenant.schema_name:
+            return HttpResponseForbidden("Invalid tenant schema")
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped
+
+
+class TenantSchemaRequiredMixin:
+    """Mixin validating the active tenant schema for class-based views."""
+
+    def dispatch(self, request, *args, **kwargs):
+        tenant = get_current_tenant()
+        if not tenant or getattr(request, "tenant_schema", None) != tenant.schema_name:
+            return HttpResponseForbidden("Invalid tenant schema")
+        return super().dispatch(request, *args, **kwargs)

--- a/common/tests/test_tenant_guard.py
+++ b/common/tests/test_tenant_guard.py
@@ -1,0 +1,29 @@
+import pytest
+from django_tenants.utils import schema_context
+
+from customers.tests.factories import TenantFactory
+from common.tenants import get_current_tenant
+
+
+@pytest.mark.django_db
+def test_demo_view_requires_tenant_header(client):
+    tenant = TenantFactory(schema_name="alpha")
+    with schema_context(tenant.schema_name):
+        response = client.get("/tenant-demo/")
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_demo_view_with_valid_header(client):
+    tenant = TenantFactory(schema_name="beta")
+    with schema_context(tenant.schema_name):
+        response = client.get("/tenant-demo/", HTTP_X_TENANT_SCHEMA=tenant.schema_name)
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.django_db
+def test_get_current_tenant_returns_active_tenant():
+    tenant = TenantFactory(schema_name="gamma")
+    with schema_context(tenant.schema_name):
+        assert get_current_tenant() == tenant

--- a/common/views.py
+++ b/common/views.py
@@ -1,1 +1,17 @@
-# Add common views here later
+from django.http import JsonResponse
+from django.views import View
+
+from .tenants import TenantSchemaRequiredMixin, tenant_schema_required
+
+
+@tenant_schema_required
+def demo_decorated_view(request):
+    """Demo function-based view protected by tenant schema validation."""
+    return JsonResponse({"status": "ok"})
+
+
+class DemoView(TenantSchemaRequiredMixin, View):
+    """Demo class-based view using the tenant schema validation mixin."""
+
+    def get(self, request):
+        return JsonResponse({"status": "ok"})

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -66,6 +66,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django_tenants.middleware.main.TenantMainMiddleware",
+    "common.middleware.TenantSchemaMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/noesis2/urls.py
+++ b/noesis2/urls.py
@@ -18,7 +18,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+from common.views import DemoView
+
 urlpatterns = [
     path("", include("theme.urls")),
     path("admin/", admin.site.urls),
+    path("tenant-demo/", DemoView.as_view(), name="tenant-demo"),
 ]


### PR DESCRIPTION
## Summary
- add `get_current_tenant` helper and tenant schema validation decorator/mixin
- inject `TenantSchemaMiddleware` and sample guarded view
- cover tenant schema guard with tests

## Testing
- `npm run lint`
- `SECRET_KEY=test pytest common/tests/test_tenant_guard.py::test_demo_view_requires_tenant_header -q` *(fails: AttributeError: 'DatabaseWrapper' object has no attribute 'set_schema')*

------
https://chatgpt.com/codex/tasks/task_e_68c18f570520832bbd551ade7b14fa96