### PR TITLE
Ensure tenant superuser command handles missing migrations

### DIFF
--- a/customers/management/commands/create_tenant_superuser.py
+++ b/customers/management/commands/create_tenant_superuser.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
 from django.contrib.auth import get_user_model
+from django.db import OperationalError
 from django_tenants.utils import schema_context
 
 from customers.models import Tenant
@@ -27,29 +28,40 @@ class Command(BaseCommand):
         if not Tenant.objects.filter(schema_name=schema).exists():
             raise CommandError(f"Tenant schema '{schema}' does not exist.")
 
+        call_command("migrate_schemas", schema=schema)
+
         with schema_context(schema):
-            if username and password:
-                User = get_user_model()
-                if User.objects.filter(username=username).exists():
+            try:
+                if username and password:
+                    User = get_user_model()
+                    if User.objects.filter(username=username).exists():
+                        self.stdout.write(
+                            self.style.WARNING(
+                                f"User '{username}' already exists in schema '{schema}'."
+                            )
+                        )
+                        return
+                    User.objects.create_superuser(
+                        username=username, email=email, password=password
+                    )
                     self.stdout.write(
-                        self.style.WARNING(
-                            f"User '{username}' already exists in schema '{schema}'."
+                        self.style.SUCCESS(
+                            f"Superuser '{username}' created in schema '{schema}'."
                         )
                     )
-                    return
-                User.objects.create_superuser(
-                    username=username, email=email, password=password
-                )
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        f"Superuser '{username}' created in schema '{schema}'."
+                else:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            "Running interactive createsuperuser inside tenant schema."
+                        )
                     )
-                )
-            else:
-                self.stdout.write(
-                    self.style.WARNING(
-                        "Running interactive createsuperuser inside tenant schema."
+                    # Delegate to Django's interactive command within the tenant schema
+                    call_command("createsuperuser")
+            except OperationalError as exc:
+                raise CommandError(
+                    (
+                        "Database schema for tenant "
+                        f"'{schema}' is not migrated. Run 'python manage.py "
+                        f"migrate_schemas --schema={schema}' before creating the superuser."
                     )
-                )
-                # Delegate to Django's interactive command within the tenant schema
-                call_command("createsuperuser")
+                ) from exc

--- a/customers/tests/test_management_commands.py
+++ b/customers/tests/test_management_commands.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.management import call_command, CommandError
+from django.db import OperationalError
 from django_tenants.utils import get_public_schema_name
 
 from customers.models import Domain, Tenant
@@ -65,3 +66,48 @@ def test_list_tenants_command(capsys):
     captured = capsys.readouterr()
     assert "alpha" in captured.out
     assert tenant.name in captured.out
+
+
+@pytest.mark.django_db
+def test_create_tenant_superuser_missing_tables(monkeypatch):
+    tenant = TenantFactory(schema_name="missing")
+
+    recorded_calls = []
+
+    def fake_call_command(name, *args, **kwargs):
+        recorded_calls.append((name, args, kwargs))
+
+    monkeypatch.setattr(
+        "customers.management.commands.create_tenant_superuser.call_command",
+        fake_call_command,
+    )
+
+    class DummyQuerySet:
+        def exists(self):
+            return False
+
+    class DummyManager:
+        def filter(self, *args, **kwargs):
+            return DummyQuerySet()
+
+        def create_superuser(self, *args, **kwargs):
+            raise OperationalError("relation does not exist")
+
+    class DummyUser:
+        objects = DummyManager()
+
+    monkeypatch.setattr(
+        "customers.management.commands.create_tenant_superuser.get_user_model",
+        lambda: DummyUser,
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        call_command(
+            "create_tenant_superuser",
+            schema=tenant.schema_name,
+            username="admin",
+            password="secret",
+        )
+
+    assert "migrate" in str(excinfo.value).lower()
+    assert recorded_calls == [("migrate_schemas", (), {"schema": tenant.schema_name})]


### PR DESCRIPTION
## Summary
- ensure the tenant superuser management command runs tenant migrations before entering the schema context and reports missing migrations clearly
- add a regression test that exercises the failure path when tenant tables are unavailable

## Testing
- pytest customers/tests/test_management_commands.py *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cb045a43f4832bb09392fcea7b5eaa