### PR TITLE
refactor: consolidate database and redis configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,16 +7,11 @@ DJANGO_SETTINGS_MODULE=noesis2.settings.development
 # Comma-separated hostnames that may serve the app
 ALLOWED_HOSTS=example.com
 
-# PostgreSQL database settings
-DB_NAME=noesis2_db
-DB_USER=user
-DB_PASSWORD=meinpasswort
-DB_HOST=db
-DB_PORT=5432
-
-# Celery (Redis) broker and result backend
-CELERY_BROKER_URL=redis://redis:6379/0
-CELERY_RESULT_BACKEND=redis://redis:6379/0
+# Core infrastructure
+# NOTE: URL-encode special characters in passwords (e.g. # -> %23, $ -> %24)
+DATABASE_URL=postgresql://noesis2:noesis2@db:5432/noesis2
+REDIS_URL=redis://redis:6379/0
+RAG_ENABLED=false
 
 # Organization settings
 # Currently no organization-specific environment variables are required
@@ -33,11 +28,7 @@ GEMINI_API_KEY=your-gemini-api-key
 GOOGLE_API_KEY=your-gemini-api-key
 LITELLM_SALT_KEY=dev-salt-key
 # LiteLLM Proxy DB (Admin UI, keys, spend logs)
-# Prefer Postgres for dev/prod; LiteLLM expects DATABASE_URL
-# NOTE: URL-encode special characters in password (e.g. # -> %23, $ -> %24)
-# Example: DATABASE_URL=postgresql://user:%23pass%24@db:5432/litellm
-DATABASE_URL=
-REDIS_URL=redis://redis:6379/0
+# Uses DATABASE_URL defined above
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
 AI_CORE_RATE_LIMIT_QUOTA=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
       - name: Verify database secrets (length check only)
         shell: bash
         run: |
-          echo "Verifying DB secrets..."
-          [ -n "${{ secrets.DB_NAME }}" ] || { echo "::error::DB_NAME is NOT set!"; exit 1; }
-          [ -n "${{ secrets.DB_USER }}" ] || { echo "::error::DB_USER is NOT set!"; exit 1; }
-          [ -n "${{ secrets.DB_PASSWORD }}" ] || { echo "::error::DB_PASSWORD is NOT set!"; exit 1; }
-          echo "DB secrets presence verified."
+          echo "Verifying DATABASE_URL..."
+          [ -n "${{ secrets.DATABASE_URL }}" ] || { echo "::error::DATABASE_URL is NOT set!"; exit 1; }
+          echo "Verifying REDIS_URL..."
+          [ -n "${{ secrets.REDIS_URL }}" ] || { echo "::error::REDIS_URL is NOT set!"; exit 1; }
+          echo "Core infrastructure secrets verified."
 
       - name: Verify Django SECRET_KEY (presence only)
         shell: bash
@@ -83,6 +83,20 @@ jobs:
             core.info(`head.ref: ${context.payload?.pull_request?.head?.ref || process.env.GITHUB_REF_NAME}`)
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install ripgrep
+        run: sudo apt-get update -y && sudo apt-get install -y ripgrep
+
+      - name: Guard against legacy DB/Celery env lookups
+        run: |
+          if rg -n 'os\.getenv\("(?:DB_|CELERY_)' -g'*.py' .; then
+            echo "::error::Found legacy os.getenv DB_/CELERY_ usage.";
+            exit 1;
+          fi
+          if rg -n 'env\.(?:str|int|bool|list|float)?\("(?:DB_|CELERY_)' -g'*.py' .; then
+            echo "::error::Found legacy env(\"DB_/CELERY_\") usage.";
+            exit 1;
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -132,11 +146,8 @@ jobs:
     env:
       SECRET_KEY: ci-secret
       DJANGO_SETTINGS_MODULE: noesis2.settings.development
