### PR TITLE
Add Makefile operator targets and document usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+.PHONY: jobs\:migrate jobs\:bootstrap tenant-new tenant-superuser jobs\:rag jobs\:rag\:health
+
+PYTHON ?= python
+MANAGE := $(PYTHON) manage.py
+
+jobs\:migrate:
+	$(MANAGE) migrate_schemas --noinput
+
+jobs\:bootstrap:
+	@: $${DOMAIN:?Environment variable DOMAIN is required}
+	$(MANAGE) bootstrap_public_tenant --domain "$$DOMAIN"
+
+tenant-new:
+	@: $${SCHEMA:?Environment variable SCHEMA is required}
+	@: $${NAME:?Environment variable NAME is required}
+	@: $${DOMAIN:?Environment variable DOMAIN is required}
+	$(MANAGE) create_tenant --schema "$$SCHEMA" --name "$$NAME" --domain "$$DOMAIN"
+
+tenant-superuser:
+	@: $${SCHEMA:?Environment variable SCHEMA is required}
+	@: $${USERNAME:?Environment variable USERNAME is required}
+	@: $${PASSWORD:?Environment variable PASSWORD is required}
+	@EMAIL_FLAG=""; \
+	if [ -n "$$EMAIL" ]; then EMAIL_FLAG="--email \"$$EMAIL\""; fi; \
+	$(MANAGE) create_tenant_superuser --schema "$$SCHEMA" --username "$$USERNAME" --password "$$PASSWORD" $$EMAIL_FLAG
+
+jobs\:rag:
+	@RAG_URL="$$RAG_DATABASE_URL"; \
+	if [ -z "$$RAG_URL" ]; then RAG_URL="$$DATABASE_URL"; fi; \
+	test -n "$$RAG_URL" || (echo "RAG_DATABASE_URL or DATABASE_URL must be set" >&2; exit 1); \
+	psql "$$RAG_URL" -v ON_ERROR_STOP=1 -f docs/rag/schema.sql
+
+jobs\:rag\:health:
+	@RAG_URL="$$RAG_DATABASE_URL"; \
+	if [ -z "$$RAG_URL" ]; then RAG_URL="$$DATABASE_URL"; fi; \
+	test -n "$$RAG_URL" || (echo "RAG_DATABASE_URL or DATABASE_URL must be set" >&2; exit 1); \
+	psql "$$RAG_URL" -v ON_ERROR_STOP=1 <<-'SQL'
+	DO $$
+	BEGIN
+	    IF to_regnamespace('rag') IS NULL THEN
+	        RAISE EXCEPTION 'Schema rag missing';
+	    END IF;
+	    IF to_regclass('rag.documents') IS NULL THEN
+	        RAISE EXCEPTION 'Table rag.documents missing';
+	    END IF;
+	    IF to_regclass('rag.chunks') IS NULL THEN
+	        RAISE EXCEPTION 'Table rag.chunks missing';
+	    END IF;
+	    IF to_regclass('rag.embeddings') IS NULL THEN
+	        RAISE EXCEPTION 'Table rag.embeddings missing';
+	    END IF;
+	    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') THEN
+	        RAISE EXCEPTION 'vector extension missing';
+	    END IF;
+	END;
+	$$;
+	SQL

--- a/README.md
+++ b/README.md
@@ -165,6 +165,30 @@ aktualisiert das Projekt entsprechend.
 
 Eine ausführliche Anleitung zur Einrichtung und Pflege von Mandanten (inkl. lokalem Setup, Admin/Operator‑Rollen und X‑Tenant‑Schema) befindet sich im Dokument [docs/multi-tenancy.md](docs/multi-tenancy.md).
 
+## Operator-Kommandos (Makefile)
+
+Im Projektwurzelverzeichnis stehen Makefile-Targets zur Verfügung, um wiederkehrende Operator-Aufgaben auszuführen:
+
+- `make jobs:migrate` – führt `python manage.py migrate_schemas --noinput` aus.
+- `make jobs:bootstrap` – legt den öffentlichen Tenant per `bootstrap_public_tenant` an (`DOMAIN` erforderlich).
+- `make tenant-new` – erstellt ein neues Schema und die zugehörige Domain (`SCHEMA`, `NAME`, `DOMAIN`).
+- `make tenant-superuser` – erzeugt einen Superuser in einem Schema (`SCHEMA`, `USERNAME`, `PASSWORD`, optional `EMAIL`).
+- `make jobs:rag` – spielt [`docs/rag/schema.sql`](docs/rag/schema.sql) gegen den RAG-Store ein (`RAG_DATABASE_URL` oder fallback `DATABASE_URL`).
+- `make jobs:rag:health` – prüft Schema, Tabellen und `vector`-Extension im RAG-Store (`RAG_DATABASE_URL` oder fallback `DATABASE_URL`).
+
+Setze die benötigten Umgebungsvariablen vor dem Aufruf, z. B.:
+
+```bash
+export DOMAIN=demo.localhost
+export SCHEMA=demo
+export NAME="Demo GmbH"
+export USERNAME=admin
+export PASSWORD=changeme
+export RAG_DATABASE_URL=postgresql://user:pass@host:5432/rag
+```
+
+`RAG_DATABASE_URL` kann leer bleiben, sofern `DATABASE_URL` auf dieselbe Instanz zeigt. Für alternative Python-Binaries lässt sich `PYTHON` überschreiben (`make PYTHON=python3 jobs:migrate`).
+
 ## LiteLLM Proxy (lokal)
 - `.env.example` → `.env` kopieren und `GOOGLE_API_KEY` setzen
 - Start: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d litellm`


### PR DESCRIPTION
## Summary
- add a repository-level Makefile with operator targets for migrations, tenant management, and RAG schema checks
- ensure RAG health target verifies schema, tables, and vector extension before succeeding
- document the new Makefile commands and required environment variables in the README

## Testing
- make -n jobs:migrate
- make -n jobs:rag
- make -n tenant-superuser

------
https://chatgpt.com/codex/tasks/task_e_68cb04ac909c832bb8f00a18648e7d4a