### PR TITLE
docs: document tenant setup steps

### DIFF
--- a/docs/tenant-management.md
+++ b/docs/tenant-management.md
@@ -2,6 +2,27 @@
 
 Dieses Dokument beschreibt, wie NOESIS 2 Mandanten (Tenants) realisiert und wie Administratoren neue Tenants anlegen und pflegen.
 
+## Lokales Setup (nach Pull)
+
+1. Abhängigkeiten aktualisieren
+   - `pip install -r requirements.txt`
+   - `pip install -r requirements-dev.txt`
+2. Gültige PostgreSQL-Zugangsdaten in `.env` hinterlegen. Das Projekt nutzt `django_tenants.postgresql_backend`.
+3. Nach jedem Pull alle Schemata migrieren:
+   ```bash
+   python manage.py migrate_schemas
+   ```
+4. Öffentliches Schema initialisieren:
+   ```bash
+   python manage.py bootstrap_public_tenant --domain <domain>
+   ```
+5. Mandanten anlegen:
+   ```bash
+   python manage.py create_tenant --schema=<schema> --name=<name> --domain=<domain>
+   ```
+6. Optional: vorhandene Tenants auflisten (`list_tenants`) oder Demodaten erzeugen (`create_demo_data`).
+7. Eigene Views mit `tenant_schema_required` oder `TenantSchemaRequiredMixin` schützen, damit nur Anfragen mit korrektem Header akzeptiert werden.
+
 ## Architektur
 
 NOESIS 2 nutzt [django-tenants](https://django-tenants.readthedocs.io/) und speichert jeden Mandanten in einem eigenen PostgreSQL-Schema. Das Modell `Tenant` erweitert `TenantMixin` und erzeugt automatisch das Schema, während `Domain` den Hostnamen mit dem jeweiligen Mandanten verknüpft.
@@ -30,3 +51,13 @@ curl -H "X-Tenant-Schema: alpha" http://localhost:8000/tenant-demo/
 ```
 
 Die Guards aus `common.tenants` können genutzt werden, um eigene Views gegen fehlerhafte Schemanutzung abzusichern.
+
+## Testen
+
+- Automatisiert: `pytest -q` führt die vorhandenen Tenant-Tests aus.
+- Manuell:
+  - Erfolgreiche Anfrage mit gesetztem Header:
+    ```bash
+    curl -H "X-Tenant-Schema: alpha" http://localhost:8000/tenant-demo/
+    ```
+  - Ohne oder falschen Header sollte `403 Forbidden` zurückgeben.


### PR DESCRIPTION
## Summary
- describe local setup for tenants including migrations and management commands
- add testing instructions for tenant-aware requests

## Testing
- `npm run lint`
- `pytest -q` *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c7fe40e0832bab6815b98be248f3