-      DB_NAME: noesis2_ci
-      DB_USER: postgres
-      DB_PASSWORD: postgres
-      DB_HOST: localhost
-      DB_PORT: 5432
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/noesis2_ci
+      REDIS_URL: redis://localhost:6379/0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -242,11 +253,8 @@ jobs:
           GCP_REGION: ${{ secrets.GCP_REGION }}
           CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          DB_NAME: ${{ secrets.DB_NAME }}
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          CELERY_BROKER_URL: ${{ secrets.CELERY_BROKER_URL }}
-          CELERY_RESULT_BACKEND: ${{ secrets.CELERY_RESULT_BACKEND }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          REDIS_URL: ${{ secrets.REDIS_URL }}
         run: |
           gcloud run jobs deploy noesis2-migrate \
             --image "$IMAGE" \
@@ -255,7 +263,7 @@ jobs:
             --max-retries=0 \
             --task-timeout=600s \
             --set-cloudsql-instances "$CLOUD_SQL_CONNECTION_NAME" \
-            --set-env-vars DJANGO_SETTINGS_MODULE=noesis2.settings.production,GOOGLE_CLOUD_PROJECT="$GCP_PROJECT_ID",CLOUD_SQL_CONNECTION_NAME="$CLOUD_SQL_CONNECTION_NAME",SECRET_KEY="$SECRET_KEY",DB_NAME="$DB_NAME",DB_USER="$DB_USER",DB_PASSWORD="$DB_PASSWORD",CELERY_BROKER_URL="$CELERY_BROKER_URL",CELERY_RESULT_BACKEND="$CELERY_RESULT_BACKEND" \
+            --set-env-vars DJANGO_SETTINGS_MODULE=noesis2.settings.production,GOOGLE_CLOUD_PROJECT="$GCP_PROJECT_ID",CLOUD_SQL_CONNECTION_NAME="$CLOUD_SQL_CONNECTION_NAME",SECRET_KEY="$SECRET_KEY",DATABASE_URL="$DATABASE_URL",REDIS_URL="$REDIS_URL" \
             --command python \
             --args manage.py,migrate_schemas,--noinput
 
@@ -285,11 +293,8 @@ jobs:
           GCP_REGION: ${{ secrets.GCP_REGION }}
           CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          DB_NAME: ${{ secrets.DB_NAME }}
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          CELERY_BROKER_URL: ${{ secrets.CELERY_BROKER_URL }}
-          CELERY_RESULT_BACKEND: ${{ secrets.CELERY_RESULT_BACKEND }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          REDIS_URL: ${{ secrets.REDIS_URL }}
           STAGING_HOST: ${{ secrets.STAGING_HOST }}
         run: |
           gcloud run jobs deploy noesis2-seed \
@@ -299,7 +304,7 @@ jobs:
             --max-retries=0 \
             --task-timeout=600s \
             --set-cloudsql-instances "$CLOUD_SQL_CONNECTION_NAME" \
-            --set-env-vars DJANGO_SETTINGS_MODULE=noesis2.settings.production,GOOGLE_CLOUD_PROJECT="$GCP_PROJECT_ID",CLOUD_SQL_CONNECTION_NAME="$CLOUD_SQL_CONNECTION_NAME",SECRET_KEY="$SECRET_KEY",DB_NAME="$DB_NAME",DB_USER="$DB_USER",DB_PASSWORD="$DB_PASSWORD",CELERY_BROKER_URL="$CELERY_BROKER_URL",CELERY_RESULT_BACKEND="$CELERY_RESULT_BACKEND" \
+            --set-env-vars DJANGO_SETTINGS_MODULE=noesis2.settings.production,GOOGLE_CLOUD_PROJECT="$GCP_PROJECT_ID",CLOUD_SQL_CONNECTION_NAME="$CLOUD_SQL_CONNECTION_NAME",SECRET_KEY="$SECRET_KEY",DATABASE_URL="$DATABASE_URL",REDIS_URL="$REDIS_URL" \
             --command bash \
             --args -lc,"python manage.py bootstrap_public_tenant --domain localhost && python manage.py create_demo_data && python manage.py add_domain --schema=demo --domain=\"$STAGING_HOST\" --primary --force-reassign"
 
@@ -345,8 +350,5 @@ jobs:
             GOOGLE_CLOUD_PROJECT=${{ secrets.GCP_PROJECT_ID }}
             CLOUD_SQL_CONNECTION_NAME=${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
             SECRET_KEY=${{ secrets.SECRET_KEY }}
-            DB_NAME=${{ secrets.DB_NAME }}
-            DB_USER=${{ secrets.DB_USER }}
-            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-            CELERY_BROKER_URL=${{ secrets.CELERY_BROKER_URL }}
-            CELERY_RESULT_BACKEND=${{ secrets.CELERY_RESULT_BACKEND }}
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+            REDIS_URL=${{ secrets.REDIS_URL }}

--- a/README.md
+++ b/README.md
@@ -119,18 +119,16 @@ Benötigte Variablen (siehe `.env.example`):
 
 - SECRET_KEY: geheimer Schlüssel für Django
 - DEBUG: `true`/`false`
-- DB_NAME: Name der PostgreSQL-Datenbank
-- DB_USER: DB-Benutzername
-- DB_PASSWORD: DB-Passwort (Sonderzeichen werden unterstützt)
-- DB_HOST: Host, z. B. `localhost`
-- DB_PORT: Port, i. d. R. `5432`
+- DATABASE_URL: Verbindungs-URL zur PostgreSQL-Datenbank
+- REDIS_URL: Redis-Endpoint (z. B. für Celery)
+- RAG_ENABLED: `true`/`false` zur Aktivierung des Retrieval-Augmented-Generation-Workflows
 
 AI Core:
 - LITELLM_BASE_URL: Basis-URL des LiteLLM-Proxys
 - LITELLM_API_KEY: API-Key für den Proxy
 - LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY: Schlüssel für Langfuse-Tracing
 
-Die Settings lesen `.env` via `django-environ`. Die Datenbank wird über eine zusammengesetzte `DATABASE_URL` konfiguriert (aus den Variablen oben), inkl. URL-Encoding für Sonderzeichen.
+Die Settings lesen `.env` via `django-environ`. `DATABASE_URL` muss eine vollständige URL enthalten (inkl. URL-Encoding für Sonderzeichen); `REDIS_URL` wird sowohl für Celery als auch für Redis-basierte Integrationen verwendet.
 
 ## Settings-Profile
 Das alte `noesis2/settings.py` wurde entfernt; verwende ausschließlich das modulare Paket `noesis2/settings/`.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,16 +4,16 @@ services:
     container_name: noesis2_db
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: noesis2
+      POSTGRES_USER: noesis2
+      POSTGRES_PASSWORD: noesis2
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./config/postgres-init:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME} -h 127.0.0.1"]
+      test: ["CMD-SHELL", "pg_isready -U noesis2 -d noesis2 -h 127.0.0.1"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -33,7 +33,7 @@ services:
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - DATABASE_URL=${DATABASE_URL}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://noesis2:noesis2@db:5432/noesis2}
       - CONFIG_FILE_PATH=/config/config.yaml
     entrypoint: ["litellm"]
     command:
@@ -85,6 +85,10 @@ services:
       litellm:
         condition: service_healthy
     restart: unless-stopped
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://noesis2:noesis2@db:5432/noesis2}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      RAG_ENABLED: ${RAG_ENABLED:-false}
 
   worker:
     build:
@@ -102,6 +106,10 @@ services:
       litellm:
         condition: service_healthy
     restart: unless-stopped
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://noesis2:noesis2@db:5432/noesis2}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      RAG_ENABLED: ${RAG_ENABLED:-false}
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     container_name: noesis2_db
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: noesis2
+      POSTGRES_USER: noesis2
+      POSTGRES_PASSWORD: noesis2
     ports:
       - "5432:5432"
     volumes:
@@ -35,6 +35,9 @@ services:
       - .env
     environment:
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-example.com}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://noesis2:noesis2@db:5432/noesis2}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      RAG_ENABLED: ${RAG_ENABLED:-false}
     depends_on:
       - db
       - redis
@@ -50,6 +53,9 @@ services:
       - .env
     environment:
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-noesis2.settings.development}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://noesis2:noesis2@db:5432/noesis2}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      RAG_ENABLED: ${RAG_ENABLED:-false}
     depends_on:
       - redis
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- load the Django database configuration exclusively from DATABASE_URL and share the Redis URL between Celery broker and backend
- simplify environment documentation and compose files to expose DATABASE_URL, REDIS_URL and the new RAG_ENABLED flag
- update CI to provide the new variables, drop legacy DB_/CELERY_ secrets, and guard against reintroducing outdated lookups

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca8c2c177c832b9538feaf251644f8