### PR TITLE
Ensure ping view test includes tenant header

### DIFF
--- a/ai_core/tests/test_views.py
+++ b/ai_core/tests/test_views.py
@@ -25,19 +25,27 @@ class DummyRedis:
 
 
 @pytest.mark.django_db
-def test_ping_view_applies_rate_limit(client, monkeypatch):
+def test_ping_view_applies_rate_limit(client, monkeypatch, test_tenant_schema_name):
     monkeypatch.setattr(rate_limit, "get_quota", lambda: 1)
     rate_limit._get_redis.cache_clear()
     monkeypatch.setattr(rate_limit, "_get_redis", lambda: DummyRedis())
 
-    resp1 = client.get("/ai/ping/", HTTP_X_CASE_ID="c")
+    resp1 = client.get(
+        "/ai/ping/",
+        HTTP_X_CASE_ID="c",
+        HTTP_X_TENANT_ID=test_tenant_schema_name,
+    )
     assert resp1.status_code == 200
     assert resp1.json() == {"ok": True}
     assert resp1["X-Trace-ID"]
     assert resp1["X-Case-ID"] == "c"
     assert resp1["X-Tenant-ID"] == test_tenant_schema_name
     assert "X-Key-Alias" not in resp1
-    resp2 = client.get("/ai/ping/", HTTP_X_CASE_ID="c")
+    resp2 = client.get(
+        "/ai/ping/",
+        HTTP_X_CASE_ID="c",
+        HTTP_X_TENANT_ID=test_tenant_schema_name,
+    )
     assert resp2.status_code == 429
     assert resp2.json()["detail"] == "rate limit"
     assert "X-Trace-ID" not in resp2


### PR DESCRIPTION
## Summary
- extend the ping rate-limit test to accept the tenant fixture
- send the tenant header with both ping requests so the test validates tenant-specific headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf0a92ed34832b90017a4e8c7439dd