### PR TITLE
Extend documentation with RAG and Langfuse guidance

### DIFF
--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -1,0 +1,41 @@
+# Warum
+Agenten orchestrieren den Zugriff auf Retrieval und Aktionen. Diese Übersicht erklärt, wie LangGraph eingebettet wird, welche Guardrails gelten und wie Requests aus der Web-App verarbeitet werden.
+
+# Wie
+## Kontrollfluss
+```mermaid
+sequenceDiagram
+    participant Web as Web-Service
+    participant Queue as Celery Queue
+    participant Agent as LangGraph Agent
+    participant Retriever as PGVector Retriever
+    participant Tools as Tools (Django, APIs)
+    participant LLM as LiteLLM
+    Web->>Queue: Task `agents.run`
+    Queue->>Agent: Starte Graph mit State `{tenant, trace_id}`
+    Agent->>Retriever: Suche relevante Chunks
+    Agent->>Tools: Führe Aktion aus (z.B. DB-Lookup)
+    Agent->>LLM: Frage Modell mit Kontext
+    LLM-->>Agent: Completion
+    Agent-->>Queue: Ergebnis + Logs
+    Queue-->>Web: Antwort speichern
+```
+
+## Knoten und Guardrails
+| Node | Aufgabe | Guardrail |
+| --- | --- | --- |
+| RetrievalNode | Ruft `pgvector` über LangChain Retriever | Erzwingt `tenant_id` Filter, max 5 Ergebnisse |
+| ReasonNode | Bewertet Ergebnisse, entscheidet nächsten Schritt | Bricht ab, wenn keine Treffer (`fallback=true`) |
+| ActNode | Führt Tools aus (z.B. Django Services) | Timeout 30s, idempotente Aufrufe |
+| LLMNode | Sendet Prompt an LiteLLM | Verwendet `prompt_version` aus Config, maskiert PII |
+
+## Tools, Cancellations und Tests
+- Tools definieren sich als LangChain-Tools mit klarer Input/Output-Spezifikation; Beispiele: `fetch_case`, `update_status`.
+- Cancellation: Jeder Node prüft `state["cancel"]`; falls gesetzt, beendet der Graph ohne weitere LLM-Calls.
+- Fehler propagieren als `AgentError` und landen in Langfuse mit Trace-Tags `error_type`/`tenant_id`.
+- Tests: Unit-Tests simulieren Nodes mit `FakeRetriever`, Integrationstests laufen über Docker Compose inklusive LiteLLM Stub; E2E (siehe [Pipeline](../cicd/pipeline.md)) ruft den Agentenpfad vollständig.
+
+# Schritte
+1. Implementiere Nodes gemäß Tabelle und dokumentiere sie mit `prompt_version` und Guardrails.
+2. Verdrahte den Web-Aufruf mit Celery Queue `agents` und registriere Tools pro Tenant, bevor Deployments erfolgen.
+3. Überwache Traces via [Langfuse Observability](../observability/langfuse.md) und aktualisiere Guardrails nach jedem Incident-Review.

--- a/docs/architektur/overview.md
+++ b/docs/architektur/overview.md
@@ -1,0 +1,137 @@
+# Warum
+Die Architekturübersicht schafft ein gemeinsames Verständnis für alle Container- und Cloud-Bausteine. Sie erklärt, wie Web-App, Hintergrundjobs und LiteLLM zusammenspielen und welche Infrastruktur in den verschiedenen Umgebungen benötigt wird.
+
+# Wie
+## Systemkontext
+Die Plattform besteht aus einer Django-Anwendung mit Mehrmandantenfähigkeit, unterstützt von Celery für asynchrone Aufgaben, einem RAG-Stack und LiteLLM als Proxy für Sprachmodelle. Die Hauptkomponenten sind:
+- **Web-Service**: Django via Gunicorn für HTTP-Traffic und Admin-Interface.
+- **Worker-Service**: Celery Worker für Standardaufgaben.
+- **Ingestion-Worker**: Dedizierte Celery Queue für Datenaufnahme und Embedding-Erstellung, siehe [RAG-Ingestion](../rag/ingestion.md).
+- **Agenten (LangGraph)**: LangChain/LangGraph-Flows innerhalb der Worker, orchestrieren Retrieval und Aktionen, beschrieben in [Agenten-Übersicht](../agents/overview.md).
+- **Beat-Service (optional)**: Celery Beat oder Scheduler für periodische Jobs.
+- **Migrate-Job**: Separater Containerlauf, führt `manage.py migrate_schemas --noinput` aus.
+- **LiteLLM-Service**: Proxy mit Admin-GUI, gesichert über Master Key laut [`config/litellm-config.yaml`](../../config/litellm-config.yaml).
+- **RAG Store**: `pgvector`-Schema in Cloud SQL mit Tabellen laut [RAG-Schema](../rag/schema.sql).
+
+## Laufzeitpfade
+| Umgebung | Bereitstellungspfad | Netzpfad |
+| --- | --- | --- |
+| Dev lokal | `docker-compose.dev.yml` startet Web, Worker, LiteLLM, Postgres, Redis | Docker-Bridge, direkte Container-Kommunikation |
+| Staging GCP | CI veröffentlicht Images nach Artifact Registry und deployt Cloud Run Dienste laut [Pipeline](../cicd/pipeline.md) | Öffentliche Cloud Run Endpunkte, Cloud SQL Connector (Public IP), Serverless VPC Access zu Memorystore |
+| Prod GCP | Genehmigter Release nutzt Traffic-Split auf Cloud Run | Interne Cloud Run Dienste hinter HTTPS Load Balancer, Private Service Connect zu Cloud SQL, Serverless VPC Access |
+
+## Komponenten und Abhängigkeiten
+```mermaid
+graph TD
+    subgraph Client
+        U[Benutzer]
+    end
+    subgraph Edge
+        LB[HTTPS Load Balancer]
+    end
+    subgraph CloudRun[Cloud Run Dienste]
+        W[Web (Gunicorn)]
+        C[Worker (Celery Core)]
+        I[Ingestion-Worker (Celery)]
+        A[Agenten (LangGraph im Worker)]
+        B[Beat / Scheduler]
+        J[Migrate Job]
+        L[LiteLLM Admin GUI]
+    end
+    subgraph Daten
+        SQL[(Cloud SQL Postgres)]
+        RAG[(RAG Store - pgvector Schema)]
+        Redis[(Memorystore Redis)]
+    end
+    subgraph Integrationen
+        AR[(Artifact Registry)]
+        SM[(Secret Manager - Prod)]
+        VPC[Serverless VPC Connector]
+    end
+
+    U --> LB
+    LB --> W
+    W --> SQL
+    W --> Redis
+    W --> L
+    W --> A
+    C --> Redis
+    C --> SQL
+    I --> Redis
+    I --> RAG
+    A --> Redis
+    A --> RAG
+    B --> Redis
+    J --> SQL
+    J --> Redis
+    L --> SQL
+    W -.-> AR
+    C -.-> AR
+    B -.-> AR
+    J -.-> AR
+    L -.-> AR
+    W -.-> SM
+    C -.-> SM
+    B -.-> SM
+    J -.-> SM
+    L -.-> SM
+    W --> VPC
+    C --> VPC
+    B --> VPC
+    J --> VPC
+    L --> VPC
+```
+
+## Deploy- und RAG-Flow
+```mermaid
+sequenceDiagram
+    participant Dev as Entwickler
+    participant VCS as Git Repository
+    participant CI as CI-Pipeline
+    participant AR as Artifact Registry
+    participant Stg as Cloud Run Staging
+    participant QA as QA-Team
+    participant Apr as Freigabe
+    participant Prod as Cloud Run Prod
+    participant Web as Web-Service
+    participant Worker as Celery Queue
+    participant Agent as LangGraph Agent
+    participant Retriever as PGVector Retriever
+    participant LLM as LiteLLM
+    Dev->>VCS: Merge in main
+    VCS->>CI: Trigger CI
+    CI->>CI: Lint & Tests laut Pipeline
+    CI->>AR: Build & Push Image (Semver+SHA)
+    CI->>Stg: Deploy Web/Worker/Beat mit --set-env-vars
+    CI->>Stg: Execute Migrate Job
+    Stg->>QA: Smoke & Funktionsprüfung
+    QA->>Apr: Ergebnis melden
+    Apr->>CI: Approval für Prod
+    CI->>Prod: Deploy mit Traffic-Split (z.B. 10/90)
+    Prod->>Prod: Smoke-Checks & Observability
+    Apr->>Prod: Traffic auf 100% erhöhen
+    Note over Dev,Prod: Nach Traffic-Shift beginnt der RAG-Aufruf
+    Prod->>Web: HTTP Request eines Tenants
+    Web->>Worker: Celery Task (Queue agents)
+    Worker->>Agent: LangGraph Flow starten
+    Agent->>Retriever: Vektor-Suche in PGVector
+    Retriever->>LLM: Prompt mit Kontext via LiteLLM
+    LLM-->>Agent: Completion liefern
+    Agent-->>Worker: Antwort aggregieren
+    Worker-->>Web: Resultat speichern
+    Web-->>Prod: Response an Client
+```
+
+## Datenpfade und Tenancy
+| Umgebung | Applikationsdaten | RAG Store | Tenancy-Modell |
+| --- | --- | --- | --- |
+| Dev lokal | PostgreSQL Container mit gemeinsamem Schema für alle Entwickler | Gleiches Container-Postgres mit aktivierter `pgvector`-Extension | Tenants über Schema `public` simuliert; zusätzliche Schemas optional per `manage.py create_tenant` |
+| Staging GCP | Cloud SQL Public IP, Django nutzt Schema je Tenant | Cloud SQL `pgvector`-Schema im selben Instance; Extension aktiviert, isoliert per Schema-Namen | Multi-Tenant über separate Schemas für Kern-Daten, PGVector nutzt `tenant_id` Spalte laut [RAG-Schema](../rag/schema.sql) |
+| Prod GCP | Cloud SQL Private IP, getrennte DB für App und LiteLLM möglich | Cloud SQL `pgvector`-Schema mit Private IP, Indexierung IVFFLAT/HNSW | Entweder Schema pro Mandant oder `tenant_id` + RLS (siehe [Prod Leitfaden](../cloud/gcp-prod.md)) |
+
+# Schritte
+1. Baue Container nach den [Docker-Konventionen](../docker/conventions.md) und tagge Images deterministisch.
+2. Pflege Umgebungsparameter anhand der [Environment-Matrix](../environments/matrix.md), bevor Infrastruktur angelegt wird.
+3. Richte Staging- und Produktionsressourcen gemäß den Cloud-Run-Leitfäden ([Staging](../cloud/gcp-staging.md), [Prod](../cloud/gcp-prod.md)) ein.
+4. Kopple die CI/CD-Stufen aus der [Pipeline-Dokumentation](../cicd/pipeline.md) mit den benötigten Berechtigungen.
+5. Bereite Betriebshandbücher ([Migrationen](../runbooks/migrations.md), [Incidents](../runbooks/incidents.md)) und Skalierungsregeln ([Operations](../operations/scaling.md)) vor, bevor Traffic verschoben wird.

