### PR TITLE
Add shared header constants and refactor usages

### DIFF
--- a/ai_core/infra/resp.py
+++ b/ai_core/infra/resp.py
@@ -4,6 +4,13 @@ from typing import Mapping
 
 from django.http import HttpResponse
 
+from common.constants import (
+    X_CASE_ID_HEADER,
+    X_KEY_ALIAS_HEADER,
+    X_TENANT_ID_HEADER,
+    X_TRACE_ID_HEADER,
+)
+
 
 Meta = Mapping[str, str]
 
@@ -15,10 +22,10 @@ def apply_std_headers(response: HttpResponse, meta: Meta) -> HttpResponse:
         return response
 
     header_map = {
-        "X-Trace-ID": meta.get("trace_id"),
-        "X-Case-ID": meta.get("case"),
-        "X-Tenant-ID": meta.get("tenant"),
-        "X-Key-Alias": meta.get("key_alias"),
+        X_TRACE_ID_HEADER: meta.get("trace_id"),
+        X_CASE_ID_HEADER: meta.get("case"),
+        X_TENANT_ID_HEADER: meta.get("tenant"),
+        X_KEY_ALIAS_HEADER: meta.get("key_alias"),
     }
 
     for header, value in header_map.items():

--- a/ai_core/tests/test_infra.py
+++ b/ai_core/tests/test_infra.py
@@ -7,6 +7,12 @@ from ai_core.infra import object_store, pii
 from ai_core.infra.config import get_config
 from ai_core.infra.resp import apply_std_headers
 from ai_core.infra.tracing import trace
+from common.constants import (
+    X_CASE_ID_HEADER,
+    X_KEY_ALIAS_HEADER,
+    X_TENANT_ID_HEADER,
+    X_TRACE_ID_HEADER,
+)
 
 
 def test_get_config_reads_env(monkeypatch):
@@ -38,10 +44,10 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
 
     result = apply_std_headers(resp, meta)
 
-    assert result["X-Trace-ID"] == "abc123"
-    assert result["X-Case-ID"] == "case-1"
-    assert result["X-Tenant-ID"] == "tenant-1"
-    assert result["X-Key-Alias"] == "alias-1"
+    assert result[X_TRACE_ID_HEADER] == "abc123"
+    assert result[X_CASE_ID_HEADER] == "case-1"
+    assert result[X_TENANT_ID_HEADER] == "tenant-1"
+    assert result[X_KEY_ALIAS_HEADER] == "alias-1"
 
 
 def test_apply_std_headers_skips_missing_optional_headers():
@@ -50,8 +56,8 @@ def test_apply_std_headers_skips_missing_optional_headers():
 
     result = apply_std_headers(resp, meta)
 
-    assert "X-Key-Alias" not in result
-    assert result["X-Trace-ID"] == "abc123"
+    assert X_KEY_ALIAS_HEADER not in result
+    assert result[X_TRACE_ID_HEADER] == "abc123"
 
 
 def test_apply_std_headers_ignores_non_success_responses():
@@ -60,10 +66,10 @@ def test_apply_std_headers_ignores_non_success_responses():
     for status in (400, 500):
         resp = HttpResponse("error", status=status)
         result = apply_std_headers(resp, meta)
-        assert "X-Trace-ID" not in result
-        assert "X-Case-ID" not in result
-        assert "X-Tenant-ID" not in result
-        assert "X-Key-Alias" not in result
+        assert X_TRACE_ID_HEADER not in result
+        assert X_CASE_ID_HEADER not in result
+        assert X_TENANT_ID_HEADER not in result
+        assert X_KEY_ALIAS_HEADER not in result
 
 
 def test_pii_mask_replaces_digits():

--- a/ai_core/tests/test_views.py
+++ b/ai_core/tests/test_views.py
@@ -9,6 +9,15 @@ from django.test import RequestFactory
 from ai_core import views
 from ai_core.infra import object_store, rate_limit
 from common import logging as common_logging
+from common.constants import (
+    META_CASE_ID_KEY,
+    META_KEY_ALIAS_KEY,
+    META_TENANT_ID_KEY,
+    X_CASE_ID_HEADER,
+    X_KEY_ALIAS_HEADER,
+    X_TENANT_ID_HEADER,
+    X_TRACE_ID_HEADER,
+)
 from common.middleware import RequestLogContextMiddleware
 
 
