### PR TITLE
Reorder security middleware before tenant routing

### DIFF
--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -73,8 +73,8 @@ TENANT_APPS = [
 INSTALLED_APPS = ["django_tenants", *SHARED_APPS, *TENANT_APPS]
 
 MIDDLEWARE = [
-    "django_tenants.middleware.main.TenantMainMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "django_tenants.middleware.main.TenantMainMiddleware",
     "common.middleware.HeaderTenantRoutingMiddleware",
     "common.middleware.TenantSchemaMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",


### PR DESCRIPTION
## Summary
- ensure Django's SecurityMiddleware runs before TenantMainMiddleware to apply security headers prior to tenant routing

## Testing
- pytest common/tests/test_tenant_guard.py::test_demo_view_requires_tenant_header *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cb040e95e8832ba9805a0eddc630ae