### PR TITLE
feat(admin): add domain switcher dropdown

### DIFF
--- a/customers/templatetags/domain_tags.py
+++ b/customers/templatetags/domain_tags.py
@@ -1,0 +1,10 @@
+from django import template
+
+from customers.models import Domain
+
+register = template.Library()
+
+
+@register.simple_tag
+def domains():
+    return Domain.objects.all()

--- a/customers/tests/factories.py
+++ b/customers/tests/factories.py
@@ -3,7 +3,7 @@ import datetime
 import factory
 from factory.django import DjangoModelFactory
 
-from customers.models import Tenant
+from customers.models import Domain, Tenant
 
 
 class TenantFactory(DjangoModelFactory):
@@ -14,3 +14,12 @@ class TenantFactory(DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Tenant {n}")
     paid_until = factory.LazyFunction(lambda: datetime.date.today())
     on_trial = True
+
+
+class DomainFactory(DjangoModelFactory):
+    class Meta:
+        model = Domain
+
+    tenant = factory.SubFactory(TenantFactory)
+    domain = factory.Sequence(lambda n: f"domain{n}.example.com")
+    is_primary = True

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -47,6 +47,7 @@ TENANT_APPS = [
 INSTALLED_APPS = [
     "django_tenants",
     *SHARED_APPS,
+    "theme.apps.ThemeConfig",
     "django.contrib.admin",
     "django.contrib.sessions",
     "django.contrib.messages",
@@ -60,7 +61,6 @@ INSTALLED_APPS = [
     "profiles",
     "organizations",
     "common",
-    "theme.apps.ThemeConfig",
 ]
 
 MIDDLEWARE = [

--- a/theme/templates/admin/base_site.html
+++ b/theme/templates/admin/base_site.html
@@ -1,0 +1,30 @@
+{% extends "admin/base.html" %}
+{% load i18n domain_tags %}
+
+{% block userlinks %}
+    {% if request.user.is_staff %}
+        {% domains as domain_list %}
+        <label for="domain-switcher">{% trans "Domain" %}:</label>
+        <select id="domain-switcher">
+            {% for domain in domain_list %}
+                <option value="{{ domain.domain }}" {% if domain.domain == request.get_host %}selected{% endif %}>{{ domain.domain }}</option>
+            {% endfor %}
+        </select>
+        <small>{% trans "Hinweis: ggf. erneut einloggen" %}</small> /
+    {% endif %}
+    {{ block.super }}
+    {% if request.user.is_staff %}
+    <script>
+        (function() {
+            var select = document.getElementById('domain-switcher');
+            if (select) {
+                select.addEventListener('change', function() {
+                    var path = "{{ request.get_full_path|escapejs }}";
+                    var url = window.location.protocol + '//' + this.value + path;
+                    window.location.href = url;
+                });
+            }
+        })();
+    </script>
+    {% endif %}
+{% endblock %}

--- a/theme/tests/test_admin_domain_dropdown.py
+++ b/theme/tests/test_admin_domain_dropdown.py
@@ -1,0 +1,22 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from customers.tests.factories import DomainFactory
+
+
+@pytest.mark.django_db
+def test_domain_dropdown_shows_domains(client):
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="admin", password="pass", is_staff=True, is_superuser=True
+    )
+    client.force_login(user)
+    DomainFactory(domain="alpha.example.com")
+    DomainFactory(domain="beta.example.com")
+    response = client.get(reverse("admin:index"))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert 'id="domain-switcher"' in content
+    assert "alpha.example.com" in content
+    assert "beta.example.com" in content


### PR DESCRIPTION
## Summary
- add template tag to list available domains
- expose domain switcher dropdown in admin top bar
- test dropdown renders all domains

## Testing
- `npm run lint`
- `SECRET_KEY=test pytest -q` *(fails: 'DatabaseWrapper' object has no attribute 'set_schema')*

------
https://chatgpt.com/codex/tasks/task_e_68c1977da958832bb378da8f5034023d