@@ -35,23 +44,21 @@ def test_ping_view_applies_rate_limit(
 
     resp1 = client.get(
         "/ai/ping/",
-        HTTP_X_CASE_ID="c",
-        HTTP_X_TENANT_ID=tenant_schema,
+        **{META_CASE_ID_KEY: "c", META_TENANT_ID_KEY: tenant_schema},
     )
     assert resp1.status_code == 200
     assert resp1.json() == {"ok": True}
-    assert resp1["X-Trace-ID"]
-    assert resp1["X-Case-ID"] == "c"
-    assert resp1["X-Tenant-ID"] == tenant_schema
-    assert "X-Key-Alias" not in resp1
+    assert resp1[X_TRACE_ID_HEADER]
+    assert resp1[X_CASE_ID_HEADER] == "c"
+    assert resp1[X_TENANT_ID_HEADER] == tenant_schema
+    assert X_KEY_ALIAS_HEADER not in resp1
     resp2 = client.get(
         "/ai/ping/",
-        HTTP_X_CASE_ID="c",
-        HTTP_X_TENANT_ID=tenant_schema,
+        **{META_CASE_ID_KEY: "c", META_TENANT_ID_KEY: tenant_schema},
     )
     assert resp2.status_code == 429
     assert resp2.json()["detail"] == "rate limit"
-    assert "X-Trace-ID" not in resp2
+    assert X_TRACE_ID_HEADER not in resp2
 
 
 @pytest.mark.django_db
@@ -60,7 +67,7 @@ def test_missing_case_header_returns_400(client, test_tenant_schema_name):
         "/ai/intake/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=test_tenant_schema_name,
+        **{META_TENANT_ID_KEY: test_tenant_schema_name},
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "invalid case header"
@@ -72,8 +79,7 @@ def test_invalid_case_header_returns_400(client, test_tenant_schema_name):
         "/ai/intake/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=test_tenant_schema_name,
-        HTTP_X_CASE_ID="not/allowed",
+        **{META_TENANT_ID_KEY: test_tenant_schema_name, META_CASE_ID_KEY: "not/allowed"},
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "invalid case header"
@@ -85,8 +91,10 @@ def test_tenant_header_mismatch_returns_400(client, test_tenant_schema_name):
         "/ai/intake/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=f"{test_tenant_schema_name}-other",
-        HTTP_X_CASE_ID="c",
+        **{
+            META_TENANT_ID_KEY: f"{test_tenant_schema_name}-other",
+            META_CASE_ID_KEY: "c",
+        },
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "tenant mismatch"
@@ -99,7 +107,7 @@ def test_missing_tenant_resolution_returns_400(client, monkeypatch):
         "/ai/intake/",
         data={},
         content_type="application/json",
-        HTTP_X_CASE_ID="c",
+        **{META_CASE_ID_KEY: "c"},
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "tenant not resolved"
@@ -116,14 +124,16 @@ def test_intake_persists_state_and_headers(
         "/ai/intake/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=test_tenant_schema_name,
-        HTTP_X_CASE_ID="  case-123  ",
+        **{
+            META_TENANT_ID_KEY: test_tenant_schema_name,
+            META_CASE_ID_KEY: "  case-123  ",
+        },
     )
     assert resp.status_code == 200
-    assert resp["X-Trace-ID"]
-    assert resp["X-Case-ID"] == "case-123"
-    assert resp["X-Tenant-ID"] == test_tenant_schema_name
-    assert "X-Key-Alias" not in resp
+    assert resp[X_TRACE_ID_HEADER]
+    assert resp[X_CASE_ID_HEADER] == "case-123"
+    assert resp[X_TENANT_ID_HEADER] == test_tenant_schema_name
+    assert X_KEY_ALIAS_HEADER not in resp
     assert resp.json()["tenant"] == test_tenant_schema_name
 
     state = object_store.read_json(f"{test_tenant_schema_name}/case-123/state.json")
@@ -140,16 +150,14 @@ def test_scope_and_needs_flow(client, monkeypatch, tmp_path, test_tenant_schema_
         "/ai/intake/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=test_tenant_schema_name,
-        HTTP_X_CASE_ID="c",
+        **{META_TENANT_ID_KEY: test_tenant_schema_name, META_CASE_ID_KEY: "c"},
     )
 
     resp_scope = client.post(
         "/ai/scope/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=test_tenant_schema_name,
-        HTTP_X_CASE_ID="c",
+        **{META_TENANT_ID_KEY: test_tenant_schema_name, META_CASE_ID_KEY: "c"},
     )
     assert resp_scope.status_code == 200
     assert resp_scope.json()["missing"] == ["scope"]
@@ -160,8 +168,7 @@ def test_scope_and_needs_flow(client, monkeypatch, tmp_path, test_tenant_schema_
         "/ai/needs/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=test_tenant_schema_name,
-        HTTP_X_CASE_ID="c",
+        **{META_TENANT_ID_KEY: test_tenant_schema_name, META_CASE_ID_KEY: "c"},
     )
     assert resp_needs.status_code == 200
     assert resp_needs.json()["missing"] == ["scope"]
@@ -179,8 +186,7 @@ def test_sysdesc_requires_no_missing(client, monkeypatch, tmp_path, test_tenant_
         "/ai/sysdesc/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=test_tenant_schema_name,
-        HTTP_X_CASE_ID="c",
+        **{META_TENANT_ID_KEY: test_tenant_schema_name, META_CASE_ID_KEY: "c"},
     )
     assert resp_skip.status_code == 200
     assert resp_skip.json()["missing"] == ["scope"]
@@ -192,8 +198,7 @@ def test_sysdesc_requires_no_missing(client, monkeypatch, tmp_path, test_tenant_
         "/ai/sysdesc/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID=test_tenant_schema_name,
-        HTTP_X_CASE_ID="c",
+        **{META_TENANT_ID_KEY: test_tenant_schema_name, META_CASE_ID_KEY: "c"},
     )
     assert resp_desc.status_code == 200
     body = resp_desc.json()
@@ -237,9 +242,11 @@ def test_request_logging_context_includes_metadata(
         "/ai/intake/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID="autotest",
-        HTTP_X_CASE_ID="case-123",
-        HTTP_X_KEY_ALIAS="alias-1234",
+        **{
+            META_TENANT_ID_KEY: "autotest",
+            META_CASE_ID_KEY: "case-123",
+            META_KEY_ALIAS_KEY: "alias-1234",
+        },
     )
     request.tenant = SimpleNamespace(schema_name="autotest")
 

--- a/common/celery.py
+++ b/common/celery.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from celery import Task
 
+from .constants import HEADER_CANDIDATE_MAP
 from .logging import bind_log_context, clear_log_context
 
 
@@ -13,12 +14,7 @@ class ContextTask(Task):
 
     abstract = True
 
-    _HEADER_CANDIDATES = {
-        "trace_id": ("x-trace-id", "trace_id", "trace-id"),
-        "case_id": ("x-case-id", "case_id", "case"),
-        "tenant": ("x-tenant-id", "tenant", "tenant_id"),
-        "key_alias": ("x-key-alias", "key_alias", "key-alias"),
-    }
+    _HEADER_CANDIDATES = HEADER_CANDIDATE_MAP
 
     def __call__(self, *args: Any, **kwargs: Any):  # noqa: D401
         clear_log_context()

--- a/common/constants.py
+++ b/common/constants.py
@@ -1,0 +1,48 @@
+"""Shared HTTP header and request metadata constants."""
+
+# Canonical header names
+X_TENANT_ID_HEADER = "X-Tenant-ID"
+X_TENANT_SCHEMA_HEADER = "X-Tenant-Schema"
+X_CASE_ID_HEADER = "X-Case-ID"
+X_TRACE_ID_HEADER = "X-Trace-ID"
+X_KEY_ALIAS_HEADER = "X-Key-Alias"
+IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+X_RETRY_ATTEMPT_HEADER = "X-Retry-Attempt"
+
+# Django request.META keys
+META_TENANT_ID_KEY = "HTTP_X_TENANT_ID"
+META_TENANT_SCHEMA_KEY = "HTTP_X_TENANT_SCHEMA"
+META_CASE_ID_KEY = "HTTP_X_CASE_ID"
+META_TRACE_ID_KEY = "HTTP_X_TRACE_ID"
+META_KEY_ALIAS_KEY = "HTTP_X_KEY_ALIAS"
+META_IDEMPOTENCY_KEY = "HTTP_IDEMPOTENCY_KEY"
+META_RETRY_ATTEMPT_KEY = "HTTP_X_RETRY_ATTEMPT"
+
+# Case-insensitive header lookups for task/request propagation
+TRACE_ID_HEADER_CANDIDATES = (
+    X_TRACE_ID_HEADER,
+    "trace_id",
+    "trace-id",
+)
+CASE_ID_HEADER_CANDIDATES = (
+    X_CASE_ID_HEADER,
+    "case_id",
+    "case",
+)
+TENANT_ID_HEADER_CANDIDATES = (
+    X_TENANT_ID_HEADER,
+    "tenant",
+    "tenant_id",
+)
+KEY_ALIAS_HEADER_CANDIDATES = (
+    X_KEY_ALIAS_HEADER,
+    "key_alias",
+    "key-alias",
+)
+
+HEADER_CANDIDATE_MAP = {
+    "trace_id": TRACE_ID_HEADER_CANDIDATES,
+    "case_id": CASE_ID_HEADER_CANDIDATES,
+    "tenant": TENANT_ID_HEADER_CANDIDATES,
+    "key_alias": KEY_ALIAS_HEADER_CANDIDATES,
+}

--- a/common/middleware.py
+++ b/common/middleware.py
@@ -3,13 +3,20 @@ from collections.abc import Mapping
 from django.conf import settings
 from django.db import connection
 
+from .constants import (
+    META_CASE_ID_KEY,
+    META_KEY_ALIAS_KEY,
+    META_TENANT_ID_KEY,
+    META_TENANT_SCHEMA_KEY,
+    META_TRACE_ID_KEY,
+)
 from .logging import bind_log_context, clear_log_context
 
 
 class TenantSchemaMiddleware:
     """Populate request.tenant_schema from the X-Tenant-Schema header."""
 
-    header_name = "HTTP_X_TENANT_SCHEMA"
+    header_name = META_TENANT_SCHEMA_KEY
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -28,7 +35,7 @@ class HeaderTenantRoutingMiddleware:
     middleware is inert and does not change schema routing.
     """
 
-    header_name = "HTTP_X_TENANT_SCHEMA"
+    header_name = META_TENANT_SCHEMA_KEY
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -51,10 +58,10 @@ class RequestLogContextMiddleware:
     """Bind request metadata to the logging context for the request lifecycle."""
 
     _HEADER_MAP = {
-        "trace_id": "HTTP_X_TRACE_ID",
-        "case_id": "HTTP_X_CASE_ID",
-        "tenant": "HTTP_X_TENANT_ID",
-        "key_alias": "HTTP_X_KEY_ALIAS",
+        "trace_id": META_TRACE_ID_KEY,
+        "case_id": META_CASE_ID_KEY,
+        "tenant": META_TENANT_ID_KEY,
+        "key_alias": META_KEY_ALIAS_KEY,
     }
 
     def __init__(self, get_response):

--- a/common/tests/test_logging.py
+++ b/common/tests/test_logging.py
@@ -5,6 +5,12 @@ from django.http import HttpResponse
 from django.test import RequestFactory
 
 from common import logging as common_logging
+from common.constants import (
+    META_CASE_ID_KEY,
+    META_KEY_ALIAS_KEY,
+    META_TENANT_ID_KEY,
+    META_TRACE_ID_KEY,
+)
 from common.middleware import RequestLogContextMiddleware
 
 
@@ -90,10 +96,12 @@ def test_request_log_context_middleware_binds_and_clears():
     factory = RequestFactory()
     request = factory.get(
         "/ai/ping/",
-        HTTP_X_TRACE_ID="trace-123",
-        HTTP_X_CASE_ID="case-456",
-        HTTP_X_TENANT_ID="tenant-789",
-        HTTP_X_KEY_ALIAS="alias-001",
+        **{
+            META_TRACE_ID_KEY: "trace-123",
+            META_CASE_ID_KEY: "case-456",
+            META_TENANT_ID_KEY: "tenant-789",
+            META_KEY_ALIAS_KEY: "alias-001",
+        },
     )
 
     observed: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- introduce common.constants module defining canonical header names, request META keys, and lookup tuples
- refactor middleware, AI Core helpers, and Celery context task to consume the shared constants
- update related tests to assert against the shared constants

## Testing
- pytest common/tests/test_logging.py ai_core/tests/test_infra.py ai_core/tests/test_views.py ai_core/tests/test_llm.py *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cf96516304832ba604f0670bf18e88