### PR TITLE
Streamline AI Core view responses and strengthen tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,11 @@ CELERY_RESULT_BACKEND=redis://redis:6379/0
 
 # Organization settings
 # Currently no organization-specific environment variables are required
+
+# AI Core infrastructure
+LITELLM_BASE_URL=http://litellm-proxy
+LITELLM_API_KEY=replace-me
+REDIS_URL=redis://redis:6379/0
+LANGFUSE_PUBLIC_KEY=your-public-key
+LANGFUSE_SECRET_KEY=your-secret-key
+AI_CORE_RATE_LIMIT_QUOTA=60

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,11 @@ Tests sind das Fundament für die Stabilität und Wartbarkeit von NOESIS 2. Jede
 - Für requests kann optional der Header `X-Tenant-Schema` gesetzt werden, um explizit ein Schema zu wählen.
 - Für Tests mit eigenen Schemas: nach `TenantFactory(schema_name=...)` bei Bedarf `tenant.create_schema(check_if_exists=True)` aufrufen.
 
+## AI Core Richtlinien
+- **Graph-/Node-I/O:** Graphen erhalten `state: dict` und `meta: {tenant, case, trace_id}` und geben `(new_state, result)` zurück. Nodes arbeiten auf klar definierten Inputs und liefern serialisierbare Outputs ohne Seiteneffekte.
+- **PII vor LLM:** Nach der Text-Extraktion immer `pii.mask` anwenden, bevor ein LLM-Client aufgerufen wird.
+- **No-Info-Fallback:** Fehlende Informationen als `gaps` zurückgeben statt Inhalte zu halluzinieren.
+- **Tracing-Pflicht:** Alle LLM-Nodes mit `@trace` dekorieren und `prompt_version` weiterreichen, damit Ereignisse `{tenant, case, trace_id, prompt_version, node}` enthalten.
 
 ## Frontend-Workflow
 - Entwicklung: `npm run dev` (Django + CSS-Watcher)

--- a/MODEL_ROUTING.yaml
+++ b/MODEL_ROUTING.yaml
@@ -1,0 +1,7 @@
+simple-query: gpt-3.5-turbo
+classify: gpt-3.5-turbo
+extract: gpt-3.5-turbo
+analyze: gpt-3.5-turbo
+draft: gpt-4-turbo
+revise: gpt-4-turbo
+synthesize: gpt-4-turbo

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ KI-gestützte SaaS-Plattform zur prozessualen Unterstützung der betrieblichen M
 - Entwicklungsumgebung: Node.js, npm
 - CI/CD & Testing: GitHub Actions, pytest
 
+## AI Core
+
+### API-Endpunkte
+Alle Pfade erfordern die Header `X-Tenant-ID` und `X-Case-ID`. Antworten enthalten Standard-Trace-Header und optionale `gaps` oder `citations`.
+
+- `GET /ai/ping/` – einfacher Health-Check
+- `POST /ai/intake/` – Metadaten speichern und Eingangsbestätigung liefern
+- `POST /ai/scope/` – Auftragsumfang prüfen und fehlende Angaben melden
+- `POST /ai/needs/` – Informationen dem Tenant-Profil zuordnen, Abbruch bei Lücken
+- `POST /ai/sysdesc/` – Systembeschreibung nur wenn keine Informationen fehlen
+
+### Graphen
+Die Views orchestrieren reine Python-Graphen. Jeder Graph erhält `state: dict` und `meta: {tenant, case, trace_id}` und gibt `(new_state, result)` zurück. Der Zustand wird nach jedem Schritt in `.ai_core_store/{tenant}/{case}/state.json` persistiert. Gates wie `needs_mapping` oder `scope_check` brechen früh ab, statt unvollständige Drafts zu erzeugen.
+
+### Lokale Nutzung
+Das bestehende `docker compose`-Setup startet Web-App und Redis. Ein externer LiteLLM-Proxy kann über `LITELLM_BASE_URL` angebunden werden. Nach dem Start (`docker compose ... up`) können die Endpunkte lokal unter `http://localhost:8000/ai/` getestet werden.
+
 ---
 
 ## Docker Quickstart
@@ -107,6 +124,11 @@ Benötigte Variablen (siehe `.env.example`):
 - DB_PASSWORD: DB-Passwort (Sonderzeichen werden unterstützt)
 - DB_HOST: Host, z. B. `localhost`
 - DB_PORT: Port, i. d. R. `5432`
+
+AI Core:
+- LITELLM_BASE_URL: Basis-URL des LiteLLM-Proxys
+- LITELLM_API_KEY: API-Key für den Proxy
+- LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY: Schlüssel für Langfuse-Tracing
 
 Die Settings lesen `.env` via `django-environ`. Die Datenbank wird über eine zusammengesetzte `DATABASE_URL` konfiguriert (aus den Variablen oben), inkl. URL-Encoding für Sonderzeichen.
 

--- a/ai_core/graphs/info_intake.py
+++ b/ai_core/graphs/info_intake.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
+    """Record incoming meta information.
+
+    Parameters
+    ----------
+    state:
+        Mutable workflow state.
+    meta:
+        Context containing ``tenant``, ``case`` and ``trace_id``.
+
+    Returns
+    -------
+    tuple
+        A tuple of ``(new_state, result)``.
+    """
+
+    new_state = dict(state)
+    new_state.setdefault("meta", meta)
+    result = {
+        "received": True,
+        "tenant": meta.get("tenant"),
+        "case": meta.get("case"),
+    }
+    return new_state, result

--- a/ai_core/graphs/needs_mapping.py
+++ b/ai_core/graphs/needs_mapping.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
+    """Map provided needs and stop early if information is missing."""
+
+    new_state = dict(state)
+    missing = new_state.get("missing") or []
+    if missing:
+        # Early exit when previous steps reported missing information.
+        return new_state, {"missing": missing}
+
+    needs_input = new_state.get("needs_input")
+    if not needs_input:
+        new_state["missing"] = ["needs_input"]
+        return new_state, {"missing": ["needs_input"]}
+
+    new_state["needs"] = needs_input
+    new_state["missing"] = []
+    return new_state, {"mapped": True}

--- a/ai_core/graphs/scope_check.py
+++ b/ai_core/graphs/scope_check.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
+    """Validate that the workflow scope is defined.
+
+    The scope check is a gate that never produces a draft.
+    Missing items are recorded under ``missing``.
+    """
+
+    new_state = dict(state)
+    missing = []
+    if not new_state.get("scope"):
+        missing.append("scope")
+    new_state["missing"] = missing
+    result = {"missing": missing}
+    return new_state, result

--- a/ai_core/graphs/system_description.py
+++ b/ai_core/graphs/system_description.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
+    """Produce a system description only if no information is missing."""
+
+    new_state = dict(state)
+    missing = new_state.get("missing") or []
+    if missing:
+        return new_state, {"skipped": True, "missing": missing}
+
+    description = f"System for tenant {meta.get('tenant')} case {meta.get('case')}"
+    new_state["description"] = description
+    return new_state, {"description": description}

--- a/ai_core/infra/config.py
+++ b/ai_core/infra/config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+import environ
+
+
+env = environ.Env()
+
+
+@dataclass(frozen=True)
+class InfraConfig:
+    """Collected environment configuration for AI Core infrastructure."""
+
+    litellm_base_url: str
+    litellm_api_key: str
+    redis_url: str
+    langfuse_public_key: str
+    langfuse_secret_key: str
+
+
+@lru_cache(maxsize=1)
+def get_config() -> InfraConfig:
+    """Load environment configuration.
+
+    Values are read once and cached for subsequent calls.
+    """
+
+    return InfraConfig(
+        litellm_base_url=env("LITELLM_BASE_URL"),
+        litellm_api_key=env("LITELLM_API_KEY"),
+        redis_url=env("REDIS_URL"),
+        langfuse_public_key=env("LANGFUSE_PUBLIC_KEY"),
+        langfuse_secret_key=env("LANGFUSE_SECRET_KEY"),
+    )

