### PR TITLE
Handle invalid identifiers in graph endpoint

### DIFF
--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -114,7 +114,10 @@ def _run_graph(request: HttpRequest, graph) -> JsonResponse:
     if error:
         return error
 
-    state = _load_state(meta["tenant"], meta["case"])
+    try:
+        state = _load_state(meta["tenant"], meta["case"])
+    except ValueError as exc:
+        return JsonResponse({"detail": str(exc)}, status=400)
     if request.body:
         try:
             payload = json.loads(request.body)
@@ -130,7 +133,10 @@ def _run_graph(request: HttpRequest, graph) -> JsonResponse:
     except Exception:
         return JsonResponse({"detail": "internal error"}, status=500)
 
-    _save_state(meta["tenant"], meta["case"], new_state)
+    try:
+        _save_state(meta["tenant"], meta["case"], new_state)
+    except ValueError as exc:
+        return JsonResponse({"detail": str(exc)}, status=400)
 
     response = JsonResponse(result)
     return apply_std_headers(response, meta)


### PR DESCRIPTION
## Summary
- return a 400 response when loading persisted state fails identifier validation
- guard state persistence so unsafe identifiers surface as client errors

## Testing
- pytest ai_core

------
https://chatgpt.com/codex/tasks/task_e_68cf0811a348832ba504d2602e6e09db