### PR TITLE
Bind log context to AI Core handlers and tasks

### DIFF
--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -8,6 +8,8 @@ from typing import Callable, Dict, List
 from celery import shared_task
 from django.conf import settings
 
+from common.logging import log_context
+
 from .infra import object_store, pii
 from .rag.schemas import Chunk
 from .rag.vector_client import EMBEDDING_DIM, PgVectorClient, get_default_client
@@ -24,87 +26,102 @@ def _build_path(meta: Dict[str, str], *parts: str) -> str:
     return "/".join([tenant, case, *parts])
 
 
+def _context_kwargs(meta: Dict[str, str]) -> dict[str, str | None]:
+    return {
+        "trace_id": meta.get("trace_id"),
+        "case_id": meta.get("case"),
+        "tenant": meta.get("tenant"),
+        "key_alias": meta.get("key_alias"),
+    }
+
+
 @shared_task
 def ingest_raw(meta: Dict[str, str], name: str, data: bytes) -> Dict[str, str]:
     """Persist raw document bytes."""
-    path = _build_path(meta, "raw", name)
-    object_store.put_bytes(path, data)
-    return {"path": path}
+    with log_context(**_context_kwargs(meta)):
+        path = _build_path(meta, "raw", name)
+        object_store.put_bytes(path, data)
+        return {"path": path}
 
 
 @shared_task
 def extract_text(meta: Dict[str, str], raw_path: str) -> Dict[str, str]:
     """Decode bytes to text and store."""