--- a/docs/cicd/pipeline.md
+++ b/docs/cicd/pipeline.md
@@ -1,0 +1,44 @@
+# Warum
+Die Pipeline sorgt dafür, dass jede Änderung getestet, geprüft und kontrolliert ausgerollt wird. Diese Anleitung zeigt die feste Reihenfolge der Stufen und die benötigten Berechtigungen.
+
+# Wie
+## Pipeline-Stufen
+| Reihenfolge | Stufe | Inhalt | Gate |
+| --- | --- | --- | --- |
+| 1 | Lint | `npm run lint` inklusive Ruff/Black, siehe `.github/workflows/ci.yml` | Merge blockiert bei Fehlern |
+| 2 | Unit | `pytest` mit Tenant-Migrationen und Coverage (siehe `.github/workflows/ci.yml`) | Must-pass für Image-Build |
+| 3 | Build | Docker Build mit Multi-Stage, Tag `vX.Y.Z-<sha>` (Semver+SHA) | Nutzt Artifact Registry Service Account |
+| 4 | Push | Docker Push zum Artifact Registry Repo | Abbruch bei fehlender Auth |
+| 5 | E2E (Compose) | Playwright Tests aus `.github/workflows/e2e.yml` gegen Docker-Compose-Stack, prüft Retrieval-Ende-zu-Ende | Ergebnis entscheidet über Staging-Deploy |
+| 6 | Vector-Schema-Migrations | Führt SQL aus [`docs/rag/schema.sql`](../rag/schema.sql) über Cloud SQL Proxy; dry-run + Apply | Stoppt Release bei DDL-Fehlern |
+| 7 | Staging Migrate Job | Cloud Run Job `noesis2-migrate` mit `migrate_schemas --noinput` | Bricht Release bei Fehlern ab |
+| 8 | Staging Deploy | Cloud Run Deploy für Web, Worker, Beat, LiteLLM mit `--set-env-vars` | Löst Smoke-Tests aus |
+| 9 | Ingestion-Smoke | Cloud Run Job (Queue `ingestion`) verarbeitet Mini-Batch, verifiziert Embeddings | Blockiert Approval bei Fehler |
+| 10 | Smoke Staging | Health-Checks (`/`, `/health/liveliness`) + Logsichtung laut [QA](../qa/checklists.md) | Gate für Approval |
+| 11 | Approval | Manuelle Freigabe (Prod Approver) in GitHub Actions | Pflicht vor Prod |
+| 12 | Prod Migrate | Cloud Run Job mit Secrets aus Secret Manager | Stoppt Flow bei Fehler |
+| 13 | Prod Deploy (Traffic-Split) | Deploy neue Revision mit z.B. 10% Traffic | Startet Prod-Smoke |
+| 14 | Smoke Prod | HTTP-Checks, Log-Review, Monitoring laut [QA](../qa/checklists.md) | Vor Bedarfs-Traffic |
+| 15 | Traffic 100% | Erhöht Anteil auf 100%, bestätigt in GitHub Actions | Markiert Release als abgeschlossen |
+
+## Artefakt-Tagging
+- Versionen folgen Semver auf Branch-Ebene. Major/Minor/Patch wird bei Release-Tags gesetzt, `-<commit-sha>` stellt Eindeutigkeit sicher.
+- Jedes Tag landet als Cloud Run Revision Label (`version`, `commit`) für Nachvollziehbarkeit.
+- Rollbacks verwenden den letzten Tag aus der Registry; Deployments ohne Tag sind nicht erlaubt.
+
+## Workload Identity Federation
+Ein gemeinsames Service-Konto interagiert mit GCP über WIF. Es erhält ausschließlich die minimal nötigen Rollen:
+- `roles/artifactregistry.writer` für Build & Push
+- `roles/run.admin` und `roles/run.developer` für Deployments
+- `roles/cloudsql.client` für Migrate-Jobs
+- `roles/cloudsql.editor` oder granularer DDL-Rolle für Vector-Schema-Migrations
+- `roles/secretmanager.secretAccessor` nur in Prod-Stufen
+- `roles/redis.admin` für Memorystore-Verbindungen
+- `roles/compute.networkUser` damit Serverless VPC Access genutzt werden darf
+
+# Schritte
+1. Pflege Semver-Versionen vor dem Merge, damit Build- und Deploy-Stufen das korrekte Tag erzeugen.
+2. Stelle sicher, dass Unit- und E2E-Tests vollständig laufen und Ergebnisse dokumentiert sind.
+3. Überprüfe vor jedem Release, ob WIF-Rollen für das Pipeline-Service-Konto aktuell sind.
+4. Folge dem Gate-Flow strikt: kein Prod-Deploy ohne bestandenes Staging und manuelle Freigabe.
+5. Dokumentiere Smoke-Ergebnisse und Traffic-Entscheidungen in den Release-Notizen.

--- a/docs/cloud/gcp-prod.md
+++ b/docs/cloud/gcp-prod.md
@@ -1,0 +1,51 @@
+# Warum
+Die Produktionsumgebung schützt Kundendaten und stellt Verfügbarkeit sicher. Dieses Dokument beschreibt alle Abweichungen zu Staging und führt durch die Härtungsmaßnahmen.
+
+# Wie
+## Architekturunterschiede
+- **Cloud SQL** nutzt ausschließlich Private IP und liegt in einer dedizierten VPC. Alle Dienste greifen über Serverless VPC Access und Private Service Connect zu.
+- **Ingress**: Cloud Run Web & LiteLLM sind intern; ein globaler HTTPS Load Balancer mit Managed SSL-Zertifikat und DNS-Eintrag veröffentlicht die Anwendung. Nur der Load Balancer ist extern erreichbar.
+- **Secrets**: Laufzeitkonfiguration wird aus Secret Manager geladen. Deployments referenzieren Secret-Versionen gemäß [Security-Leitfaden](../security/secrets.md).
+- **LiteLLM GUI**: Optional mit Cloud IAP abgesichert, zusätzlich zur Master-Key-Authentifizierung aus [`config/litellm-config.yaml`](../../config/litellm-config.yaml).
+- **RAG Store**: `pgvector` läuft im Cloud SQL-Instance mit Private IP; Indexe (IVFFLAT/HNSW) und Wartungsjobs sichern Latenzen.
+
+## Ressourcen und Parameter
+| Dienst | Produktionsspezifikum |
+| --- | --- |
+| Web | minInstances 2, maxInstances 10, Concurrency 30, CPU 2, Memory 2 GiB, Traffic-Split für Releases (z.B. 10/90, 50/50, 100%) |
+| Worker | Separater Cloud Run Service mit Concurrency 1, minInstances 1, maxInstances 20; Queue-Länge aus Monitoring steuert manuelle Anpassungen |
+| Beat | Eine Instanz fix, keine Skalierung, Private Ingress |
+| Migrate-Job | Cloud Run Job mit Timeout 900 s, maxRetries 1, startet nur nach Freigabe laut [Pipeline](../cicd/pipeline.md) |
+| LiteLLM | Interner Cloud Run Service, Zugriff via IAP-Gruppe oder VPC-Only, Logging aktiv; Rate-Limits via `AI_CORE_RATE_LIMIT_QUOTA` |
+| Cloud SQL | PITR aktiv (min. 7 Tage), Backups täglich, Wartungsfenster definiert; getrennte DB für App und LiteLLM empfohlen |
+| RAG Store | Schema `rag` oder `tenant_rag_*` im selben Instance; `pgvector` Extension aktiv, Indizes IVFFLAT (k=100) oder HNSW (ef_search=64) |
+| Memorystore | Hochverfügbarer Redis (Standard Tier), Auth-Token aktiviert |
+| Artifact Registry | Gleiches Repo wie Staging, nur signierte Tags (`cosign` optional) |
+| Secret Manager | Versioniertes Speichern aller produktiven ENV-Variablen, Rotation automatisiert |
+| Langfuse | SaaS oder selbst gehostet; Secrets ausschließlich über Secret Manager, Sampling 5% (Default), PII-Redaction aktiv |
+
+## Betrieb und Sicherheit
+- **Traffic-Split & Rollback**: Releases laufen über Cloud Run Revisions. Nach Smoke-Tests (siehe [QA](../qa/checklists.md)) wird Traffic sukzessive erhöht. Rollback bedeutet Traffic zurück auf die letzte Revision und ggf. Restore aus PITR.
+- **Backups**: Cloud SQL automatisierte Backups + PITR, Memorystore Snapshots wöchentlich exportieren.
+- **IAM**: Workload Identity Federation nutzt ein Service-Konto mit Rollen `roles/run.admin`, `roles/artifactregistry.writer`, `roles/cloudsql.client`, `roles/secretmanager.secretAccessor`, `roles/redis.admin`, `roles/compute.networkUser`.
+- **Log-Retention**: Cloud Logging auf 90 Tage einstellen, Audit-Logs nicht kürzen. Export wichtiger Logtypen nach BigQuery zur Langzeitaufbewahrung.
+- **Langfuse**: Secret-Verteilung ausschließlich via Secret Manager (`LANGFUSE_*`), Sampling-Regeln pro Mandant dokumentieren, PII-Redaction (`masking_rules`) aktiv.
+
+## pgvector Betrieb
+- Verwende IVFFLAT-Indizes (`lists` nach Datensatzanzahl skalieren) für Standard-Suche; für hochwertige Re-ranking-Pfade optional HNSW mit `ef_search=64`.
+- Plane Wartungsjobs: `REINDEX CONCURRENTLY` und `ANALYZE` monatlich, `VACUUM` nach größeren Löschläufen laut [RAG-Übersicht](../rag/overview.md).
+- Alle schemaändernden Migrationen laufen getrennt in der Pipeline-Stufe „Vector-Schema-Migrations“. Rollbacks nutzen PITR oder Index-Drop + Rebuild (siehe [Migrations-Runbook](../runbooks/migrations.md)).
+
+## Tenancy-Modell
+- Option 1: Schema pro Mandant (`tenant_<slug>`), getrennte `rag`-Schemas spiegeln diese Struktur. Vorteil: natürliche Isolation, Nachteil: mehr Verwaltungsaufwand.
+- Option 2: Gemeinsames Schema mit Spalte `tenant_id` und aktivem Row-Level-Security (`USING tenant_id = current_setting('app.tenant_id')::uuid`).
+- Entscheide pro Produktphase; dokumentiere Wahl in [Security](../security/secrets.md) unter Allowed Hosts und `DATABASE_URL`.
+
+# Schritte
+1. Erstelle oder erweitere die Produktions-VPC mit Subnetzen für Private Service Connect und Serverless VPC Access.
+2. Provisioniere Cloud SQL mit Private IP, aktiviere PITR und definiere Backups sowie Wartungsfenster.
+3. Richte Memorystore (Standard Tier) ein und sichere den Zugriff über die VPC.
+4. Hinterlege alle produktiven Secrets im Secret Manager und setze Zugriffspfade gemäß [Security](../security/secrets.md).
+5. Konfiguriere den globalen HTTPS Load Balancer (Managed SSL, DNS, optional Cloud Armor) und verknüpfe Cloud Run über interne Ingress-Einstellungen.
+6. Binde Workload Identity Federation mit den genannten IAM-Rollen an die CI/CD-Pipeline ([Pipeline](../cicd/pipeline.md)).
+7. Plane Release-Runbooks: Migrationen gemäß [Runbook](../runbooks/migrations.md), Incident-Reaktionen via [Incidents](../runbooks/incidents.md), Skalierung über [Operations](../operations/scaling.md).

