### PR TITLE
Update LiteLLM routing labels

### DIFF
--- a/MODEL_ROUTING.local.yaml.sample
+++ b/MODEL_ROUTING.local.yaml.sample
@@ -2,6 +2,12 @@ labels:
   # Local/dev: use AI Studio provider via LiteLLM config (requires GEMINI_API_KEY)
   default: gemini-2.5-flash
   fast: gemini-2.5-flash
+  simple-query: gemini-2.5-flash
+  synthesize: gemini-2.5-flash
+  extract: gemini-2.5-flash
+  classify: gemini-2.5-flash
+  analyze: gemini-2.5-flash
   reasoning: gemini-2.5-pro
+  draft: gemini-2.5-pro
   embedding: google/text-embedding-004
 

--- a/MODEL_ROUTING.yaml
+++ b/MODEL_ROUTING.yaml
@@ -1,6 +1,12 @@
 labels:
   default: vertex_ai/gemini-2.5-flash
   fast: vertex_ai/gemini-2.5-flash
+  simple-query: vertex_ai/gemini-2.5-flash
+  synthesize: vertex_ai/gemini-2.5-flash
+  extract: vertex_ai/gemini-2.5-flash
+  classify: vertex_ai/gemini-2.5-flash
+  analyze: vertex_ai/gemini-2.5-flash
   reasoning: vertex_ai/gemini-2.5-pro
+  draft: vertex_ai/gemini-2.5-pro
   embedding: vertex_ai/text-embedding-004
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ Best Practice: In Dev einen gemeinsamen DB‑User für App und LiteLLM verwenden
   - LiteLLM authentifiziert gegen Vertex AI per Service Account (ADC), kein API‑Key nötig.
   - Regionensplit: Cloud Run `europe-west3`, Vertex `us-central1` (siehe `scripts/init_litellm_gcloud.sh` und CI).
   - Routing: `MODEL_ROUTING.yaml` zeigt auf `vertex_ai/*` Modelle (z. B. `vertex_ai/gemini-2.5-flash`).
+  - Labels → Modelle (Vertex AI):
+    - `default`, `fast`, `simple-query`, `synthesize`, `extract`, `classify`, `analyze` → `vertex_ai/gemini-2.5-flash`
+    - `reasoning`, `draft` → `vertex_ai/gemini-2.5-pro`
+    - `embedding` → `vertex_ai/text-embedding-004`
   - CI setzt `VERTEXAI_PROJECT` und `VERTEXAI_LOCATION` und pinned die Cloud‑Run Service‑Account‑Identität.
 
 - Lokal (Docker Compose)
@@ -224,6 +228,11 @@ Best Practice: In Dev einen gemeinsamen DB‑User für App und LiteLLM verwenden
     docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d litellm
     bash scripts/smoke_litellm.sh
     ```
+
+  - Labels → Modelle (AI Studio):
+    - `default`, `fast`, `simple-query`, `synthesize`, `extract`, `classify`, `analyze` → `gemini-2.5-flash`
+    - `reasoning`, `draft` → `gemini-2.5-pro`
+    - `embedding` → `google/text-embedding-004`
 
 Hinweis: `MODEL_ROUTING.local.yaml` ist git‑ignored und überschreibt nur lokal. In Prod wird ausschließlich `MODEL_ROUTING.yaml` verwendet.
 


### PR DESCRIPTION
## Summary
- add dedicated LiteLLM labels for simple querying, synthesis, extraction, classification, analysis and drafting
- align local model routing sample with new labels and AI Studio model IDs
- document complete label-to-model mapping for production and local setups in the README

## Testing
- pytest ai_core/tests/test_llm.py -k simple_query *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa9d48da0832bbc7d75ce4bfe6177