### PR TITLE
Align shared and tenant app settings

### DIFF
--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -36,18 +36,8 @@ ALLOWED_HOSTS = env.list(
 
 # Application definition
 
+# Apps that live in the ``public`` schema and are shared across all tenants
 SHARED_APPS = [
-    "django_tenants",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "customers",
-    "django.contrib.contenttypes",
-    "profiles",
-]
-
-INSTALLED_APPS = [
-    *SHARED_APPS,
-    "theme.apps.ThemeConfig",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -57,6 +47,7 @@ INSTALLED_APPS = [
     "customers",
 ]
 
+# Apps that are installed separately for each tenant schema
 TENANT_APPS = [
     "theme.apps.ThemeConfig",
     "projects",
@@ -69,7 +60,8 @@ TENANT_APPS = [
     "common",
 ]
 
-INSTALLED_APPS = list(dict.fromkeys(SHARED_APPS + TENANT_APPS))
+# Final installed apps: ``django_tenants`` plus shared and tenant apps
+INSTALLED_APPS = ["django_tenants", *SHARED_APPS, *TENANT_APPS]
 
 MIDDLEWARE = [
     "django_tenants.middleware.main.TenantMainMiddleware",


### PR DESCRIPTION
## Summary
- ensure SHARED_APPS include Django core and customer apps
- collect all tenant-specific apps in TENANT_APPS
- derive INSTALLED_APPS from django-tenants plus shared and tenant apps

## Testing
- `npm run lint`
- `pytest -q` *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cc51a190832b98186445f73afb3f