-    full = object_store.BASE_PATH / raw_path
-    text = full.read_bytes().decode("utf-8")
-    out_path = _build_path(meta, "text", f"{Path(raw_path).stem}.txt")
-    object_store.put_bytes(out_path, text.encode("utf-8"))
-    return {"path": out_path}
+    with log_context(**_context_kwargs(meta)):
+        full = object_store.BASE_PATH / raw_path
+        text = full.read_bytes().decode("utf-8")
+        out_path = _build_path(meta, "text", f"{Path(raw_path).stem}.txt")
+        object_store.put_bytes(out_path, text.encode("utf-8"))
+        return {"path": out_path}
 
 
 @shared_task
 def pii_mask(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
     """Mask PII in text."""
-    full = object_store.BASE_PATH / text_path
-    text = full.read_text(encoding="utf-8")
-    masked = pii.mask(text)
-    out_path = _build_path(meta, "text", f"{Path(text_path).stem}.masked.txt")
-    object_store.put_bytes(out_path, masked.encode("utf-8"))
-    return {"path": out_path}
+    with log_context(**_context_kwargs(meta)):
+        full = object_store.BASE_PATH / text_path
+        text = full.read_text(encoding="utf-8")
+        masked = pii.mask(text)
+        out_path = _build_path(meta, "text", f"{Path(text_path).stem}.masked.txt")
+        object_store.put_bytes(out_path, masked.encode("utf-8"))
+        return {"path": out_path}
 
 
 @shared_task
 def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
     """Split text into chunks; stubbed as a single chunk."""
-    full = object_store.BASE_PATH / text_path
-    text = full.read_text(encoding="utf-8")
-    hash_val = hashlib.sha1(text.encode("utf-8")).hexdigest()
-    chunks: List[Dict[str, object]] = [
-        {
-            "content": text,
-            "meta": {
-                "tenant": meta["tenant"],
-                "case": meta["case"],
-                "source": text_path,
-                "hash": hash_val,
-            },
-        }
-    ]
-    out_path = _build_path(meta, "embeddings", "chunks.json")
-    object_store.write_json(out_path, chunks)
-    return {"path": out_path}
+    with log_context(**_context_kwargs(meta)):
+        full = object_store.BASE_PATH / text_path
+        text = full.read_text(encoding="utf-8")
+        hash_val = hashlib.sha1(text.encode("utf-8")).hexdigest()
+        chunks: List[Dict[str, object]] = [
+            {
+                "content": text,
+                "meta": {
+                    "tenant": meta["tenant"],
+                    "case": meta["case"],
+                    "source": text_path,
+                    "hash": hash_val,
+                },
+            }
+        ]
+        out_path = _build_path(meta, "embeddings", "chunks.json")
+        object_store.write_json(out_path, chunks)
+        return {"path": out_path}
 
 
 @shared_task
 def embed(meta: Dict[str, str], chunks_path: str) -> Dict[str, str]:
     """Attach dummy embedding vectors to chunks."""
-    chunks = object_store.read_json(chunks_path)
-    embeddings = [{**ch, "embedding": [0.0] * EMBEDDING_DIM} for ch in chunks]
-    out_path = _build_path(meta, "embeddings", "vectors.json")
-    object_store.write_json(out_path, embeddings)
-    return {"path": out_path}
+    with log_context(**_context_kwargs(meta)):
+        chunks = object_store.read_json(chunks_path)
+        embeddings = [{**ch, "embedding": [0.0] * EMBEDDING_DIM} for ch in chunks]
+        out_path = _build_path(meta, "embeddings", "vectors.json")
+        object_store.write_json(out_path, embeddings)
+        return {"path": out_path}
 
 
 @shared_task
 def upsert(meta: Dict[str, str], embeddings_path: str) -> int:
     """Upsert embedded chunks into the vector client."""
-    if not settings.RAG_ENABLED:
-        logger.info(
-            "Skipping vector upsert because RAG is disabled (tenant=%s, case=%s)",
-            meta.get("tenant"),
-            meta.get("case"),
-        )
-        return 0
+    with log_context(**_context_kwargs(meta)):
+        if not settings.RAG_ENABLED:
+            logger.info(
+                "Skipping vector upsert because RAG is disabled (tenant=%s, case=%s)",
+                meta.get("tenant"),
+                meta.get("case"),
+            )
+            return 0
 
-    data = object_store.read_json(embeddings_path)
-    chunk_objs = []
-    for ch in data:
-        vector = ch.get("embedding")
-        embedding = [float(v) for v in vector] if vector is not None else None
-        chunk_objs.append(
-            Chunk(content=ch["content"], meta=ch["meta"], embedding=embedding)
-        )
+        data = object_store.read_json(embeddings_path)
+        chunk_objs = []
+        for ch in data:
+            vector = ch.get("embedding")
+            embedding = [float(v) for v in vector] if vector is not None else None
+            chunk_objs.append(
+                Chunk(content=ch["content"], meta=ch["meta"], embedding=embedding)
+            )
 
-    client = VECTOR_CLIENT_FACTORY()
-    written = client.upsert_chunks(chunk_objs)
-    return written
+        client = VECTOR_CLIENT_FACTORY()
+        written = client.upsert_chunks(chunk_objs)
+        return written

--- a/ai_core/tests/test_tasks.py
+++ b/ai_core/tests/test_tasks.py
@@ -1,9 +1,12 @@
+import io
+import logging
 import uuid
 
 import pytest
 
 from ai_core import tasks
 from ai_core.rag import metrics, vector_client
+from common import logging as common_logging
 
 
 def test_pipeline_skips_when_rag_disabled(tmp_path, monkeypatch, settings, caplog):
@@ -70,3 +73,48 @@ def test_upsert_no_chunks_is_noop(monkeypatch, settings):
     assert written == 0
     assert dummy_counter.value == 0
     vector_client.reset_default_client()
+
+
+def test_task_logging_context_includes_metadata(monkeypatch, tmp_path, settings):
+    monkeypatch.setattr(tasks.object_store, "BASE_PATH", tmp_path)
+    original_put_bytes = tasks.object_store.put_bytes
+
+    log_buffer = io.StringIO()
+    handler = logging.StreamHandler(log_buffer)
+    handler.addFilter(common_logging.RequestTaskContextFilter())
+    formatter = logging.Formatter(settings.LOGGING["formatters"]["verbose"]["format"])
+    handler.setFormatter(formatter)
+
+    logger = logging.getLogger("ai_core.tests.tasks")
+    original_propagate = logger.propagate
+    logger.propagate = False
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    def _logging_put_bytes(path: str, data: bytes):
+        logger.info("task-run")
+        return original_put_bytes(path, data)
+
+    monkeypatch.setattr(tasks.object_store, "put_bytes", _logging_put_bytes)
+
+    try:
+        tasks.ingest_raw(
+            {
+                "tenant": "tenant-123",
+                "case": "case-456",
+                "trace_id": "trace-7890",
+                "key_alias": "alias-1234",
+            },
+            "doc.txt",
+            b"payload",
+        )
+    finally:
+        logger.removeHandler(handler)
+        logger.propagate = original_propagate
+
+    output = log_buffer.getvalue()
+    assert "task-run" in output
+    assert "trace=-" not in output
+    assert "case=-" not in output
+    assert "tenant=-" not in output
+    assert "key_alias=-" not in output


### PR DESCRIPTION
## Summary
- wrap AI Core request handling in `common.logging.log_context` to propagate tenant, case, trace and key alias metadata
- bind Celery task entrypoints to the logging context so task-side logging carries the same metadata
- add regression tests that capture formatter output for both request and task flows to ensure populated metadata appears in logs

## Testing
- SECRET_KEY=dummy DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres REDIS_URL=redis://localhost:6379/0 DJANGO_SETTINGS_MODULE=noesis2.settings.development pytest ai_core/tests/test_views.py::test_request_logging_context_includes_metadata ai_core/tests/test_tasks.py::test_task_logging_context_includes_metadata *(fails: requires PostgreSQL server on localhost:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68cef3e3eee8832ba30f6d87188c58ae