### PR TITLE
Gate CI workflows behind [CI] opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,19 @@ on:
     branches: [ "main" ]
   push:
     branches: [ "main" ]
+env:
+  RUN_CI: ${{ ((
+      github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.title, '[CI]') ||
+        contains(github.event.pull_request.body || '', '[CI]')
+      )
+    ) || (
+      github.event_name == 'push' &&
+      contains(join(github.event.commits.*.message, ' '), '[CI]')
+    )) && 'true' || 'false' }}
 jobs:
   verify-secrets:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: Verify Secrets
     runs-on: ubuntu-latest
     steps:
@@ -64,6 +74,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: env.RUN_CI == 'true'
     steps:
       - name: Debug GitHub context
         uses: actions/github-script@v7
@@ -113,6 +124,7 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    if: env.RUN_CI == 'true'
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -183,7 +195,7 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     env:
       REGISTRY_HOST: ${{ secrets.GCP_REGION }}-docker.pkg.dev
       IMAGE: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GAR_REPOSITORY }}/noesis2-web:${{ github.sha }}
@@ -211,7 +223,7 @@ jobs:
     name: Publish LiteLLM proxy image
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     outputs:
       image: ${{ steps.publish.outputs.image }}
     steps:
@@ -240,7 +252,7 @@ jobs:
     name: Run LiteLLM migrations
     runs-on: ubuntu-latest
     needs: build-push-litellm
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Google Cloud Auth
         uses: google-github-actions/auth@v2
@@ -313,7 +325,7 @@ jobs:
     name: Deploy LiteLLM proxy
     runs-on: ubuntu-latest
     needs: litellm-migrate
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     outputs:
       service_url: ${{ steps.deploy.outputs.service_url }}
     steps:
@@ -367,7 +379,7 @@ jobs:
     name: Smoke test LiteLLM proxy
     runs-on: ubuntu-latest
     needs: deploy-litellm
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     env:
       SERVICE_URL: ${{ needs.deploy-litellm.outputs.service_url }}
       LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
@@ -446,7 +458,7 @@ jobs:
     name: Run DB Migrations
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Build DATABASE_URL
         shell: bash
@@ -488,7 +500,7 @@ jobs:
     name: RAG Schema Migration (staging)
     runs-on: ubuntu-latest
     needs: migrate
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Build DATABASE_URL
         shell: bash
@@ -539,7 +551,7 @@ jobs:
     name: Seed Staging Data
     runs-on: ubuntu-latest
     needs: migrate
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Build DATABASE_URL
         shell: bash
@@ -594,7 +606,7 @@ jobs:
     name: Deploy to Cloud Run (staging)
     runs-on: ubuntu-latest
     needs: rag-migrate-staging
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     env:
       IMAGE: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GAR_REPOSITORY }}/noesis2-web:${{ github.sha }}
     steps:
@@ -634,7 +646,7 @@ jobs:
     name: Smoke Test (staging)
     runs-on: ubuntu-latest
     needs: deploy-staging
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: env.RUN_CI == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Google Cloud Auth
         uses: google-github-actions/auth@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,21 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  RUN_CI: ${{ ((
+      github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.title, '[CI]') ||
+        contains(github.event.pull_request.body || '', '[CI]')
+      )
+    ) || (
+      github.event_name == 'push' &&
+      contains(join(github.event.commits.*.message, ' '), '[CI]')
+    )) && 'true' || 'false' }}
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    if: env.RUN_CI == 'true' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- add a shared RUN_CI flag to the CI and E2E workflows that turns true when "[CI]" is present in PR metadata or push commit messages
- guard lint/test/build/deploy and staging smoke jobs behind the RUN_CI flag while keeping the existing push-to-main checks intact
- allow the e2e workflow to run without the flag only when dispatched manually

## Testing
- not run (GitHub Actions workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cfb6d5c8b0832b8ae8143cef77d813