### PR TITLE
Propagate tenant headers to LLM requests

### DIFF
--- a/ai_core/llm/client.py
+++ b/ai_core/llm/client.py
@@ -33,6 +33,15 @@ def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
     cfg = get_config()
     url = f"{cfg.litellm_base_url.rstrip('/')}/v1/chat/completions"
     headers = {"Authorization": f"Bearer {cfg.litellm_api_key}"}
+    propagated_headers = {
+        "X-Trace-ID": metadata.get("trace_id"),
+        "X-Case-ID": metadata.get("case"),
+        "X-Tenant-ID": metadata.get("tenant"),
+    }
+    key_alias = metadata.get("key_alias")
+    if key_alias:
+        propagated_headers["X-Key-Alias"] = key_alias
+    headers.update({k: v for k, v in propagated_headers.items() if v})
     payload = {
         "model": model_id,
         "messages": [{"role": "user", "content": prompt_safe}],

--- a/ai_core/tests/test_llm.py
+++ b/ai_core/tests/test_llm.py
@@ -27,6 +27,7 @@ def test_llm_client_masks_records_and_retries(monkeypatch):
         "case": "c1",
         "trace_id": "tr1",
         "prompt_version": "v1",
+        "key_alias": "alias-01",
     }
 
     class FailOnce:
@@ -37,6 +38,11 @@ def test_llm_client_masks_records_and_retries(monkeypatch):
             self, url: str, headers: dict[str, str], json: dict[str, Any], timeout: int
         ):
             assert json["messages"][0]["content"] == "XXXX"
+            assert headers["Authorization"] == "Bearer token"
+            assert headers["X-Trace-ID"] == "tr1"
+            assert headers["X-Case-ID"] == "c1"
+            assert headers["X-Tenant-ID"] == "t1"
+            assert headers["X-Key-Alias"] == "alias-01"
             self.calls += 1
             if self.calls == 1:
 


### PR DESCRIPTION
## Summary
- capture the optional X-Key-Alias header during request preparation and validate it
- forward tenant, case, trace, and key alias identifiers as headers on LLM requests
- extend the LLM client retry test to assert the propagated headers

## Testing
- pytest ai_core/tests/test_llm.py

------
https://chatgpt.com/codex/tasks/task_e_68cee0b95e08832b9e6ba78471c410fe