--- a/docs/cloud/gcp-staging.md
+++ b/docs/cloud/gcp-staging.md
@@ -1,0 +1,57 @@
+# Warum
+Die Staging-Umgebung bildet die Produktionsarchitektur nach, erlaubt aber schnelle Iteration. Dieses Dokument zeigt, welche GCP-Ressourcen nötig sind und wie sie zusammenspielen.
+
+# Wie
+## Ressourcenübersicht
+| Dienst | Typ | Wichtige Parameter |
+| --- | --- | --- |
+| Web | Cloud Run Service | Region `europe-west4`, CPU 1, RAM 1 GiB, Concurrency 30, minInstances 0, maxInstances 3, Cloud SQL Connector (Public IP) |
+| Worker | Cloud Run Service | Gleiches Image wie Web, Concurrency 1, CPU 1, maxInstances 3, verbindet sich zu Redis über Serverless VPC Access |
+| Beat (optional) | Cloud Run Service | Startbefehl `celery -A noesis2 beat -l info`, 1 Instanz fix, Zugriff auf Redis |
+| Migrate-Job | Cloud Run Job | Timeout 600 s, maxRetries 0, Cloud SQL Connector, führt `migrate_schemas --noinput` aus |
+| Seed-Job | Cloud Run Job | Re-usable Job aus CI für Demo-Daten, gleiche Env wie Migrate-Job |
+| LiteLLM | Cloud Run Service | Image `ghcr.io/berriai/litellm:main-stable`, Concurrency 10, minInstances 0, benötigt Cloud SQL Connector und Redis |
+| Cloud SQL | PostgreSQL 16 | Public IP aktiviert, Cloud SQL Auth Proxy/Connector, Datenbank `noesis2_staging`, zweites Schema für LiteLLM |
+| RAG Store | Cloud SQL Schema | Schema `rag` in derselben Instanz, `pgvector` Extension aktiviert, Tabellen laut [Schema](../rag/schema.sql) |
+| Memorystore | Redis 7 | Private Service, Verbindung über Serverless VPC Connector, Standardgröße 1 GiB |
+| Artifact Registry | Docker Repository | Region wie Cloud Run, Reponame `noesis2`, nutzt Semver+SHA Tags |
+| Langfuse | Cloud Run Service oder SaaS | Optional als separater Dienst, empfängt Traces aus Worker und LiteLLM, API Keys aus CI |
+
+## Netzwerk und Konnektivität
+- Cloud Run Dienste greifen auf Cloud SQL über den Cloud SQL Connector (Public IP) zu; kein Öffnen von Firewalls nötig.
+- Memorystore liegt in einer dedizierten VPC. Alle Cloud Run Dienste erhalten einen Serverless VPC Access Connector (`/28` Subnetz) für Redis-Zugriffe.
+- Ausgehender Traffic nutzt standardmäßig egress über das Internet; sensibler Traffic geht über den Connector.
+
+## Konfiguration
+- GitHub Actions setzt alle Variablen per `--set-env-vars`, siehe [Pipeline](../cicd/pipeline.md). Secret Manager wird in Staging nicht verwendet.
+- Wichtige Variablen: `EMBEDDINGS_MODEL`, `EMBEDDINGS_DIM`, `EMBEDDINGS_API_BASE`, `LANGFUSE_KEY`, `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LITELLM_URL`.
+- Basissecrets folgen dem Schema aus [Security](../security/secrets.md); Rotation erfolgt durch Aktualisierung der CI-Secrets und anschließendes Redeploy.
+- LiteLLM verlangt `require_auth: true` laut [`config/litellm-config.yaml`](../../config/litellm-config.yaml); nur Benutzer mit gültigem Master Key oder API Key erhalten Zugang.
+
+## pgvector aktivieren
+- Aktiviere die Extension nach Provisionierung: `CREATE EXTENSION IF NOT EXISTS vector;` im Schema `rag`.
+- Optionale Flags für Performance: `work_mem=128MB` und `effective_io_concurrency=200`. Änderungen erfolgen über das Cloud SQL Flag-Set.
+- Halte Tabellen `documents`, `chunks`, `embeddings` konsistent zum [RAG-Schema](../rag/schema.sql); Migrationen laufen über die Stufe „Vector-Schema-Migrations“ in der [Pipeline](../cicd/pipeline.md).
+
+## Service-Konten
+- CI-Service-Konto benötigt `roles/cloudsql.client`, `roles/run.developer` und `roles/iam.serviceAccountUser` für Deployments.
+- Worker-Identität (Workload Identity) benötigt `roles/cloudsql.client`, um Embeddings schreiben und lesen zu können.
+- Zugriff auf Langfuse (Self-Hosted) erfolgt über denselben Service-Account mit `roles/run.invoker`, falls Langfuse in GCP läuft.
+
+## Ingestion-Limits
+- Plane pro Worker maximal zwei gleichzeitige Ingestion-Batches à 128 Chunks. Größere Batches erhöhen die Speicherauslastung.
+- Setze Cloud Run Timeout auf 900 Sekunden für Ingestion-Worker, um lange Embedding-Läufe abzudecken.
+- Verwende `BATCH_SIZE` und `MAX_TOKENS` laut [RAG-Ingestion](../rag/ingestion.md) und dokumentiere Anpassungen im Release-Plan.
+
+## Zugriffsmodell LiteLLM
+- Web- und Worker-Container nutzen `LITELLM_URL` intern.
+- Administrativer Zugriff auf die LiteLLM GUI erfolgt über das Cloud Run Auth-Gateway; Service-Konten erhalten den `roles/run.invoker`.
+- Audit-Logs landen in Cloud Logging und werden mindestens 30 Tage aufbewahrt.
+
+# Schritte
+1. Lege das Artifact-Registry-Repository im Zielprojekt an, damit CI Push-Rechte konfigurieren kann.
+2. Provisioniere Cloud SQL (Public IP) und Memorystore; dokumentiere Verbindungsnamen für die [Pipeline](../cicd/pipeline.md) und aktiviere `pgvector` im Schema `rag`.
+3. Erstelle den Serverless VPC Access Connector und verbinde Web, Worker, Beat, LiteLLM sowie optionale Langfuse-Instanz damit.
+4. Deploye die Cloud Run Dienste mit dem aktuellen Image und setze Umgebungsvariablen ausschließlich via CI (`--set-env-vars`), inklusive `EMBEDDINGS_*` und `LANGFUSE_*`.
+5. Richte die Cloud Run Jobs (Migration, Seed, Ingestion-Testbatch) ein und teste sie gemäß [Migrations-Runbook](../runbooks/migrations.md) und [RAG-Ingestion](../rag/ingestion.md).
+6. Aktiviere Logging-Dashboards, Langfuse-Workspaces und Smoke-Checks laut [QA-Checklisten](../qa/checklists.md).

