### PR TITLE
Fix Retry-After HTTP-date handling

### DIFF
--- a/ai_core/llm/client.py
+++ b/ai_core/llm/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import math
 import logging
 import random
 import time
@@ -188,7 +189,8 @@ def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
                                 tzinfo=datetime.timezone.utc
                             )
                         target_ts = retry_after_dt.timestamp()
-                        sleep_for = target_ts - time.time()
+                        delta = target_ts - time.time()
+                        sleep_for = max(0.0, float(math.ceil(delta)))
             if sleep_for is None:
                 base_delay = min(5, 2**attempt)
                 sleep_for = base_delay + random.uniform(0, 0.3)


### PR DESCRIPTION
## Summary
- round up HTTP-date Retry-After delays before sleeping to avoid resuming early
- stub `time.time()` in the rate limit test to cover the new rounding behavior deterministically

## Testing
- pytest ai_core/tests/test_llm.py -k rate_limit --maxfail=1


------
https://chatgpt.com/codex/tasks/task_e_68cfb6bf702c832bad86f4b6e02f4472