--- a/ai_core/infra/ledger.py
+++ b/ai_core/infra/ledger.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def record(meta: dict[str, Any]) -> None:
+    """Log metadata as a JSON line to stdout."""
+
+    print(json.dumps(meta), file=sys.stdout)

--- a/ai_core/infra/object_store.py
+++ b/ai_core/infra/object_store.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+BASE_PATH = Path(".ai_core_store")
+
+
+def _full_path(relative: str) -> Path:
+    path = BASE_PATH / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def put_bytes(path: str, data: bytes) -> Path:
+    """Persist raw bytes to the object store."""
+    target = _full_path(path)
+    target.write_bytes(data)
+    return target
+
+
+def read_json(path: str) -> Any:
+    """Read JSON from the object store."""
+    target = BASE_PATH / path
+    with target.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def write_json(path: str, obj: Any) -> Path:
+    """Write JSON to the object store."""
+    target = _full_path(path)
+    with target.open("w", encoding="utf-8") as fh:
+        json.dump(obj, fh)
+    return target

--- a/ai_core/infra/pii.py
+++ b/ai_core/infra/pii.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+def mask(text: str) -> str:
+    """Placeholder implementation for PII masking.
+
+    Currently replaces any digit with ``X`` as a simplistic stand-in for a real
+    anonymisation routine.
+    """
+
+    return "".join("X" if ch.isdigit() else ch for ch in text)

--- a/ai_core/infra/prompts.py
+++ b/ai_core/infra/prompts.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict
+
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def load(alias: str) -> Dict[str, str]:
+    """Load a prompt by alias.
+
+    The alias maps to a markdown file under ``ai_core/prompts`` where
+    files are versioned ``<name>.v<version>.md``. The function returns the
+    prompt text along with its version string (e.g. ``"v1"``).
+    """
+    prompts_dir = Path(__file__).resolve().parents[1] / "prompts"
+    base = prompts_dir / alias
+    candidates = sorted(base.parent.glob(f"{base.name}.v*.md"))
+    if not candidates:
+        raise FileNotFoundError(f"No prompt for alias '{alias}'")
+
+    prompt_file = candidates[-1]
+    match = re.search(r"\.v(\d+)\.md$", prompt_file.name)
+    if not match:
+        raise ValueError(f"Invalid prompt filename: {prompt_file.name}")
+    version = f"v{match.group(1)}"
+    text = prompt_file.read_text(encoding="utf-8")
+    return {"version": version, "text": text}

--- a/ai_core/infra/rate_limit.py
+++ b/ai_core/infra/rate_limit.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+import time
+from functools import lru_cache
+from typing import Optional
+
+import environ
+from redis import Redis
+from redis.exceptions import RedisError
+
+from .config import get_config
+
+env = environ.Env()
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_QUOTA = 60
+
+
+def get_quota() -> int:
+    """Return the per-tenant quota from ``AI_CORE_RATE_LIMIT_QUOTA``."""
+    return env.int("AI_CORE_RATE_LIMIT_QUOTA", default=DEFAULT_QUOTA)
+
+
+@lru_cache(maxsize=1)
+def _get_redis() -> Redis:
+    """Return a cached Redis client instance."""
+    return Redis.from_url(get_config().redis_url, decode_responses=True)
+
+
+def check(tenant: str, now: Optional[float] = None) -> bool:
+    """Check whether the tenant has remaining requests in the current window.
+
+    Parameters
+    ----------
+    tenant:
+        Tenant identifier.
+    now:
+        Optional epoch timestamp used for testing.
+
+    Returns
+    -------
+    bool
+        ``True`` if the request is allowed, ``False`` otherwise.
+    """
+
+    quota = get_quota()
+    ts = int(now if now is not None else time.time())
+    window_start = ts - (ts % 60)
+    ttl = 60 - (ts - window_start)
+    key = f"rl:{tenant}"
+
+    try:
+        client = _get_redis()
+        count = client.incr(key)
+        if count == 1:
+            client.expire(key, ttl)
+        return count <= quota
+    except RedisError as exc:
+        logger.warning("rate limit fail-open for %s: %s", tenant, exc)
+        return True

--- a/ai_core/infra/resp.py
+++ b/ai_core/infra/resp.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from django.http import HttpResponse
+
+
+def apply_std_headers(
+    response: HttpResponse, trace_id: str, prompt_version: str | None = None
+) -> HttpResponse:
+    """Attach standard headers to a response.
+
+    Parameters
+    ----------
+    response:
+        The response object to modify.
+    trace_id:
+        Trace identifier for linking logs and metrics.
+    prompt_version:
+        Version identifier for the prompt used to generate the response. Only
+        set when provided.
+    """
+
+    response["X-Trace-ID"] = trace_id
+    if prompt_version:
+        response["X-Prompt-Version"] = prompt_version
+    return response