--- a/docs/docker/conventions.md
+++ b/docs/docker/conventions.md
@@ -1,0 +1,36 @@
+# Warum
+Saubere Container-Images sind die Grundlage für reproduzierbare Deployments und sichere Cloud-Workloads. Dieses Dokument fasst verbindliche Bau- und Laufzeitregeln zusammen.
+
+# Wie
+## Build-Prinzipien
+- **Multi-Stage**: Das bestehende [`Dockerfile`](../../Dockerfile) trennt Node-Asset-Build, Python-Build und Runner. Diese Struktur bleibt Pflicht, damit das Runtime-Image klein bleibt.
+- **Non-root**: Der Runner legt `appuser` (UID 10001) an und wechselt dauerhaft zu ihm. Neue Images dürfen keine Root-Prozesse starten.
+- **Read-only Filesystem**: Für Staging und Prod wird das Root-Filesystem als read-only konfiguriert; Schreibzugriff erfolgt über `/tmp` und Cloud-Volumes. Django-Collectstatic liefert fertige Assets, daher sind keine Schreiboperationen nötig.
+- **Deterministische Versionierung**: Images erhalten Semver+SHA (z.B. `v1.4.0-<commit>`) laut [Pipeline](../cicd/pipeline.md); keine Floating-Tags.
+- **Bibliotheksabhängigkeiten**: Python-Requirements enthalten LangChain, LangGraph, `pgvector`-Client (`pgvector`/`psycopg`) und das Langfuse SDK. Versionen werden in `requirements*.txt` eingefroren und mit dem Image ausgeliefert.
+
+## Startkommandos
+- **Web-Service**: Startet Gunicorn über das `CMD` im Image (`gunicorn noesis2.wsgi:application --bind 0.0.0.0:${PORT} --workers 3`). Cloud Run `PORT` steuert den Listener.
+- **Worker-Service**: Startbefehl `celery -A noesis2 worker -l info`. In Prod zusätzliche `--concurrency`-Flags gemäß [Scaling-Guide](../operations/scaling.md).
+- **Ingestion-Worker**: Separate Queue `celery -A noesis2 worker -l info -Q ingestion` für Embedding-Läufe. Deployment siehe [RAG-Ingestion](../rag/ingestion.md).
+- **Agenten-Worker**: Verwenden dieselbe Binary wie Worker, aber Queue-Flag `-Q agents`. Guardrails stehen in der [Agenten-Übersicht](../agents/overview.md).
+- **Beat/Scheduler**: Separater Container mit `celery -A noesis2 beat -l info`; niemals im Worker-Prozess kombinieren.
+- **Migrate-Job**: Führt `python manage.py migrate_schemas --noinput` aus und endet bei Erfolg. Siehe [Runbook](../runbooks/migrations.md).
+- **LiteLLM**: Nutzt `litellm --config /config/config.yaml --host 0.0.0.0 --port 4000 --num_workers 1` laut `docker-compose.dev.yml`.
+
+## Gesundheitsendpunkte
+- **Web**: `/` beantwortet HTTP 200 und dient als Liveness; `/admin/login/` prüft Session-Stack. Für Readiness wird ein leichtgewichtiger JSON-Endpunkt ergänzt (z.B. `GET /tenant-demo/` liefert `{"status": "ok"}` via `DemoView`).
+- **Worker**: Health basiert auf Celery Inspect (`celery --app noesis2 inspect ping` in separatem Kontrolljob). Cloud Run skaliert Worker-Container bei fehlgeschlagenen Pings herunter.
+- **Ingestion-Queue**: Zusätzliche Probe `celery --app noesis2 inspect active -d ingestion@*` prüft, dass die Queue verarbeitet wird und Batch-Laufzeiten innerhalb der Grenzwerte aus [Scaling](../operations/scaling.md) bleiben.
+- **Agenten-Queue**: Heartbeat-Metriken (`celery events`) melden Fehlerhäufigkeit und Antwortzeit. Langfuse-Traces dienen als ergänzende Readiness, siehe [Langfuse Observability](../observability/langfuse.md).
+- **LiteLLM**: `/health/liveliness` liefert `alive`, `/health` gibt Aggregatszustand zurück (siehe `docker-compose.dev.yml`).
+
+## Was nicht passiert
+- Web- und Worker-Container führen **keine** automatischen Migrationen aus; der [Migrate-Job](../runbooks/migrations.md) übernimmt das exklusiv. Für lokale Entwicklung darf `entrypoint.sh` angepasst werden, Staging/Prod nutzen eine Variante ohne `migrate`.
+- In Staging und Prod werden **keine lokalen Volumes** eingehängt; persistente Daten liegen ausschließlich in Cloud SQL und Memorystore.
+
+# Schritte
+1. Halte dich beim Erstellen neuer Images an die vorhandene Multi-Stage-Struktur und überprüfe nach jedem Build die Dateigröße.
+2. Prüfe Startkommandos und Health-Ziele jedes Dienstes, bevor du Deployment-Templates aktualisierst.
+3. Entferne alle automatischen Migrationen aus Laufzeit-Entrypoints für Cloud-Umgebungen und verweise auf das dedizierte Runbook.
+4. Verifiziere bei Reviews, dass neue Container ohne lokale Volumes und mit read-only Filesystem spezifiziert sind.

--- a/docs/environments/matrix.md
+++ b/docs/environments/matrix.md
@@ -1,0 +1,23 @@
+# Warum
+Die Umgebungsmatrix verhindert Fehlkonfigurationen und schafft Klarheit über Infrastruktur, Sicherheit und Kosten pro Stage. Junior-Entwickler sehen sofort, welche Dienste wo laufen und welche Regeln gelten.
+
+# Wie
+Die drei Stufen folgen denselben Container-Artefakten, unterscheiden sich aber bei Netzwerk, Geheimnissen, RAG-Bausteinen und Governance. Wichtige Leitplanken:
+- Automatische Migrationen laufen nur lokal; Cloud-Deployments folgen dem [Migrations-Runbook](../runbooks/migrations.md).
+- Staging erhält Konfiguration ausschließlich über `--set-env-vars` aus der CI ([Pipeline](../cicd/pipeline.md)); kein Secret Manager.
+- Prod liest Secrets zwingend aus dem [Secret-Management](../security/secrets.md) via Secret Manager Versionen.
+ - Der `pgvector`-Speicher folgt den Tabellen aus [RAG-Schema](../rag/schema.sql); in Prod gelten Private-IP und PITR.
+ - Ingestion- und Agenten-Queues bleiben getrennt, damit Last sauber skaliert werden kann (siehe [Scaling](../operations/scaling.md)).
+
+## Vergleich
+| Umgebung | Container | Netz | Datenbanken | RAG Store | Ingestion | Agenten | Secrets | Ingress | Observability (Langfuse) | Skalierung | Kostenhebel |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Dev lokal | Docker Compose (Web, Worker, LiteLLM, Postgres, Redis) | Docker-Bridge, lokale Ports | Postgres 16 Container, Redis 7 Container, LiteLLM nutzt `DATABASE_URL` | Gleiches Postgres-Container-Schema, `pgvector` lokal aktiviert | Compose-Worker mit Queue `ingestion`, Batchgröße klein halten | Agenten laufen im selben Worker, Logging auf Konsole | `.env` aus Repo-Wurzel | `http://localhost:{8000,4000}` | Langfuse optional lokal mit SQLite; Logs primär Konsole | Manuell via Compose (Start/Stop) | Container pausieren, Datenbank-Volume löschen |
+| Staging GCP | Cloud Run Services: Web, Worker, optional Beat, LiteLLM; Cloud Run Job für Migration/Seed | Öffentliches Cloud Run + Serverless VPC Access zu Memorystore; Cloud SQL Connector (Public IP) | Cloud SQL Postgres mit Public IP, Memorystore Redis Private Service; LiteLLM nutzt Cloud SQL Schema | Cloud SQL Schema `rag` mit `pgvector` Extension, Index-Tests mit 1k Vektoren | Cloud Run Worker mit Queue `ingestion`, Limits laut [Scaling](../operations/scaling.md) (max 2 gleichzeitige Batches) | Agenten-Queue `agents` mit LangGraph, Output nach Langfuse | CI setzt Umgebungsvariablen je Deploy (`--set-env-vars`) | Cloud Run URL (authentifiziert für Admin), temporär öffentlich für QA | Langfuse Cloud/Container über CI-Variablen (`LANGFUSE_*`), Sampling 25% | Auto-Scaling pro Dienst (min 0, max 3), Worker nach Queue-Metriken | Min-Instances = 0, regionale Ressourcen klein halten |
+| Prod GCP | Cloud Run Services identisch zu Staging plus dedizierter Beat falls benötigt | Private VPC + Serverless Connector, Cloud SQL Private IP, interne Dienste | Cloud SQL Postgres mit PITR, Memorystore Redis, optional getrennte DB für LiteLLM | Cloud SQL Private IP, `pgvector` mit IVFFLAT/HNSW Indizes, PITR aktiv | Cloud Run Worker Queue `ingestion`, maxInstances abgestimmt auf Kostenlimit; Batches 512 Chunks | Agenten-Queue `agents` mit RLS-sicherem Zugriff; Guardrails aktiv | Secret Manager + Runtime Secrets ([Security](../security/secrets.md)) | Interne Cloud Run URLs; externer Zugriff nur via HTTPS Load Balancer & Managed SSL | Langfuse via Secret Manager (`LANGFUSE_*`), Sampling 5%, PII-Redaction aktiv | Min-Instances > 0 für Web, Worker horizontal via Traffic-Split, Beat fix 1 | Traffic-Split für Canary, Skalierungsgrenzen optimieren, Speicherklassen wählen |
+
+# Schritte
+1. Nutze die Matrix als Vorlage, wenn eine neue Stage entsteht oder Einstellungen abweichen sollen.
+2. Prüfe pro Spalte, ob notwendige Ressourcen bereits im passenden Cloud-Projekt existieren.
+3. Gleiche Secret-Quellen mit dem [Security-Guide](../security/secrets.md) ab, bevor Deployments freigegeben werden.
+4. Plane Observability- und Skalierungsmaßnahmen gemeinsam mit [Operations](../operations/scaling.md), damit Kosten und Stabilität zusammenpassen.

