### PR TITLE
Handle tenant header separately from schema

### DIFF
--- a/ai_core/tests/test_views_min.py
+++ b/ai_core/tests/test_views_min.py
@@ -40,15 +40,17 @@ def test_scope_rate_limited(client, monkeypatch):
 def test_scope_success_persists_state(client, monkeypatch, tmp_path):
     monkeypatch.setattr(rate_limit, "check", lambda tenant, now=None: True)
     monkeypatch.setattr(object_store, "BASE_PATH", tmp_path)
+    monkeypatch.setattr("ai_core.views._resolve_tenant_id", lambda request: "resolved")
 
+    tenant_header = "tenant-header"
     resp = client.post(
         "/ai/scope/",
         data={},
         content_type="application/json",
-        HTTP_X_TENANT_ID="t1",
+        HTTP_X_TENANT_ID=tenant_header,
         HTTP_X_CASE_ID="c1",
     )
     assert resp.status_code == 200
     assert resp["X-Trace-ID"]
-    state_file = Path(tmp_path, "t1", "c1", "state.json")
+    state_file = Path(tmp_path, tenant_header, "c1", "state.json")
     assert state_file.exists()


### PR DESCRIPTION
## Summary
- validate the X-Tenant-ID header independently from the resolved schema and store the sanitized header value in request metadata
- honor an optional X-Tenant-Schema header by checking it against the active schema for defense in depth
- update ai_core view tests to cover the new tenant header behavior and ensure state persistence uses the caller-provided tenant id

## Testing
- pytest ai_core/tests/test_views_min.py ai_core/tests/test_views.py *(fails: environment lacks django_tenants PostgreSQL backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cfcab2523c832bb589a537ff3eea05