### PR TITLE
Attach metadata headers to successful responses

### DIFF
--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -121,9 +121,8 @@ def _run_graph(request: HttpRequest, graph) -> JsonResponse:
 
     _save_state(meta["tenant"], meta["case"], new_state)
 
-    prompt_version = result.get("prompt_version")
     response = JsonResponse(result)
-    return apply_std_headers(response, meta["trace_id"], prompt_version)
+    return apply_std_headers(response, meta)
 
 
 def ping(request: HttpRequest) -> JsonResponse:
@@ -133,7 +132,7 @@ def ping(request: HttpRequest) -> JsonResponse:
         return error
     with log_context(**_log_context_kwargs(meta)):
         response = JsonResponse({"ok": True})
-    return apply_std_headers(response, meta["trace_id"])
+    return apply_std_headers(response, meta)
 
 
 @csrf_exempt


### PR DESCRIPTION
## Summary
- update apply_std_headers to accept request metadata and only add tracing headers on 2xx responses
- pass request metadata into apply_std_headers from the AI Core views
- expand infrastructure and view tests to cover the richer header set and absence on error responses

## Testing
- pytest ai_core/tests/test_infra.py ai_core/tests/test_views.py

------
https://chatgpt.com/codex/tasks/task_e_68cefadaff48832bbdf9ac7c931b5a3b