--- a/docs/litellm/admin-gui.md
+++ b/docs/litellm/admin-gui.md
@@ -1,0 +1,43 @@
+# Warum
+LiteLLM bündelt alle LLM-Zugriffe und liefert eine Admin-GUI. Dieses Dokument erklärt Betrieb, Berechtigungen und Grenzen, damit der Dienst kontrolliert bleibt.
+
+# Wie
+## Betriebsmodell
+- LiteLLM läuft als eigener Cloud Run Service (siehe [Architektur](../architektur/overview.md)).
+- Konfiguration stammt aus [`config/litellm-config.yaml`](../../config/litellm-config.yaml); `require_auth: true` erzwingt Authentifizierung.
+- Der Dienst verwendet `DATABASE_URL`, um Nutzungsdaten und API-Keys zu speichern. In Cloud-Umgebungen liegt diese Datenbank im selben Cloud SQL Projekt wie Django.
+
+## Berechtigungen
+- Zugriffe erfolgen über API Keys (Master Key für Admins, individuelle Keys für Dienste). Master Key wird wie in [Security](../security/secrets.md) verwaltet.
+- Cloud Run Auth (`roles/run.invoker`) beschränkt HTTP-Zugriffe. In Prod optional zusätzlich Cloud IAP für die GUI.
+- Änderungen an Modelleinstellungen erfolgen nur durch AI Platform Owner oder delegierte Admins.
+
+## Rate-Limits & Protokollierung
+- `AI_CORE_RATE_LIMIT_QUOTA` steuert die erlaubten Requests pro Tenant. Anpassungen passieren synchron in Django und LiteLLM, damit Limits übereinstimmen.
+- LiteLLM protokolliert alle Requests in Cloud Logging und Langfuse (ENV `LANGFUSE_*`). Logs werden 30 Tage (Staging) bzw. 90 Tage (Prod) aufbewahrt.
+- „Modell-Trace aktivieren“: Setze `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` und `LANGFUSE_KEY` im LiteLLM-Service. Optional `LANGFUSE_SAMPLE_RATE` für feinere Steuerung, siehe [Langfuse Observability](../observability/langfuse.md).
+- Kosten-Alerts definieren: Verwende Langfuse KPIs `cost_total` pro Tenant; Alerts bei >80% des Monatsbudgets.
+- Rate-Limits pro Team: Weise jedem API-Key einen Tenant zu und setze `rate_limit_per_minute` im LiteLLM Config Mapping.
+- Fehler und Überschreitungen lösen Alerts aus, die mit dem [Incident-Runbook](../runbooks/incidents.md) verknüpft sind.
+
+## Risiken
+- Fehlkonfigurierte Keys können unbegrenzte Kosten erzeugen.
+- Ohne Auth könnten sensible Prompts abfließen.
+- Datenbankdrift zwischen Django und LiteLLM führt zu Inkonsistenzen bei Limits oder Billing.
+
+## Do & Don't
+- **Do**: Keys regelmäßig rotieren, Logs prüfen, Rate-Limits testen, GUI nur über abgesicherte Wege öffnen.
+- **Do**: Deployments synchron mit App-Release planen, damit `DATABASE_URL` und Migrationsstand passen.
+- **Don't**: GUI öffentlich freischalten oder Keys per Chat-Tools teilen.
+- **Don't**: LiteLLM-Config direkt in der Cloud Run Konsole ändern; Änderungen gehören ins Repo.
+
+## Zugriffsmuster
+- **Staging**: Zugriff über interne Cloud Run URL + Identity-Aware Proxy optional; QA nutzt eigene API Keys mit begrenzten Limits.
+- **Prod**: Zugriff ausschließlich über HTTPS Load Balancer bzw. IAP. Nur freigegebene Service-Konten oder Benutzergruppen dürfen Requests senden.
+- Modell- und Trace-Zugriff: Nur Observability-Team darf Langfuse Credentials für Prod einsehen; jede Änderung wird protokolliert.
+
+# Schritte
+1. Verwalte Keys gemäß [Security](../security/secrets.md) und verteile neue Werte nur über sichere Kanäle.
+2. Prüfe nach Deployments die LiteLLM Health-Endpunkte, Langfuse-Traces und Log-Dashboards.
+3. Kontrolliere regelmäßig Rate-Limit-Reports und Tenant-Kosten; setze Alerts in Langfuse und Cloud Monitoring.
+4. Dokumentiere jede Konfigurationsänderung in der Admin-GUI im Änderungsprotokoll und verweise auf Langfuse Dashboards.

--- a/docs/observability/langfuse.md
+++ b/docs/observability/langfuse.md
@@ -1,0 +1,48 @@
+# Warum
+Langfuse bündelt Tracing und Kostenkontrolle für Agenten, Ingestion und LiteLLM. Dieses Kapitel zeigt Integration, Datenflüsse und Alarmierung.
+
+# Wie
+## Datenfluss
+```mermaid
+flowchart LR
+    subgraph Worker
+        CW[Celery Worker]
+        AG[LangGraph Agent]
+        IN[Ingestion Pipeline]
+    end
+    subgraph LiteLLM
+        LL[LiteLLM Service]
+    end
+    subgraph Langfuse
+        LF[Langfuse API]
+        DB[(Langfuse Store)]
+    end
+    CW -->|Callbacks| LF
+    AG -->|trace/span| LF
+    IN -->|metrics| LF
+    LL -->|model trace| LF
+    LF --> DB
+```
+
+- Worker binden das Langfuse Python SDK (`langfuse.decorators`, Async-Callbacks) ein. Jeder Task sendet `trace_id`, `tenant_id`, `operation`.
+- LangGraph nutzt das integrierte Observability-Plugin; Nodes melden `span`-Informationen inklusive Input/Output-Metadaten.
+- Ingestion sendet Batch-Statistiken (`batch_size`, `duration`, `cost_estimate`) über Custom Metrics.
+- LiteLLM aktiviert Model-Trace per ENV `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_KEY`; Sampling wird über `LANGFUSE_SAMPLE_RATE` (0.05 Prod, 0.25 Staging) gesteuert.
+
+## Felder und Sampling
+| Feld | Quelle | Beschreibung |
+| --- | --- | --- |
+| `trace_id` | Django Request ID | Verbindet Web, Celery, LangGraph |
+| `tenant_id` | Celery Task Meta | Steuert RLS und Filter |
+| `operation` | Task- oder Node-Name | `ingestion.embed`, `agent.reason`, `liteLLM.call` |
+| `cost_total` | LiteLLM | Aggregierte Kosten pro Request |
+| `error_type` | Worker/LiteLLM | Klassifiziert Fehlertyp (z.B. `rate_limit`) |
+
+- Sampling-Richtwerte: Prod 5%, Staging 25%, Dev 100%. Anpassungen erfolgen über `LANGFUSE_SAMPLE_RATE` und werden im [Security-Guide](../security/secrets.md) dokumentiert.
+- PII-Redaction: Nutze `PII_REDACTION_RULES` (Regex, Hash) im Langfuse Backend und stelle sicher, dass Prompts keine Rohdaten enthalten.
+- Dashboards: Standard-Dashboards `Agent Erfolg`, `Ingestion Durchsatz`, `Kosten pro Tenant`. Alerts lösen bei Fehlerquote >5% oder Kosten >80% Budget aus.
+
+# Schritte
+1. Installiere und initialisiere das Langfuse SDK in Worker und Agenten (siehe [Docker-Konventionen](../docker/conventions.md)); setze ENV `LANGFUSE_*` laut [Security](../security/secrets.md).
+2. Aktiviere LiteLLM Model-Trace (`LANGFUSE_*`, `LANGFUSE_SAMPLE_RATE`) und validiere Traces über die GUI.
+3. Richte Dashboards und Alerts ein, dokumentiere Schwellenwerte im Incident-Runbook und überprüfe sie nach jedem Release.