--- a/ai_core/infra/tracing.py
+++ b/ai_core/infra/tracing.py
@@ -1,0 +1,110 @@
+"""Node-level tracing helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable, TypeVar, cast
+
+import requests
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def trace_meta(meta: dict[str, Any], prompt_version: str | None) -> dict[str, Any]:
+    """Return metadata enriched with ``prompt_version`` when provided."""
+
+    enriched = dict(meta)
+    if prompt_version is not None:
+        enriched["prompt_version"] = prompt_version
+    return enriched
+
+
+def _log(payload: dict[str, Any]) -> None:
+    """Emit a JSON log line to stdout."""
+
+    print(json.dumps(payload))
+
+
+def _dispatch_langfuse(trace_id: str, node_name: str, metadata: dict[str, Any]) -> None:
+    """Send a tracing event to Langfuse in the background if credentials exist."""
+
+    public = os.getenv("LANGFUSE_PUBLIC_KEY")
+    secret = os.getenv("LANGFUSE_SECRET_KEY")
+    if not public or not secret:
+        return
+
+    url = os.getenv(
+        "LANGFUSE_BASE_URL",
+        "https://cloud.langfuse.com/api/public/ingest",
+    )
+
+    payload = {"traceId": trace_id, "name": node_name, "metadata": metadata}
+    headers = {"X-Langfuse-Public-Key": public, "X-Langfuse-Secret-Key": secret}
+
+    def _send() -> None:
+        try:
+            requests.post(url, json=payload, headers=headers, timeout=2)
+        except Exception as exc:  # pragma: no cover - best-effort logging
+            logging.getLogger(__name__).warning("langfuse dispatch failed: %s", exc)
+
+    threading.Thread(target=_send, daemon=True).start()
+
+
+def trace(node_name: str) -> Callable[[F], F]:
+    """Decorator emitting start/end logs and optional Langfuse events."""
+
+    def decorator(func: F) -> F:
+        def wrapped(*args: Any, **kwargs: Any):  # type: ignore[misc]
+            meta = kwargs.get("meta")
+            if meta is None and len(args) > 1:
+                meta = args[1]
+            if not isinstance(meta, dict):
+                meta = {}
+
+            meta_enriched = trace_meta(meta, meta.get("prompt_version"))
+
+            start_ts = time.time()
+            start_payload = {
+                "event": "node.start",
+                "node": node_name,
+                "tenant": meta_enriched.get("tenant"),
+                "case": meta_enriched.get("case"),
+                "trace_id": meta_enriched.get("trace_id"),
+                "prompt_version": meta_enriched.get("prompt_version"),
+                "ts": start_ts,
+            }
+            _log(start_payload)
+
+            try:
+                return func(*args, **kwargs)
+            finally:
+                end_ts = time.time()
+                end_payload = {
+                    "event": "node.end",
+                    "node": node_name,
+                    "tenant": meta_enriched.get("tenant"),
+                    "case": meta_enriched.get("case"),
+                    "trace_id": meta_enriched.get("trace_id"),
+                    "prompt_version": meta_enriched.get("prompt_version"),
+                    "ts": end_ts,
+                    "duration_ms": int((end_ts - start_ts) * 1000),
+                }
+                _log(end_payload)
+
+                _dispatch_langfuse(
+                    trace_id=str(meta_enriched.get("trace_id")),
+                    node_name=node_name,
+                    metadata={
+                        "tenant": meta_enriched.get("tenant"),
+                        "case": meta_enriched.get("case"),
+                        "prompt_version": meta_enriched.get("prompt_version"),
+                    },
+                )
+
+        return cast(F, wrapped)
+
+    return decorator

--- a/ai_core/llm/client.py
+++ b/ai_core/llm/client.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict
+
+import requests
+
+from ai_core.infra.config import get_config
+from ai_core.infra.pii import mask
+from ai_core.infra import ledger
+from .routing import resolve
+
+logger = logging.getLogger(__name__)
+
+
+def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Call the LLM via LiteLLM proxy using a routing ``label``.
+
+    Parameters
+    ----------
+    label:
+        Routing label that resolves to a model id.
+    prompt:
+        Prompt text which will be PII-masked before sending.
+    metadata:
+        Dict containing at least ``tenant``, ``case`` and ``trace_id``.
+    """
+
+    model_id = resolve(label)
+    prompt_safe = mask(prompt)
+
+    cfg = get_config()
+    url = f"{cfg.litellm_base_url.rstrip('/')}/v1/chat/completions"
+    headers = {"Authorization": f"Bearer {cfg.litellm_api_key}"}
+    payload = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": prompt_safe}],
+    }
+
+    max_retries = 3
+    timeout = 20
+    for attempt in range(max_retries):
+        try:
+            resp = requests.post(url, headers=headers, json=payload, timeout=timeout)
+        except requests.RequestException as exc:
+            status = None
+            err = exc
+        else:
+            status = resp.status_code
+            err = None
+
+        if status and 500 <= status < 600:
+            logger.warning("llm 5xx response", extra={"status": status})
+            if attempt == max_retries - 1:
+                raise ValueError("llm error") from None
+            time.sleep(min(5, 2**attempt))
+            continue
+
+        if err is not None:
+            logger.warning("llm request error", exc_info=err)
+            if attempt == max_retries - 1:
+                raise ValueError("llm error") from None
+            time.sleep(min(5, 2**attempt))
+            continue
+
+        if status and 400 <= status < 500:
+            logger.warning("llm 4xx response", extra={"status": status})
+            raise ValueError("llm error")
+
+        data = resp.json()
+        break
+
+    text = data["choices"][0]["message"]["content"]
+    usage_raw = data.get("usage", {})
+    usage = {
+        "in_tokens": usage_raw.get("prompt_tokens", 0),
+        "out_tokens": usage_raw.get("completion_tokens", 0),
+        "cost": 0.0,
+    }
+    result = {
+        "text": text,
+        "usage": usage,
+        "model": model_id,
+        "prompt_version": metadata.get("prompt_version"),
+    }
+
+    ledger.record(
+        {
+            "tenant": metadata.get("tenant"),
+            "case": metadata.get("case"),
+            "trace_id": metadata.get("trace_id"),
+            "label": label,
+            "model": model_id,
+            "usage": usage,
+            "ts": time.time(),
+        }
+    )
+
+    return result

--- a/ai_core/llm/routing.py
+++ b/ai_core/llm/routing.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+ROUTING_FILE = Path(__file__).resolve().parents[2] / "MODEL_ROUTING.yaml"
+
+
+@lru_cache(maxsize=1)
+def load_map() -> dict[str, str]:
+    """Load and cache the label→model mapping from ``MODEL_ROUTING.yaml``."""
+
+    with ROUTING_FILE.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data
+
+
+def resolve(label: str) -> str:
+    """Return the model id for ``label``.
+
+    Raises
+    ------
+    ValueError
+        If the label does not exist in the routing map.
+    """
+
+    mapping = load_map()
+    try:
+        return mapping[label]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"unknown label: {label}") from exc

--- a/ai_core/nodes/__init__.py
+++ b/ai_core/nodes/__init__.py
@@ -1,0 +1,11 @@
+from . import retrieve, compose, extract, classify, assess, draft_blocks, needs
+
+__all__ = [
+    "retrieve",
+    "compose",
+    "extract",
+    "classify",
+    "assess",
+    "draft_blocks",
+    "needs",
+]

