### PR TITLE
Validate tenant creation and ensure atomic tenant creation

### DIFF
--- a/customers/tests/test_management_commands.py
+++ b/customers/tests/test_management_commands.py
@@ -1,8 +1,10 @@
 import pytest
+from django.conf import settings
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from customers.models import Domain, Tenant
-from .factories import TenantFactory
+from .factories import DomainFactory, TenantFactory
 
 
 @pytest.mark.django_db
@@ -13,6 +15,48 @@ def test_create_tenant_command():
     tenant = Tenant.objects.get(schema_name="testschema")
     assert tenant.name == "Test"
     assert Domain.objects.filter(tenant=tenant, domain="test.example.com").exists()
+
+
+@pytest.mark.django_db
+def test_create_tenant_command_public_schema():
+    with pytest.raises(CommandError):
+        call_command(
+            "create_tenant",
+            schema=settings.PUBLIC_SCHEMA_NAME,
+            name="Test",
+            domain="test.example.com",
+        )
+
+
+@pytest.mark.django_db
+def test_create_tenant_command_duplicate_schema():
+    TenantFactory(schema_name="dup")
+    with pytest.raises(CommandError):
+        call_command(
+            "create_tenant", schema="dup", name="Test", domain="test2.example.com"
+        )
+
+
+@pytest.mark.django_db
+def test_create_tenant_command_duplicate_domain():
+    DomainFactory(domain="dup.example.com")
+    with pytest.raises(CommandError):
+        call_command(
+            "create_tenant", schema="test2", name="Test", domain="dup.example.com"
+        )
+
+
+@pytest.mark.django_db
+def test_create_tenant_command_is_atomic(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(Domain.objects, "create", _raise)
+    with pytest.raises(RuntimeError):
+        call_command(
+            "create_tenant", schema="atomic", name="Atomic", domain="atomic.example"
+        )
+    assert not Tenant.objects.filter(schema_name="atomic").exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- prevent creating tenant with reserved public schema or duplicate schema/domain
- wrap tenant/domain creation in transaction to ensure atomicity
- expand management command tests for validation and atomicity

## Testing
- `npm run lint` *(fails: invalid syntax in noesis2/settings/base.py)*
- `pytest -q` *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c0102ad8832ba3365836ae925b0a