--- a/docs/operations/scaling.md
+++ b/docs/operations/scaling.md
@@ -1,0 +1,29 @@
+# Warum
+Skalierung stellt sicher, dass Anfragen rechtzeitig beantwortet werden und Ressourcen effizient genutzt werden. Dieses Dokument definiert Regeln für Web-, Worker- und Scheduler-Dienste.
+
+# Wie
+## Web-Service
+- Gunicorn startet mit drei Sync-Workern (`--workers 3`). Setze Cloud Run Concurrency auf höchstens 30, damit nicht mehr als zehn Anfragen pro Worker parallel ankommen.
+- Prod benötigt mindestens zwei Instanzen, damit Releases mit Traffic-Split möglich sind; Staging darf auf null skalieren.
+- CPU 1 in Staging, CPU 2 in Prod. Memory 1 GiB (Staging) bzw. 2 GiB (Prod) deckt Tenant-Wechsel und Caching.
+- Beobachte `requests_per_second` und `latency` aus Cloud Monitoring. Bei dauerhaft >70% CPU erhöhe Worker-Anzahl im Container oder Concurrency in kleinen Schritten.
+
+## Worker-Service
+- Celery Worker laufen mit Concurrency = CPU-Kerne. Für Cloud Run Services bedeutet das: CPU 1 → 1 gleichzeitige Task. Passe `--concurrency` explizit an, wenn Tasks I/O-bound sind.
+- Skalierung richtet sich nach Queue-Tiefe (`redis` Keys). Cloud Monitoring Alarm bei >100 offenen Tasks löst manuelles Hochskalieren (maxInstances) aus.
+- Tasks müssen idempotent sein (siehe `ai_core` Rate-Limit Tests), damit Wiederholungen keine doppelten Effekte auslösen.
+- Timeout-Grenzen: Standard 10 Minuten; Tasks, die länger laufen, sollten in dedizierte Worker ausgelagert werden.
+- **Ingestion-Queue**: Concurrency pro Instanz maximal 2; `BATCH_SIZE` 128, `CHUNK_SIZE` 800 Token, `CHUNK_OVERLAP` 80. Bei Rate-Limit-Fehlern Exponential-Backoff mit Start 30 Sekunden, Maximum 5 Minuten.
+- **Agenten-Queue**: Concurrency = 1 pro Instanz für deterministisches State-Handling. LangGraph-Knoten müssen idempotent sein und Timeouts auf 120 Sekunden setzen; darüber hinaus abgebrochene Tasks loggen.
+- Kostengrenzen: Staging < 5 EUR/Tag, Prod < 30 EUR/Stunde für Embeddings. Überwachung via Langfuse Usage-Dashboard, Alerts im [Langfuse Guide](../observability/langfuse.md).
+
+## Beat vs Scheduler
+- Aktivere Beat nur, wenn periodische Jobs existieren. Eine einzelne Instanz reicht; hohe Verfügbarkeit wird durch schnelle Restart-Zeiten erreicht.
+- Alternative Scheduler (Cloud Scheduler -> Pub/Sub -> Worker) kommen zum Einsatz, wenn Jobs selten sind oder exakte Cron-Zeiten erfordern.
+- Beat schreibt in Redis; stelle sicher, dass Beat und Worker dieselbe Redis-Instanz nutzen, sonst laufen Tasks doppelt.
+
+# Schritte
+1. Prüfe Metriken (CPU, Latenz, Queue-Länge) vor jeder Skalierungsentscheidung und dokumentiere Baseline-Werte.
+2. Passe Concurrency, min/max Instances und ggf. Worker-Flags an und deploye neue Revisionen über die [Pipeline](../cicd/pipeline.md).
+3. Überwache Effekte mindestens einen Tag lang; setze Alerts bei erwarteten Grenzwerten.
+4. Aktualisiere das [Incident-Runbook](../runbooks/incidents.md) und die [QA-Checklisten](../qa/checklists.md), falls neue Schwellenwerte gelten.

--- a/docs/qa/checklists.md
+++ b/docs/qa/checklists.md
@@ -1,0 +1,26 @@
+# Warum
+Qualitätssicherung verhindert Überraschungen nach Deployments. Diese Checklisten beschreiben, was vor und nach jedem Rollout geprüft wird.
+
+# Wie
+## Vor dem Deploy
+- Build-Artefakte sind vorhanden (Semver+SHA Tag in Artifact Registry) und wurden signiert, falls erforderlich.
+- Migrationen: Trockenlauf per Cloud Run Job in Staging durchgeführt, Ergebnis dokumentiert ([Migrations-Runbook](../runbooks/migrations.md)).
+- Konnektivität: Smoke-Verbindungen zu Cloud SQL und Memorystore geprüft; LiteLLM `/health/liveliness` liefert `alive`.
+- Monitoring: Alerts für CPU, Fehlerquote und Queue-Länge aktiv und ohne offene Warnungen.
+
+## Nach dem Deploy
+- `/` und `/admin/login/` antworten mit HTTP 200, LiteLLM `/health` meldet keine Fehlerzählung.
+- Cloud Logging zeigt keine neuen Fehlerstapel; Error Reporting frei von kritischen Einträgen.
+- Metriken (Latenz, Fehler, Queue-Tiefe) bleiben im grünen Bereich der letzten 24 Stunden.
+- Backups aktiv: Cloud SQL Backupstatus `SUCCESS`, PITR-Zeitfenster vorhanden, Memorystore Snapshot aktualisiert.
+
+## Abbruchkriterien & Rollback
+- Smoke-Test fehlschlägt oder Fehlerquote >5%: sofort Traffic auf vorherige Revision (siehe [Pipeline](../cicd/pipeline.md)).
+- Migration schlägt fehl: kein weiterer Deploy, Datenbankzustand sichern und [Runbook](../runbooks/migrations.md) folgen.
+- LiteLLM oder Worker nicht verfügbar: Incidents gemäß [Runbook](../runbooks/incidents.md) starten, Release pausieren.
+
+# Schritte
+1. Führe alle Vorab-Checks aus und dokumentiere Ergebnisse im Release-Template.
+2. Nach Deploy: Arbeite die Nach-Deploy-Liste ab und dokumentiere Zeitpunkte.
+3. Entscheide anhand der Abbruchkriterien, ob Traffic erhöht, eingefroren oder zurückgerollt wird.
+4. Hinterlege alle Ergebnisse im Projekt-Wiki, damit Lessons Learned nachvollziehbar sind.

--- a/docs/rag/ingestion.md
+++ b/docs/rag/ingestion.md
@@ -1,0 +1,44 @@
+# Warum
+Die Ingestion-Pipeline speist Inhalte in den RAG-Store ein. Dieses Dokument beschreibt den Ablauf, Parametergrenzen und Fehlertoleranz, damit Junior-Entwickler verlässlich Embeddings erzeugen.
+
+# Wie
+## Pipeline
+```mermaid
+flowchart TD
+    subgraph Input
+        L[Loader]
+    end
+    subgraph Processing
+        SP[Splitter]
+        CH[Chunker]
+        EM[Embedder]
+        UP[Upsert]
+    end
+    L --> SP --> CH --> EM --> UP
+    UP --> VS[(pgvector)]
+```
+
+- Loader ziehen Daten (z.B. S3, CRM) und liefern strukturierte Records.
+- Splitter normalisiert Formate (Markdown → Plaintext), Chunker erzeugt überlappende Stücke.
+- Embedder ruft LiteLLM mit `EMBEDDINGS_MODEL`/`EMBEDDINGS_API_BASE` auf und schreibt Ergebnisse in `pgvector`.
+- Upsert nutzt Hashes, um Duplikate zu überspringen und `documents.deleted_at` zu respektieren.
+
+## Parameter
+| Parameter | Default | Grenze | Beschreibung |
+| --- | --- | --- | --- |
+| `CHUNK_SIZE` | 800 Tokens | 1.200 | Größe eines Textchunks; größer erhöht Kontext, aber auch Embedding-Kosten |
+| `CHUNK_OVERLAP` | 80 Tokens | 200 | Überlappung zwischen Chunks; reduziert Informationsverlust |
+| `BATCH_SIZE` | 128 Chunks | 256 | Anzahl Embeddings pro API-Aufruf; beeinflusst Latenz und Rate-Limit |
+| `MAX_TOKENS` | 3.000 | 4.096 | Sicherheitslimit für Model-Requests |
+| `RETRY_BACKOFF` | 30s → x2 | 5m Max | Exponentielles Backoff bei Fehlern |
+
+## Fehlertoleranz und Deduplizierung
+- Jeder Datensatz erhält einen SHA-256-Hash aus `(tenant_id, source, content)`. Der Hash wird vor Upsert geprüft; Matches werden übersprungen.
+- Bei Rate-Limits markiert der Worker den Batch als „retry“ und wartet laut Backoff. Nach fünf Fehlversuchen landet der Eintrag in einer Dead-Letter-Queue zur manuellen Prüfung.
+- Netzwerkfehler lösen Wiederholungen aus; nach Erfolg werden Dead-Letter-Einträge automatisch erneut angestoßen.
+- Fehler werden in Langfuse als Span `ingestion.error` mit Metadaten protokolliert.
+
+# Schritte
+1. Konfiguriere Loader, Splitter und Embedding-Parameter laut Tabelle und verknüpfe sie mit der Queue `ingestion` (siehe [Docker-Konventionen](../docker/conventions.md)).
+2. Starte Testbatches in Staging über die Pipeline-Stufe „Ingestion-Smoke“ und beobachte Langfuse- sowie Cloud-SQL-Statistiken.
+3. Übernimm dieselben Einstellungen nach Prod, dokumentiere Anpassungen (z.B. `BATCH_SIZE`) und aktiviere Alerts im [Langfuse Guide](../observability/langfuse.md).