--- a/ai_core/nodes/assess.py
+++ b/ai_core/nodes/assess.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ai_core.infra.prompts import load
+from ai_core.infra.pii import mask
+from ai_core.infra.tracing import trace
+from ai_core.llm import client
+
+
+@trace("assess")
+def run(
+    state: Dict[str, Any], meta: Dict[str, str]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Assess risk based on extracted facts."""
+    prompt = load("assess/risk")
+    meta["prompt_version"] = prompt["version"]
+    base = state.get("text", "")
+    full_prompt = f"{prompt['text']}\n\n{base}"
+    masked = mask(full_prompt)
+    result = client.call("analyze", masked, meta)
+    new_state = dict(state)
+    new_state["risk"] = result["text"]
+    return new_state, {"risk": result["text"], "prompt_version": prompt["version"]}

--- a/ai_core/nodes/classify.py
+++ b/ai_core/nodes/classify.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ai_core.infra.prompts import load
+from ai_core.infra.pii import mask
+from ai_core.infra.tracing import trace
+from ai_core.llm import client
+
+
+@trace("classify")
+def run(
+    state: Dict[str, Any], meta: Dict[str, str]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Classify text regarding co-determination."""
+    prompt = load("classify/mitbestimmung")
+    meta["prompt_version"] = prompt["version"]
+    base = state.get("text", "")
+    full_prompt = f"{prompt['text']}\n\n{base}"
+    masked = mask(full_prompt)
+    result = client.call("classify", masked, meta)
+    new_state = dict(state)
+    new_state["classification"] = result["text"]
+    return new_state, {
+        "classification": result["text"],
+        "prompt_version": prompt["version"],
+    }

--- a/ai_core/nodes/draft_blocks.py
+++ b/ai_core/nodes/draft_blocks.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ai_core.infra.prompts import load
+from ai_core.infra.pii import mask
+from ai_core.infra.tracing import trace
+from ai_core.llm import client
+
+
+@trace("draft_blocks")
+def run(
+    state: Dict[str, Any], meta: Dict[str, str]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Generate draft blocks using system and function prompts."""
+    system = load("draft/system")
+    functions = load("draft/functions")
+    clause = load("draft/clause_standard")
+    meta["prompt_version"] = clause["version"]
+    combined = "\n".join([system["text"], functions["text"], clause["text"]])
+    masked = mask(combined)
+    result = client.call("draft", masked, meta)
+    new_state = dict(state)
+    new_state["draft"] = result["text"]
+    return new_state, {"draft": result["text"], "prompt_version": clause["version"]}

--- a/ai_core/nodes/extract.py
+++ b/ai_core/nodes/extract.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ai_core.infra.prompts import load
+from ai_core.infra.pii import mask
+from ai_core.infra.tracing import trace
+from ai_core.llm import client
+
+
+@trace("extract")
+def run(
+    state: Dict[str, Any], meta: Dict[str, str]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Extract items and facts from text using the LLM."""
+    prompt = load("extract/items")
+    meta["prompt_version"] = prompt["version"]
+    base = state.get("text", "")
+    full_prompt = f"{prompt['text']}\n\n{base}"
+    masked = mask(full_prompt)
+    result = client.call("extract", masked, meta)
+    new_state = dict(state)
+    new_state["items"] = result["text"]
+    return new_state, {"items": result["text"], "prompt_version": prompt["version"]}

--- a/ai_core/nodes/needs.py
+++ b/ai_core/nodes/needs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import yaml
+
+
+def run(
+    state: Dict[str, Any], meta: Dict[str, str]
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Map info_state against tenant profile and report filled/missing/ignored."""
+    profile_path = (
+        Path(__file__).resolve().parents[1]
+        / "prompts"
+        / "profiles"
+        / "tenant_default.yaml"
+    )
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    system = profile.get("system", {})
+    required = system.get("required", [])
+    optional = system.get("optional", [])
+    allowed = set(required + optional)
+    info_state = state.get("info_state", {})
+    filled = [k for k in allowed if k in info_state]
+    missing = [k for k in required if k not in info_state]
+    ignored = [k for k in info_state.keys() if k not in allowed]
+    result = {"filled": filled, "missing": missing, "ignored": ignored}
+    new_state = dict(state)
+    new_state["needs"] = result
+    return new_state, result

--- a/ai_core/nodes/retrieve.py
+++ b/ai_core/nodes/retrieve.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ai_core.rag.vector_client import InMemoryVectorClient
+
+
+def run(
+    state: Dict[str, Any],
+    meta: Dict[str, str],
+    *,
+    client: InMemoryVectorClient,
+    top_k: int = 5,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Search the vector client for relevant snippets.
+
+    Parameters
+    ----------
+    state:
+        Must contain ``query`` with the search string.
+    meta:
+        Contains ``tenant`` and ``case`` identifiers.
+    client:
+        Vector client used for search.
+    top_k:
+        Number of snippets to return.
+    """
+    query = state.get("query", "")
+    filters = {"tenant": meta.get("tenant"), "case": meta.get("case")}
+    chunks = client.search(query, filters=filters, top_k=top_k)
+    snippets = [{"text": c.content, "source": c.meta.get("source", "")} for c in chunks]
+    new_state = dict(state)
+    new_state["snippets"] = snippets
+    confidence = 1.0 if snippets else 0.0
+    return new_state, {"snippets": snippets, "confidence": confidence}

--- a/ai_core/prompts/assess/risk.v1.md
+++ b/ai_core/prompts/assess/risk.v1.md
@@ -1,0 +1,2 @@
+Assess the risk level based on the provided facts.
+Respond with low, medium, or high.

--- a/ai_core/prompts/classify/mitbestimmung.v1.md
+++ b/ai_core/prompts/classify/mitbestimmung.v1.md
@@ -1,0 +1,7 @@
+Ziel: Einstufung nach BetrVG §87 Abs.1 Nr.6 auf Basis des bereitgestellten Kontextes.
+Arbeite faktenbasiert, zitiere Quellen (Kurzlabel) und halluziniere nicht.
+Label: "ja" | "nein" | "unsicher"
+Auch bewerten: personenbezug (ja/nein/unsicher), kontrollgeeignetheit (ja/nein/unsicher).
+Wenn Informationen fehlen, gib gaps[] aus.
+Ausgabe (JSON):
+{ "label":"...", "reasons":[], "personenbezug":"...", "kontrollgeeignet":"...", "citations":[], "gaps":[] }

--- a/ai_core/prompts/draft/clause_standard.v1.md
+++ b/ai_core/prompts/draft/clause_standard.v1.md
@@ -1,0 +1,6 @@
+Ziel: Standard-Klauselvorschläge als Bausteine.
+Zitiere Quellen (Kurzlabel).
+Liefere 3 Varianten (konservativ/ausgewogen/experimentell) mit Parametern (Schwellen, Fristen).
+Wenn Informationen fehlen, gib gaps[] aus.
+Ausgabe:
+{ "variants":[{"style":"...","text":"...","params":{}}], "citations":[], "gaps":[], "notes":[] }

--- a/ai_core/prompts/draft/functions.v1.md
+++ b/ai_core/prompts/draft/functions.v1.md
@@ -1,0 +1,6 @@
+Ziel: Funktionsliste (ohne Bewertung).
+Liste erkannte Funktionen mit Kurzbeschreibung.
+Zitiere Quellen (Kurzlabel).
+Keine Aussagen zu Rollen/Auswertungen.
+Ausgabe:
+{ "items":[{"title":"...","desc":"..."}], "citations":[], "gaps":[] }

--- a/ai_core/prompts/draft/system.v1.md
+++ b/ai_core/prompts/draft/system.v1.md
@@ -1,0 +1,12 @@
+Ziel: Systembeschreibung für Betriebsrats-Informationsbedarf.
+Nutze NUR freigegebene Felder.
+Zitiere Quellen (Kurzlabel).
+Struktur:
+1. Zweck und Einsatzbereich
+2. Technische Einordnung (Deployment, Hauptkomponenten)
+3. Datenkategorien (ohne PII-Details)
+4. Integrationen (hochlevel)
+5. Referenzen (Quellen)
+Wenn Pflichtfelder fehlen: keine Halluzination; liefere gaps[].
+Ausgabe:
+{ "content_md":"...", "citations":[], "gaps":[] }

--- a/ai_core/prompts/extract/items.v1.md
+++ b/ai_core/prompts/extract/items.v1.md
@@ -1,0 +1,2 @@
+Extract key items and facts from the following text.
+Return a concise list.

--- a/ai_core/prompts/precheck/score.v1.md
+++ b/ai_core/prompts/precheck/score.v1.md
@@ -1,0 +1,7 @@
+Ziel: Reifegrad 0–3 für Vorverhandlungs-Precheck.
+Arbeite faktenbasiert und nutze nur den bereitgestellten Kontext.
+Bewerte: Kontextvollständigkeit, Klarheit des Zwecks, erkennbare Risiken.
+Zitiere Quellen (Kurzlabel).
+Wenn Informationen fehlen, gib gaps[] aus.
+Ausgabe (JSON):
+{ "score": 0|1|2|3, "reasons":[], "citations":[], "gaps":[] }

--- a/ai_core/prompts/profiles/tenant_default.yaml
+++ b/ai_core/prompts/profiles/tenant_default.yaml
@@ -1,0 +1,4 @@
+system:
+  required: ["purpose", "deployment_model", "main_components"]
+  optional: ["data_categories", "integrations", "references"]
+  forbidden: []

--- a/ai_core/prompts/retriever/answer.v1.md
+++ b/ai_core/prompts/retriever/answer.v1.md
@@ -1,0 +1,9 @@
+Ziel: Beantworte die Frage faktenbasiert aus bereitgestelltem Kontext.
+Pflicht:
+- Nutze NUR die übergebenen Snippets.
+- Zitiere Quellen (Kurzlabel).
+- Wenn Kontext unzureichend: gib eine präzise Gap-Liste aus.
+Ausgabe:
+- answer
+- citations[]
+- gaps[]

--- a/ai_core/rag/filters.py
+++ b/ai_core/rag/filters.py
@@ -1,0 +1,6 @@
+from typing import Any, Mapping
+
+
+def strict_match(meta: Mapping[str, Any], tenant: str, case: str) -> bool:
+    """Return True if the chunk metadata matches tenant and case exactly."""
+    return meta.get("tenant") == tenant and meta.get("case") == case

--- a/ai_core/rag/schemas.py
+++ b/ai_core/rag/schemas.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class Chunk:
+    """A chunk of knowledge used for retrieval."""
+
+    content: str
+    meta: Dict[str, Any]
+    """Metadata with keys: tenant, case, source, hash."""

--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from .filters import strict_match
+from .schemas import Chunk
+
+
+class InMemoryVectorClient:
+    """A minimal in-memory vector client for testing."""
+
+    def __init__(self) -> None:
+        self._chunks: Dict[str, Chunk] = {}
+
+    def upsert_chunks(self, chunks: Iterable[Chunk]) -> None:
+        for chunk in chunks:
+            key = chunk.meta.get("hash")
+            if key:
+                self._chunks[key] = chunk
+
+    def search(
+        self, query: str, filters: Dict[str, str], top_k: int = 5
+    ) -> List[Chunk]:
+        tenant = filters.get("tenant")
+        case = filters.get("case")
+        query_lower = query.lower()
+        results: List[Chunk] = []
+        for chunk in self._chunks.values():
+            if not strict_match(chunk.meta, tenant, case):
+                continue
+            if query_lower in chunk.content.lower():
+                results.append(chunk)
+        return results[:top_k]

--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -1,6 +1,90 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Dict, List
+
 from celery import shared_task
+
+from .infra import object_store, pii
+from .rag.vector_client import InMemoryVectorClient
+from .rag.schemas import Chunk
+
+# Global in-memory vector client used by the upsert task
+VECTOR_CLIENT = InMemoryVectorClient()
+
+
+def _build_path(meta: Dict[str, str], *parts: str) -> str:
+    tenant = meta["tenant"]
+    case = meta["case"]
+    return "/".join([tenant, case, *parts])
 
 
 @shared_task
-def process_document_task(document_id):
-    print(f"Starte Verarbeitung für Dokument {document_id}")
+def ingest_raw(meta: Dict[str, str], name: str, data: bytes) -> Dict[str, str]:
+    """Persist raw document bytes."""
+    path = _build_path(meta, "raw", name)
+    object_store.put_bytes(path, data)
+    return {"path": path}
+
+
+@shared_task
+def extract_text(meta: Dict[str, str], raw_path: str) -> Dict[str, str]:
+    """Decode bytes to text and store."""
+    full = object_store.BASE_PATH / raw_path
+    text = full.read_bytes().decode("utf-8")
+    out_path = _build_path(meta, "text", f"{Path(raw_path).stem}.txt")
+    object_store.put_bytes(out_path, text.encode("utf-8"))
+    return {"path": out_path}
+
+
+@shared_task
+def pii_mask(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
+    """Mask PII in text."""
+    full = object_store.BASE_PATH / text_path
+    text = full.read_text(encoding="utf-8")
+    masked = pii.mask(text)
+    out_path = _build_path(meta, "text", f"{Path(text_path).stem}.masked.txt")
+    object_store.put_bytes(out_path, masked.encode("utf-8"))
+    return {"path": out_path}
+
+
+@shared_task
+def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
+    """Split text into chunks; stubbed as a single chunk."""
+    full = object_store.BASE_PATH / text_path
+    text = full.read_text(encoding="utf-8")
+    hash_val = hashlib.sha1(text.encode("utf-8")).hexdigest()
+    chunks: List[Dict[str, object]] = [
+        {
+            "content": text,
+            "meta": {
+                "tenant": meta["tenant"],
+                "case": meta["case"],
+                "source": text_path,
+                "hash": hash_val,
+            },
+        }
+    ]
+    out_path = _build_path(meta, "embeddings", "chunks.json")
+    object_store.write_json(out_path, chunks)
+    return {"path": out_path}
+
+
+@shared_task
+def embed(meta: Dict[str, str], chunks_path: str) -> Dict[str, str]:
+    """Attach dummy embedding vectors to chunks."""
+    chunks = object_store.read_json(chunks_path)
+    embeddings = [{**ch, "vector": [0.0]} for ch in chunks]
+    out_path = _build_path(meta, "embeddings", "vectors.json")
+    object_store.write_json(out_path, embeddings)
+    return {"path": out_path}
+
+
+@shared_task
+def upsert(meta: Dict[str, str], embeddings_path: str) -> int:
+    """Upsert embedded chunks into the vector client."""
+    data = object_store.read_json(embeddings_path)
+    chunk_objs = [Chunk(content=ch["content"], meta=ch["meta"]) for ch in data]
+    VECTOR_CLIENT.upsert_chunks(chunk_objs)
+    return len(chunk_objs)

--- a/ai_core/tests/test_graphs.py
+++ b/ai_core/tests/test_graphs.py
@@ -1,0 +1,40 @@
+from ai_core.graphs import info_intake, scope_check, needs_mapping, system_description
+
+META = {"tenant": "t1", "case": "c1", "trace_id": "tr"}
+
+
+def test_info_intake_adds_meta():
+    state, result = info_intake.run({}, META)
+    assert state["meta"] == META
+    assert result["tenant"] == META["tenant"]
+
+
+def test_scope_check_never_creates_draft():
+    state, result = scope_check.run({}, META)
+    assert "draft" not in state
+    assert "draft" not in result
+    assert result["missing"] == ["scope"]
+
+
+def test_needs_mapping_breaks_on_missing():
+    initial = {"missing": ["scope"]}
+    state, result = needs_mapping.run(initial, META)
+    assert result["missing"] == ["scope"]
+    assert "needs" not in state
+
+
+def test_needs_mapping_success():
+    initial = {"missing": [], "needs_input": ["a", "b"]}
+    state, result = needs_mapping.run(initial, META)
+    assert state["needs"] == ["a", "b"]
+    assert result["mapped"] is True
+
+
+def test_system_description_only_when_no_missing():
+    state, result = system_description.run({"missing": ["scope"]}, META)
+    assert result["skipped"] is True
+    assert "description" not in state
+
+    state2, result2 = system_description.run({"missing": []}, META)
+    assert "description" in state2
+    assert result2["description"] == state2["description"]

--- a/ai_core/tests/test_infra.py
+++ b/ai_core/tests/test_infra.py
@@ -1,0 +1,91 @@
+import json
+
+from django.http import HttpResponse
+
+from ai_core.infra import object_store, pii
+from ai_core.infra.config import get_config
+from ai_core.infra.resp import apply_std_headers
+from ai_core.infra.tracing import trace
+
+
+def test_get_config_reads_env(monkeypatch):
+    get_config.cache_clear()
+    monkeypatch.setenv("LITELLM_BASE_URL", "http://litellm.local")
+    monkeypatch.setenv("LITELLM_API_KEY", "secret")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pub")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sec")
+
+    cfg = get_config()
+    assert cfg.litellm_base_url == "http://litellm.local"
+    assert cfg.litellm_api_key == "secret"
+    assert cfg.redis_url == "redis://localhost:6379/0"
+    assert cfg.langfuse_public_key == "pub"
+    assert cfg.langfuse_secret_key == "sec"
+
+
+def test_apply_std_headers_sets_headers():
+    resp = HttpResponse("ok")
+    result = apply_std_headers(resp, trace_id="abc123", prompt_version="v1")
+    assert result["X-Prompt-Version"] == "v1"
+    assert result["X-Trace-ID"] == "abc123"
+
+
+def test_apply_std_headers_skips_prompt_header_when_missing():
+    resp = HttpResponse("ok")
+    result = apply_std_headers(resp, trace_id="abc123")
+    assert "X-Prompt-Version" not in result
+    assert result["X-Trace-ID"] == "abc123"
+
+
+def test_pii_mask_replaces_digits():
+    assert pii.mask("User 123") == "User XXX"
+
+
+def test_object_store_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    object_store.write_json("tenant/case/state.json", {"ok": True})
+    assert object_store.read_json("tenant/case/state.json") == {"ok": True}
+    object_store.put_bytes("tenant/case/raw/data.bin", b"hi")
+    stored = tmp_path / ".ai_core_store/tenant/case/raw/data.bin"
+    assert stored.read_bytes() == b"hi"
+
+
+def test_trace_logs_locally_when_no_keys(monkeypatch, capsys):
+    @trace("node1")
+    def sample(state, meta):
+        return "ok"
+
+    sample(
+        {}, {"tenant": "t1", "case": "c1", "trace_id": "tid", "prompt_version": "v1"}
+    )
+    lines = [line for line in capsys.readouterr().out.strip().splitlines() if line]
+    assert len(lines) == 2
+    start, end = map(json.loads, lines)
+    assert start["event"] == "node.start"
+    assert end["event"] == "node.end"
+    assert end["duration_ms"] >= 0
+
+
+def test_trace_sends_to_langfuse(monkeypatch):
+    dispatched = []
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pub")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sec")
+    monkeypatch.setattr(
+        "ai_core.infra.tracing._dispatch_langfuse",
+        lambda trace_id, node_name, metadata: dispatched.append(
+            {"traceId": trace_id, "name": node_name, "metadata": metadata}
+        ),
+    )
+
+    @trace("node2")
+    def sample(state, meta):
+        return "ok"
+
+    sample(
+        {}, {"tenant": "t1", "case": "c1", "trace_id": "tid", "prompt_version": "v1"}
+    )
+    assert dispatched[0]["traceId"] == "tid"
+    assert dispatched[0]["name"] == "node2"
+    assert dispatched[0]["metadata"]["tenant"] == "t1"

--- a/ai_core/tests/test_llm.py
+++ b/ai_core/tests/test_llm.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from ai_core.llm import routing
+from ai_core.llm.client import call
+
+
+def test_resolve_reads_yaml(tmp_path, monkeypatch):
+    mapping = {"simple-query": "gpt-3.5"}
+    file = tmp_path / "MODEL_ROUTING.yaml"
+    file.write_text(json.dumps(mapping))
+    monkeypatch.setattr(routing, "ROUTING_FILE", file)
+    routing.load_map.cache_clear()
+
+    assert routing.resolve("simple-query") == "gpt-3.5"
+    with pytest.raises(ValueError):
+        routing.resolve("missing")
+
+
+def test_llm_client_masks_records_and_retries(monkeypatch):
+    metadata = {
+        "tenant": "t1",
+        "case": "c1",
+        "trace_id": "tr1",
+        "prompt_version": "v1",
+    }
+
+    class FailOnce:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(
+            self, url: str, headers: dict[str, str], json: dict[str, Any], timeout: int
+        ):
+            assert json["messages"][0]["content"] == "XXXX"
+            self.calls += 1
+            if self.calls == 1:
+
+                class Resp:
+                    status_code = 500
+
+                    def json(self):
+                        return {}
+
+                return Resp()
+            else:
+
+                class Resp:
+                    status_code = 200
+
+                    def json(self):
+                        return {
+                            "choices": [{"message": {"content": "ok"}}],
+                            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                        }
+
+                return Resp()
+
+    fail_once = FailOnce()
+
+    ledger_calls = {}
+
+    def mock_record(meta):
+        ledger_calls["meta"] = meta
+
+    monkeypatch.setattr("ai_core.llm.client.requests.post", fail_once)
+    monkeypatch.setattr("ai_core.llm.client.ledger.record", mock_record)
+    monkeypatch.setenv("LITELLM_BASE_URL", "https://example.com")
+    monkeypatch.setenv("LITELLM_API_KEY", "token")
+
+    from ai_core.infra import config as conf
+
+    conf.get_config.cache_clear()
+
+    res = call("simple-query", "secret", metadata)
+    assert res["model"]
+    assert res["prompt_version"] == "v1"
+    assert ledger_calls["meta"]["label"] == "simple-query"
+    assert ledger_calls["meta"]["tenant"] == "t1"
+    assert ledger_calls["meta"]["usage"]["in_tokens"] == 1
+    assert "text" not in ledger_calls["meta"]
+    assert fail_once.calls == 2

--- a/ai_core/tests/test_nodes.py
+++ b/ai_core/tests/test_nodes.py
@@ -1,0 +1,107 @@
+from ai_core.nodes import (
+    retrieve,
+    compose,
+    extract,
+    classify,
+    assess,
+    draft_blocks,
+    needs,
+)
+from ai_core.rag.vector_client import InMemoryVectorClient
+from ai_core.rag.schemas import Chunk
+
+META = {"tenant": "t1", "case": "c1", "trace_id": "tr"}
+
+
+def test_retrieve_returns_snippets():
+    client = InMemoryVectorClient()
+    chunk = Chunk(
+        "Hello 123", {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h"}
+    )
+    client.upsert_chunks([chunk])
+    state, result = retrieve.run({"query": "Hello"}, META.copy(), client=client)
+    assert result["snippets"][0]["text"] == "Hello 123"
+    assert result["snippets"][0]["source"] == "s1"
+    assert state["snippets"] == result["snippets"]
+
+
+def _mock_call(called):
+    def inner(label, prompt, metadata, **kwargs):
+        called["label"] = label
+        called["prompt"] = prompt
+        called["meta"] = metadata
+        return {"text": "resp", "usage": {}, "model": "m"}
+
+    return inner
+
+
+def test_compose_masks_and_sets_version(monkeypatch):
+    called = {}
+    monkeypatch.setattr("ai_core.llm.client.call", _mock_call(called))
+    state = {
+        "question": "Number 1234?",
+        "snippets": [{"text": "Answer", "source": "s"}],
+    }
+    new_state, result = compose.run(state, META.copy())
+    assert called["label"] == "synthesize"
+    assert "XXXX" in called["prompt"]
+    assert called["meta"]["prompt_version"] == "v1"
+    assert new_state["answer"] == "resp"
+    assert result["answer"] == "resp"
+
+
+def test_extract_classify_assess(monkeypatch):
+    called = {}
+    monkeypatch.setattr("ai_core.llm.client.call", _mock_call(called))
+    state = {"text": "Fact 42"}
+    new_state, _ = extract.run(state, META.copy())
+    assert called["label"] == "extract"
+    assert "XXXX" in called["prompt"]
+    assert new_state["items"] == "resp"
+
+    new_state, _ = classify.run(state, META.copy())
+    assert called["label"] == "classify"
+    assert new_state["classification"] == "resp"
+
+    new_state, _ = assess.run(state, META.copy())
+    assert called["label"] == "analyze"
+    assert new_state["risk"] == "resp"
+
+
+def test_draft_blocks(monkeypatch):
+    called = {}
+    monkeypatch.setattr("ai_core.llm.client.call", _mock_call(called))
+    state = {}
+    new_state, result = draft_blocks.run(state, META.copy())
+    assert called["label"] == "draft"
+    # all three prompt segments should be present
+    assert "Systembeschreibung" in called["prompt"]
+    assert "Funktionsliste" in called["prompt"]
+    assert "Standard-Klauselvorschläge" in called["prompt"]
+    assert new_state["draft"] == "resp"
+    assert result["draft"] == "resp"
+
+
+def test_needs_mapping():
+    state = {"info_state": {"purpose": "Acme", "extra": "foo"}}
+    new_state, result = needs.run(state, META.copy())
+    assert result["filled"] == ["purpose"]
+    assert result["missing"] == ["deployment_model", "main_components"]
+    assert result["ignored"] == ["extra"]
+    assert new_state["needs"] == result
+
+
+def test_tracing_called(monkeypatch):
+    payloads = []
+    monkeypatch.setattr(
+        "ai_core.infra.tracing._dispatch_langfuse", lambda *a, **k: None
+    )
+    monkeypatch.setattr("ai_core.infra.tracing._log", lambda p: payloads.append(p))
+    called = {}
+    monkeypatch.setattr("ai_core.llm.client.call", _mock_call(called))
+    state = {"question": "Q?", "snippets": []}
+    compose.run(state, META.copy())
+    assert payloads[0]["event"] == "node.start"
+    assert payloads[0]["node"] == "compose"
+    assert payloads[0]["tenant"] == "t1"
+    assert payloads[0]["prompt_version"] == "v1"

--- a/ai_core/tests/test_prompts.py
+++ b/ai_core/tests/test_prompts.py
@@ -1,0 +1,7 @@
+from ai_core.infra.prompts import load
+
+
+def test_load_finds_prompt_and_version():
+    data = load("retriever/answer")
+    assert data["version"] == "v1"
+    assert "Beantworte die Frage faktenbasiert" in data["text"]

--- a/ai_core/tests/test_rag_filters.py
+++ b/ai_core/tests/test_rag_filters.py
@@ -1,0 +1,16 @@
+from ai_core.rag.filters import strict_match
+
+
+def test_strict_match_positive():
+    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    assert strict_match(meta, "t1", "c1") is True
+
+
+def test_strict_match_negative():
+    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    assert strict_match(meta, "t1", "c2") is False
+
+
+def test_strict_match_negative_tenant():
+    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    assert strict_match(meta, "t2", "c1") is False

--- a/ai_core/tests/test_rate_limit.py
+++ b/ai_core/tests/test_rate_limit.py
@@ -1,0 +1,58 @@
+import logging
+from redis.exceptions import RedisError
+
+from ai_core.infra import rate_limit
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+        self.expire_at = {}
+        self.now = 0
+
+    def incr(self, key):
+        self._expire(key)
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    def expire(self, key, ttl):
+        self.expire_at[key] = self.now + ttl
+
+    def _expire(self, key):
+        if key in self.expire_at and self.now >= self.expire_at[key]:
+            self.store.pop(key, None)
+            self.expire_at.pop(key, None)
+
+
+def test_check_respects_quota_and_window(monkeypatch):
+    fake = FakeRedis()
+    rate_limit._get_redis.cache_clear()
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: fake)
+    monkeypatch.setattr(rate_limit, "get_quota", lambda: 2)
+
+    fake.now = 0
+    assert rate_limit.check("t1", now=0)
+    fake.now = 1
+    assert rate_limit.check("t1", now=1)
+    fake.now = 2
+    assert not rate_limit.check("t1", now=2)
+
+    fake.now = 61
+    assert rate_limit.check("t1", now=61)
+
+
+def test_get_quota_env_override(monkeypatch):
+    monkeypatch.setenv("AI_CORE_RATE_LIMIT_QUOTA", "5")
+    assert rate_limit.get_quota() == 5
+
+
+def test_fail_open_on_redis_error(monkeypatch, caplog):
+    rate_limit._get_redis.cache_clear()
+
+    def boom():
+        raise RedisError("boom")
+
+    monkeypatch.setattr(rate_limit, "_get_redis", boom)
+    with caplog.at_level(logging.WARNING):
+        assert rate_limit.check("t1")
+    assert "fail-open" in caplog.text

--- a/ai_core/tests/test_tasks.py
+++ b/ai_core/tests/test_tasks.py
@@ -1,0 +1,24 @@
+from ai_core import tasks
+from ai_core.rag.vector_client import InMemoryVectorClient
+
+
+def test_pipeline(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    meta = {"tenant": "t1", "case": "c1"}
+
+    raw = tasks.ingest_raw(meta, "doc.txt", b"User 123")
+    text = tasks.extract_text(meta, raw["path"])
+    masked = tasks.pii_mask(meta, text["path"])
+    chunks = tasks.chunk(meta, masked["path"])
+    embeds = tasks.embed(meta, chunks["path"])
+
+    vc = InMemoryVectorClient()
+    monkeypatch.setattr(tasks, "VECTOR_CLIENT", vc)
+    count = tasks.upsert(meta, embeds["path"])
+    assert count == 1
+
+    masked_file = tmp_path / ".ai_core_store/t1/c1/text/doc.masked.txt"
+    assert masked_file.read_text() == "User XXX"
+
+    results = vc.search("User", {"tenant": "t1", "case": "c1"})
+    assert len(results) == 1

--- a/ai_core/tests/test_views.py
+++ b/ai_core/tests/test_views.py
@@ -1,0 +1,122 @@
+import pytest
+
+from ai_core.infra import object_store, rate_limit
+
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+
+    def incr(self, key):
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    def expire(self, key, ttl):
+        return None
+
+
+@pytest.mark.django_db
+def test_ping_view_applies_rate_limit(client, monkeypatch):
+    monkeypatch.setattr(rate_limit, "get_quota", lambda: 1)
+    rate_limit._get_redis.cache_clear()
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: DummyRedis())
+
+    resp1 = client.get("/ai/ping/", HTTP_X_TENANT_ID="t", HTTP_X_CASE_ID="c")
+    assert resp1.status_code == 200
+    assert resp1.json() == {"ok": True}
+    assert "X-Prompt-Version" not in resp1
+    resp2 = client.get("/ai/ping/", HTTP_X_TENANT_ID="t", HTTP_X_CASE_ID="c")
+    assert resp2.status_code == 429
+    assert resp2.json()["detail"] == "rate limit"
+
+
+@pytest.mark.django_db
+def test_missing_headers_returns_400(client):
+    resp = client.post("/ai/intake/", data={}, content_type="application/json")
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "missing headers"
+
+
+@pytest.mark.django_db
+def test_intake_persists_state_and_headers(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(rate_limit, "check", lambda tenant, now=None: True)
+    monkeypatch.setattr(object_store, "BASE_PATH", tmp_path)
+
+    resp = client.post(
+        "/ai/intake/",
+        data={},
+        content_type="application/json",
+        HTTP_X_TENANT_ID="t",
+        HTTP_X_CASE_ID="c",
+    )
+    assert resp.status_code == 200
+    assert resp["X-Trace-ID"]
+    assert "X-Prompt-Version" not in resp
+
+    state = object_store.read_json("t/c/state.json")
+    assert state["meta"]["tenant"] == "t"
+
+
+@pytest.mark.django_db
+def test_scope_and_needs_flow(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(rate_limit, "check", lambda tenant, now=None: True)
+    monkeypatch.setattr(object_store, "BASE_PATH", tmp_path)
+
+    client.post(
+        "/ai/intake/",
+        data={},
+        content_type="application/json",
+        HTTP_X_TENANT_ID="t",
+        HTTP_X_CASE_ID="c",
+    )
+
+    resp_scope = client.post(
+        "/ai/scope/",
+        data={},
+        content_type="application/json",
+        HTTP_X_TENANT_ID="t",
+        HTTP_X_CASE_ID="c",
+    )
+    assert resp_scope.status_code == 200
+    assert resp_scope.json()["missing"] == ["scope"]
+    state = object_store.read_json("t/c/state.json")
+    assert state["missing"] == ["scope"]
+
+    resp_needs = client.post(
+        "/ai/needs/",
+        data={},
+        content_type="application/json",
+        HTTP_X_TENANT_ID="t",
+        HTTP_X_CASE_ID="c",
+    )
+    assert resp_needs.status_code == 200
+    assert resp_needs.json()["missing"] == ["scope"]
+
+
+@pytest.mark.django_db
+def test_sysdesc_requires_no_missing(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(rate_limit, "check", lambda tenant, now=None: True)
+    monkeypatch.setattr(object_store, "BASE_PATH", tmp_path)
+
+    object_store.write_json("t/c/state.json", {"missing": ["scope"]})
+    resp_skip = client.post(
+        "/ai/sysdesc/",
+        data={},
+        content_type="application/json",
+        HTTP_X_TENANT_ID="t",
+        HTTP_X_CASE_ID="c",
+    )
+    assert resp_skip.status_code == 200
+    assert resp_skip.json()["missing"] == ["scope"]
+
+    object_store.write_json("t/c/state.json", {"missing": []})
+    resp_desc = client.post(
+        "/ai/sysdesc/",
+        data={},
+        content_type="application/json",
+        HTTP_X_TENANT_ID="t",
+        HTTP_X_CASE_ID="c",
+    )
+    assert resp_desc.status_code == 200
+    body = resp_desc.json()
+    assert "description" in body

--- a/ai_core/tests/test_views_min.py
+++ b/ai_core/tests/test_views_min.py
@@ -1,0 +1,54 @@
+import pytest
+from pathlib import Path
+
+from ai_core.infra import object_store, rate_limit
+
+
+@pytest.mark.django_db
+def test_ping_ok(client, monkeypatch):
+    monkeypatch.setattr(rate_limit, "check", lambda tenant, now=None: True)
+    resp = client.get(
+        "/ai/ping/",
+        HTTP_X_TENANT_ID="t1",
+        HTTP_X_CASE_ID="c1",
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert resp["X-Trace-ID"]
+
+
+@pytest.mark.django_db
+def test_scope_missing_headers(client):
+    resp = client.post("/ai/scope/", data={}, content_type="application/json")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_scope_rate_limited(client, monkeypatch):
+    monkeypatch.setattr(rate_limit, "check", lambda tenant, now=None: False)
+    resp = client.post(
+        "/ai/scope/",
+        data={},
+        content_type="application/json",
+        HTTP_X_TENANT_ID="t1",
+        HTTP_X_CASE_ID="c1",
+    )
+    assert resp.status_code == 429
+
+
+@pytest.mark.django_db
+def test_scope_success_persists_state(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(rate_limit, "check", lambda tenant, now=None: True)
+    monkeypatch.setattr(object_store, "BASE_PATH", tmp_path)
+
+    resp = client.post(
+        "/ai/scope/",
+        data={},
+        content_type="application/json",
+        HTTP_X_TENANT_ID="t1",
+        HTTP_X_CASE_ID="c1",
+    )
+    assert resp.status_code == 200
+    assert resp["X-Trace-ID"]
+    state_file = Path(tmp_path, "t1", "c1", "state.json")
+    assert state_file.exists()

--- a/ai_core/urls.py
+++ b/ai_core/urls.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from django.urls import path
+
+from . import views
+
+app_name = "ai_core"
+
+urlpatterns = [
+    path("ping/", views.ping, name="ping"),
+    path("intake/", views.intake, name="intake"),
+    path("scope/", views.scope, name="scope"),
+    path("needs/", views.needs, name="needs"),
+    path("sysdesc/", views.sysdesc, name="sysdesc"),
+]

--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -1,1 +1,100 @@
-# Create your views here.
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+from django.http import HttpRequest, JsonResponse
+from django.views.decorators.http import require_POST
+
+from .graphs import info_intake, needs_mapping, scope_check, system_description
+from .infra import rate_limit
+from .infra.object_store import read_json, write_json
+from .infra.resp import apply_std_headers
+
+
+def assert_case_active(tenant: str, case_id: str) -> None:
+    """Placeholder for future case activity checks."""
+    return None
+
+
+def _prepare_request(request: HttpRequest):
+    tenant = request.headers.get("X-Tenant-ID")
+    case_id = request.headers.get("X-Case-ID")
+    if not tenant or not case_id:
+        return None, JsonResponse({"detail": "missing headers"}, status=400)
+
+    if not rate_limit.check(tenant):
+        return None, JsonResponse({"detail": "rate limit"}, status=429)
+
+    trace_id = uuid4().hex
+    assert_case_active(tenant, case_id)
+    meta = {"tenant": tenant, "case": case_id, "trace_id": trace_id}
+    return meta, None
+
+
+def _load_state(tenant: str, case_id: str) -> dict:
+    try:
+        return read_json(f"{tenant}/{case_id}/state.json")
+    except FileNotFoundError:
+        return {}
+
+
+def _save_state(tenant: str, case_id: str, state: dict) -> None:
+    write_json(f"{tenant}/{case_id}/state.json", state)
+
+
+def _run_graph(request: HttpRequest, graph) -> JsonResponse:
+    meta, error = _prepare_request(request)
+    if error:
+        return error
+
+    state = _load_state(meta["tenant"], meta["case"])
+    if request.body:
+        try:
+            payload = json.loads(request.body)
+            if isinstance(payload, dict):
+                state.update(payload)
+        except json.JSONDecodeError:
+            return JsonResponse({"detail": "invalid json"}, status=400)
+
+    try:
+        new_state, result = graph.run(state, meta)
+    except ValueError as exc:
+        return JsonResponse({"detail": str(exc)}, status=400)
+    except Exception:
+        return JsonResponse({"detail": "internal error"}, status=500)
+
+    _save_state(meta["tenant"], meta["case"], new_state)
+
+    prompt_version = result.get("prompt_version")
+    response = JsonResponse(result)
+    return apply_std_headers(response, meta["trace_id"], prompt_version)
+
+
+def ping(request: HttpRequest) -> JsonResponse:
+    """Lightweight endpoint used to verify AI Core availability."""
+    meta, error = _prepare_request(request)
+    if error:
+        return error
+    response = JsonResponse({"ok": True})
+    return apply_std_headers(response, meta["trace_id"])
+
+
+@require_POST
+def intake(request: HttpRequest) -> JsonResponse:
+    return _run_graph(request, info_intake)
+
+
+@require_POST
+def scope(request: HttpRequest) -> JsonResponse:
+    return _run_graph(request, scope_check)
+
+
+@require_POST
+def needs(request: HttpRequest) -> JsonResponse:
+    return _run_graph(request, needs_mapping)
+
+
+@require_POST
+def sysdesc(request: HttpRequest) -> JsonResponse:
+    return _run_graph(request, system_description)

--- a/noesis2/urls.py
+++ b/noesis2/urls.py
@@ -24,6 +24,7 @@ from users.views import accept_invitation
 urlpatterns = [
     path("", include("theme.urls")),
     path("admin/", admin.site.urls),
+    path("ai/", include("ai_core.urls")),
     path("tenant-demo/", DemoView.as_view(), name="tenant-demo"),
     path("invite/accept/<str:token>/", accept_invitation, name="accept-invitation"),
 ]


### PR DESCRIPTION
## Summary
- add `trace_meta` helper and decorate nodes with start/end JSON logs capturing duration
- background-dispatch tracing metadata to Langfuse when credentials exist
- expand infra and node tests for logging lifecycle and remote dispatch
- cover strict tenant/case matching and add minimal ping/scope view checks for headers, rate limits, and state persistence

## Testing
- `npm run lint`
- `pytest -q` *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68c67cf4cc94832bb129d70ab37d3236