--- a/docs/rag/overview.md
+++ b/docs/rag/overview.md
@@ -1,0 +1,40 @@
+# Warum
+Retrieval-Augmented Generation (RAG) verbindet strukturierte Tenant-Daten mit LLM-Antworten. Dieses Kapitel erklärt das Zielbild und zeigt, wie Ingestion, Speicherung und Agenten zusammenspielen.
+
+# Wie
+## Architektur
+```mermaid
+flowchart LR
+    L[Loader] --> S[Splitter]
+    S --> C[Chunking]
+    C --> E[Embedding]
+    E --> V[Vector Store (pgvector)]
+    V --> R[Retriever]
+    R --> RR[Re-Ranking (optional)]
+    RR --> A[Agent (LangGraph)]
+    A --> LLM[LiteLLM]
+    LLM --> A
+    A --> Out[Antwort]
+```
+
+- Loader ziehen Quelldaten aus Dokumenten, APIs oder Datenbanken.
+- Splitter & Chunker erzeugen überlappende Textblöcke; Parameter stehen in [RAG-Ingestion](ingestion.md).
+- Embeddings landen in `pgvector` (siehe [Schema](schema.sql)), inklusive Metadaten pro Tenant.
+- Retriever filtert per `tenant_id`, optional Re-Ranking (z.B. Cross-Encoder) bevor Agenten reagieren.
+
+## Mandantenfähigkeit
+| Modell | Beschreibung | Einsatz |
+| --- | --- | --- |
+| Schema pro Mandant | Eigenes Schema `tenant_<slug>` für Tabellen `documents`, `chunks`, `embeddings` | Hohe Isolation, Prod empfohlen wenn <50 Tenants |
+| Gemeinsames Schema mit `tenant_id` | Eine Tabelle pro Entität, `tenant_id` (UUID) erzwingt RLS-Regeln | Skalierbar für viele Tenants; Prod mit RLS, Staging identisch |
+| Hybrid | Kern-Tabellen pro Schema, Embeddings global mit `tenant_id` | Wenn LiteLLM und Django gemeinsame Daten teilen müssen |
+
+## Löschkonzept
+- Dokumente erhalten Hashes (siehe [Schema](schema.sql)) und `metadata` mit Herkunft.
+- Löschläufe laufen als Ingestion-Task mit Modus „delete“ und markieren `documents.deleted_at` (Soft Delete). Hard Delete optional über `DELETE ... WHERE tenant_id = ?`.
+- Nach dem Löschen wird `VACUUM`/`ANALYZE` ausgeführt (Staging monatlich, Prod wöchentlich). Index-Rebuild via [Migrations-Runbook](../runbooks/migrations.md).
+
+# Schritte
+1. Plane Tenant-Strategie laut Tabelle und dokumentiere sie im Architektur-Overview.
+2. Implementiere Ingestion-Pipelines mit Parametern aus [RAG-Ingestion](ingestion.md) und schreibe Embeddings in das Schema aus [schema.sql](schema.sql).
+3. Aktiviere Observability für Agenten und Retriever über [Langfuse](../observability/langfuse.md), bevor Nutzer Zugriff erhalten.

--- a/docs/rag/schema.sql
+++ b/docs/rag/schema.sql
@@ -1,0 +1,66 @@
+-- Warum: Dieses Skript definiert das pgvector-Zielbild für RAG. Es ist idempotent und kann in der Pipeline-Stufe „Vector-Schema-Migrations“ ausgeführt werden.
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS rag;
+SET search_path TO rag, public;
+
+CREATE TABLE IF NOT EXISTS documents (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL,
+    source TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    hash TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    deleted_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS documents_tenant_hash_idx
+    ON documents (tenant_id, hash);
+
+CREATE INDEX IF NOT EXISTS documents_metadata_gin_idx
+    ON documents USING GIN (metadata);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    id UUID PRIMARY KEY,
+    document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    ord INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    tokens INTEGER NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS chunks_document_ord_idx
+    ON chunks (document_id, ord);
+
+CREATE INDEX IF NOT EXISTS chunks_metadata_gin_idx
+    ON chunks USING GIN (metadata);
+
+CREATE TABLE IF NOT EXISTS embeddings (
+    id UUID PRIMARY KEY,
+    chunk_id UUID NOT NULL REFERENCES chunks(id) ON DELETE CASCADE,
+    embedding vector(EMBEDDINGS_DIM) NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS embeddings_chunk_idx
+    ON embeddings (chunk_id);
+
+-- Verwende IVFFLAT für große Datenmengen, HNSW für geringe Latenz. Beide Indizes sind optional; erst erzeugen, wenn genug Daten vorhanden sind.
+CREATE INDEX IF NOT EXISTS embeddings_embedding_ivfflat_idx
+    ON embeddings USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 100);
+
+CREATE INDEX IF NOT EXISTS embeddings_embedding_hnsw_idx
+    ON embeddings USING hnsw (embedding vector_cosine_ops)
+    WITH (ef_construction = 64, ef_search = 64);
+
+COMMIT;
+
+ANALYZE rag.documents;
+ANALYZE rag.chunks;
+ANALYZE rag.embeddings;
+
+-- Hinweise für Migrationen:
+-- * Führe Index-Updates mit `CREATE INDEX CONCURRENTLY` in Prod aus, falls Downtime vermieden werden muss.
+-- * Nach großen Löschläufen: `VACUUM (VERBOSE, ANALYZE) rag.embeddings;`
+-- * Bei Schemaänderungen stets `IF NOT EXISTS`/`ADD COLUMN IF NOT EXISTS` nutzen, damit Wiederholungen idempotent bleiben.

--- a/docs/runbooks/incidents.md
+++ b/docs/runbooks/incidents.md
@@ -1,0 +1,20 @@
+# Warum
+Incidents passieren. Dieses Runbook liefert schnelle Orientierung für die häufigsten Störungen und verhindert Ad-hoc-Entscheidungen.
+
+# Wie
+## Szenarien
+| Szenario | Messpunkte | Typische Ursachen | Erstmaßnahmen | Eskalation |
+| --- | --- | --- | --- | --- |
+| Cloud SQL nicht erreichbar | Cloud Monitoring Uptime, `django.db.utils` Fehler in Logs, Pipeline-Alerts | Wartung, Verbindungslimit erreicht, VPC-Problem | Traffic einfrieren (kein weiteres Rollout), Statusseite aktualisieren, Verbindungslimits prüfen | Datenbank-Team / GCP Support, falls länger als 15 Minuten |
+| Memorystore/Redis down | Celery `ConnectionError`, Queue-Stau, LiteLLM Timeout | Memorystore Wartung, VPC Connector ausgefallen, Auth-Token abgelaufen | Worker pausieren, Connector-Status prüfen, Failover-Redis aktivieren falls vorhanden | Platform-Team, ggf. Redis-Snapshot wiederherstellen |
+| HTTP 5xx Spike | Cloud Run Error Rate > 5%, Sentry/Logging Anstieg, Load Balancer Fehler | Regression in neuem Release, erschöpfte DB-Verbindungen, externe API langsam | Sofortiger Traffic-Rollback laut [Pipeline](../cicd/pipeline.md), letzte stabile Revision aktivieren, Ressourcen-Auslastung prüfen | Produkt & Engineering Management, ggf. Feature-Flag deaktivieren |
+| LiteLLM nicht erreichbar | `/health/liveliness` schlägt fehl, Admin-GUI 503, AI Requests timeouts | Master Key falsch, Cloud SQL Schema gesperrt, Rate-Limit überschritten | Schlüssel prüfen ([Security](../security/secrets.md)), Cloud Run Logs analysieren, Dienst neu starten | AI Platform Owner, ggf. API-Provider kontaktieren |
+| Retrieval liefert 0 Treffer | Langfuse Trace „retrieval_results=0“, Django Response `fallback=true`, Queue-Metriken stabil | Fehlende Vektor-Daten, falscher `tenant_id`, Filter in LangChain falsch | Prüfe `documents`/`chunks` für Tenant, starte Ingestion-Mini-Batch laut [RAG-Ingestion](../rag/ingestion.md) | Data Ops für Content-Gaps, ggf. Produktteam |
+| Embedding-Rate-Limit | LiteLLM Logs `429`, Langfuse Alert „embedding_rate_limit“, Queue Stau in `ingestion` | Modellprovider-Limit erreicht, fehlendes Backoff, parallele Batches zu hoch | Reduziere `BATCH_SIZE`, setze Retry Delay (siehe [Scaling](../operations/scaling.md)), informiere Stakeholder über Verzögerung | Provider-Support bei anhaltender Limitierung |
+| Vektorindex korrupt/langsam | Query-Latenz > 1s, PG Logs `ERROR: index corrupted`, Monitoring Alarme | Abgebrochene `REINDEX`, veraltete Statistiken, Storage-Bottleneck | Leite Verkehr auf Fallback (`fallback=true`), führe `REINDEX CONCURRENTLY`/`ANALYZE` in Staging-Test durch, bevor Prod wieder Traffic erhält | Datenbank-Team, ggf. PITR-Restore |
+
+# Schritte
+1. Identifiziere das Szenario anhand der Messpunkte in der Tabelle.
+2. Setze die aufgeführten Erstmaßnahmen um und dokumentiere jede Aktion im Incident-Channel.
+3. Entscheide nach fünf Minuten, ob Eskalation nötig ist, und informiere die angegebenen Teams.
+4. Nach Stabilisierung: Erfasse Post-Mortem-Notizen und aktualisiere Checklisten in [QA](../qa/checklists.md), falls Anpassungen nötig sind.

--- a/docs/runbooks/migrations.md
+++ b/docs/runbooks/migrations.md
@@ -1,0 +1,38 @@
+# Warum
+Schemaänderungen sind kritisch für Tenant-Daten. Dieses Runbook stellt sicher, dass Migrationen reproduzierbar und ohne Downtime laufen.
+
+# Wie
+## Vorbereitung
+- Prüfe das Migration-Diff im Repo und stelle sicher, dass `manage.py migrate_schemas` idempotent ist (kein Datenverlust bei erneutem Lauf).
+- Kontrolliere, dass aktuelle Backups verfügbar sind: in Staging ein manuelles Snapshot, in Prod PITR + letztes tägliches Backup.
+- Verifiziere, dass keine Web/Worker-Container automatische Migrationen ausführen ([Docker-Konventionen](../docker/conventions.md)).
+
+## Durchführung
+- Verwende ausschließlich den Cloud Run Job `noesis2-migrate`. Er nutzt das Web-Image und führt `python manage.py migrate_schemas --noinput` aus.
+- Job-Konfiguration: Timeout 600 s (Staging) bzw. 900 s (Prod), `maxRetries` 0 (Staging) bzw. 1 (Prod).
+- Stelle sicher, dass `DJANGO_SETTINGS_MODULE=noesis2.settings.production` gesetzt ist und dass Cloud SQL/Redis-Verbindungen vorhanden sind.
+- Vector-spezifische DDL (Tabellen, Indizes) laufen separat in der Pipeline-Stufe „Vector-Schema-Migrations“. Skript liegt in [`docs/rag/schema.sql`](../rag/schema.sql) und wird per `psql` oder Cloud SQL Proxy angewendet.
+
+## Validierung
+- Überwache Job-Logs in Cloud Logging: Erfolgsnachricht `Job completed successfully` und Exit-Code 0 bestätigen den Abschluss.
+- Führe direkt im Anschluss Readiness-Checks aus: HTTP 200 auf `/` und `/tenant-demo/`, Celery-Queue leer (`redis` Keys stabil), LiteLLM `/health` grün.
+- Dokumentiere Schema-Versionen (`django_migrations` Tabelle) und vergleiche sie mit erwarteten Migrationen.
+
+## Rollback
+- Bricht der Job, bleibt Schema unverändert. Analysiere Logs, fixiere Migration und wiederhole den Job.
+- Bei teilweisen Änderungen nutze Staging-Backup bzw. Prod-PITR, um in ein konsistentes Zeitfenster vor dem Lauf zurückzuspringen.
+- Nach einem Rollback wird der Job mit derselben Image-Version erneut gestartet, nachdem das Problem behoben wurde.
+
+## pgvector-Schema
+- Tabellenlayout laut [`docs/rag/schema.sql`](../rag/schema.sql): `documents`, `chunks`, `embeddings` mit Foreign Keys und `metadata` als `jsonb`.
+- Indizes: Primärschlüssel je Tabelle, GIN auf `metadata`, Vektorindex IVFFLAT oder HNSW auf `embeddings.embedding` (`cosine`).
+- DDL ist idempotent: `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS` und `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`.
+- Führe `ANALYZE` nach großen Uploads aus und plane `REINDEX CONCURRENTLY` bei Index-Wechseln.
+- Rollback bei fehlerhaften Index-Updates: `DROP INDEX CONCURRENTLY`, danach vorherige Definition erneut ausführen; Daten bleiben unverändert.
+
+# Schritte
+1. Sichere, dass Backups aktuell sind und Approval für Migration vorliegt.
+2. Trigger den Cloud Run Migrate-Job (Staging automatisch via [Pipeline](../cicd/pipeline.md), Prod nach Approval manuell/CI).
+3. Überwache Logs und Validierungschecks laut Abschnitt „Validierung“.
+4. Melde den Status im Release-Channel und dokumentiere Schema-Versionen.
+5. Bei Fehlern: Stoppe weiteren Traffic-Shift, führe Rollback laut Abschnitt „Rollback“ durch und wiederhole Schritt 2 nach Fix.

--- a/docs/security/secrets.md
+++ b/docs/security/secrets.md
@@ -1,0 +1,44 @@
+# Warum
+Sichere Geheimnisse verhindern Datenverlust und Ausfälle. Dieses Dokument definiert die ENV-Verträge und beschreibt, wie sie in den Umgebungen verwaltet werden.
+
+# Wie
+## ENV-Verträge
+| Variable | Beschreibung | Dev | Staging | Prod |
+| --- | --- | --- | --- | --- |
+| `DATABASE_URL` | Postgres-Verbindungsstring, von Django und LiteLLM genutzt | `.env` lokal, häufig identisch mit `postgres://user:pass@db:5432/noesis2` | Aus CI gesetzt (`--set-env-vars`), zeigt auf Cloud SQL Public IP | Secret Manager, Version pro Rotation; verweist auf Cloud SQL Private IP |
+| `REDIS_URL` | Redis-Broker für Celery und Caching | `.env` → `redis://redis:6379/0` | CI setzt Wert auf Memorystore Instanz (`rediss://`) | Secret Manager → Memorystore (TLS, Auth-Token) |
+| `DJANGO_SETTINGS_MODULE` | Django Settings Modul | Lokal `noesis2.settings.development` | CI setzt `noesis2.settings.production` | Secret Manager oder Runtime Config → `noesis2.settings.production` |
+| `SECRET_KEY` | Django Crypto Key | `.env` zufällig generiert | CI Secret (per GitHub Secret) | Secret Manager Version, Rotation 90 Tage |
+| `ALLOWED_HOSTS` | Kommagetrennte Domains | `.env` (`localhost`) | CI-Variable mit Staging-Domain | Secret Manager, Prod-Domains + LB |
+| `LITELLM_URL` | Basis-URL für LiteLLM Proxy (Alias für `LITELLM_BASE_URL` im Code) | `.env` zeigt auf `http://litellm:4000` | CI setzt auf interne Cloud Run URL, nur auth Nutzer | Secret Manager liefert interne URL; optional zweiter Eintrag für IAP |
+| `EMBEDDINGS_MODEL` | Modellname für Embedding-Erstellung | `.env` frei wählbar (z.B. `text-embedding-3-small`) | CI-Variable pro Deploy; Versionswechsel nur nach Smoke-Test | Secret Manager Version, dokumentiert in Release-Notes |
+| `EMBEDDINGS_DIM` | Dimensionszahl der Vektoren (Integer) | `.env` konsistent zur lokalen Modellwahl | CI setzt Wert passend zum Modell | Secret Manager, gemeinsam mit Modellwechsel aktualisieren |
+| `EMBEDDINGS_API_BASE` | LiteLLM-Endpunkt für Embedding-Requests | `.env` → `http://litellm:4000/v1` | CI `--set-env-vars` nutzt Cloud Run interne URL | Secret Manager verweist auf HTTPS Load Balancer oder interne URL |
+| `LANGFUSE_HOST` | Basis-URL für Langfuse Workspace | Optional lokal (`http://localhost:3000`) | CI-Variable; SaaS oder Self-Host URL | Secret Manager Wert, kein direkter Konsolenzugriff |
+| `LANGFUSE_KEY` | Server-SDK-Key für Worker und Agenten | `.env` Dummy | CI-Secret | Secret Manager Version, Rotation 60 Tage |
+| `LANGFUSE_PUBLIC_KEY` | Browser-Key für LiteLLM GUI Trace | Nicht gesetzt | CI-Secret | Secret Manager Version |
+| `LANGFUSE_SECRET_KEY` | Privater Key für LiteLLM Trace Upload | Nicht gesetzt | CI-Secret | Secret Manager Version |
+
+Weitere Schlüssel wie `GEMINI_API_KEY`, `LITELLM_MASTER_KEY`, `AI_CORE_RATE_LIMIT_QUOTA` folgen denselben Quellen und werden nicht im Image gespeichert.
+
+## PII-Redaction und Log-Scopes
+- Web- und Worker-Services setzen `LOG_SCOPE=tenant` und entfernen personenbezogene Daten vor Log-Schreibungen. Maskierung erfolgt über die Middleware aus `ai_core.pii`.
+- Langfuse nutzt `PII_REDACTION_RULES` (Regex oder Hashing) zur Entfernung von Namen, E-Mail-Adressen und Vertragsnummern; Regeln werden in Secret Manager abgelegt.
+- LiteLLM zeichnet Prompts nur anonymisiert auf (`store_prompt=false` für sensible Modelle) und sendet Trace-Metadaten an Langfuse.
+- Zugriff auf Logs: Entwickler lesen Staging-Logs, Prod nur Observability-Team mit Audit-Log.
+
+## Rotation
+- Rotationen erfolgen mindestens alle 90 Tage bzw. vor Freigabe sensibler Features.
+- Dev: Entwickler erstellen neue `.env`-Werte manuell; keine Weitergabe via Git.
+- Staging: GitHub Secret aktualisieren, Pipeline triggert Redeploy, alte Values werden invalidiert.
+- Prod: Neue Secret-Version in Secret Manager anlegen, Revision deployen, alte Version nach Validierung deaktivieren.
+- LiteLLM Keys rotieren paarweise (Master + API). Informiere alle Dienste, die `LITELLM_URL` nutzen, und teste `GET /health` danach.
+
+## Kein Secret im Image
+Das [`Dockerfile`](../../Dockerfile) kopiert nur Quellcode und generierte Assets. Secrets gelangen ausschließlich zur Laufzeit über Umgebungsvariablen. Prüfe Pull Requests darauf, dass keine Credentials eingecheckt werden.
+
+# Schritte
+1. Definiere neue Secrets immer zuerst in diesem Dokument und stimme sie mit dem Team ab.
+2. Lege die Werte gemäß Tabelle in der richtigen Quelle (Dev `.env`, CI Secret, Secret Manager) ab.
+3. Redeploye betroffene Dienste und prüfe Health-Checks sowie Logs.
+4. Entferne alte Secret-Versionen nach erfolgreichem Rollout und dokumentiere die Rotation.


### PR DESCRIPTION
## Summary
- integrate RAG components into the architecture overview, environment matrix, and cloud run guides with pgvector and ingestion specifics
- add LangChain/LangGraph, ingestion queues, and Langfuse observability rules across docker, security, pipeline, operations, and runbooks
- introduce dedicated RAG, agent, and Langfuse references covering schema DDL, ingestion parameters, tracing flows, and guardrails

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c98f52bed0832b8b370692b1f14d62