### PR TITLE
Ensure logging emits trace metadata

### DIFF
--- a/ai_core/infra/rate_limit.py
+++ b/ai_core/infra/rate_limit.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import time
 from functools import lru_cache
 from typing import Optional
@@ -10,9 +9,10 @@ from redis import Redis
 from redis.exceptions import RedisError
 
 from .config import get_config
+from common.logging import get_logger
 
 env = environ.Env()
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DEFAULT_QUOTA = 60
 

--- a/ai_core/infra/tracing.py
+++ b/ai_core/infra/tracing.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import threading
 import time
@@ -11,7 +10,12 @@ from typing import Any, Callable, TypeVar, cast
 
 import requests
 
+from common.logging import get_logger
+
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+logger = get_logger(__name__)
 
 
 def trace_meta(meta: dict[str, Any], prompt_version: str | None) -> dict[str, Any]:
@@ -49,7 +53,7 @@ def _dispatch_langfuse(trace_id: str, node_name: str, metadata: dict[str, Any]) 
         try:
             requests.post(url, json=payload, headers=headers, timeout=2)
         except Exception as exc:  # pragma: no cover - best-effort logging
-            logging.getLogger(__name__).warning("langfuse dispatch failed: %s", exc)
+            logger.warning("langfuse dispatch failed: %s", exc)
 
     threading.Thread(target=_send, daemon=True).start()
 

--- a/ai_core/llm/client.py
+++ b/ai_core/llm/client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import math
-import logging
 import random
 import time
 from email.utils import parsedate_to_datetime
@@ -13,7 +12,7 @@ import requests
 from ai_core.infra.config import get_config
 from ai_core.infra.pii import mask_prompt
 from ai_core.infra import ledger
-from common.logging import mask_value
+from common.logging import get_logger, mask_value
 from common.constants import (
     IDEMPOTENCY_KEY_HEADER,
     X_CASE_ID_HEADER,
@@ -24,7 +23,7 @@ from common.constants import (
 )
 from .routing import resolve
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class LlmClientError(Exception):

--- a/ai_core/nodes/retrieve.py
+++ b/ai_core/nodes/retrieve.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import logging
 from typing import Any, Dict, Optional, Tuple
 
 from django.conf import settings
 
 from ai_core.rag.vector_client import PgVectorClient
+from common.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def run(

--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import atexit
 import json
-import logging
 import os
 import threading
 import time
@@ -14,6 +13,8 @@ from psycopg2 import sql
 from psycopg2.extras import Json, register_default_jsonb
 from psycopg2.pool import SimpleConnectionPool
 
+from common.logging import get_logger
+
 from . import metrics
 from .filters import strict_match
 from .schemas import Chunk
@@ -21,7 +22,7 @@ from .schemas import Chunk
 # Ensure jsonb columns are decoded into Python dictionaries
 register_default_jsonb(loads=json.loads, globally=True)
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DEFAULT_STATEMENT_TIMEOUT_MS = 15000
 EMBEDDING_DIM = int(os.getenv("RAG_EMBEDDING_DIM", "1536"))

--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import logging
 from pathlib import Path
 from typing import Callable, Dict, List
 
@@ -9,11 +8,12 @@ from celery import shared_task
 from django.conf import settings
 
 from common.celery import ContextTask
+from common.logging import get_logger
 from .infra import object_store, pii
 from .rag.schemas import Chunk
 from .rag.vector_client import EMBEDDING_DIM, PgVectorClient, get_default_client
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Factory returning the default pgvector client (can be patched in tests)
 VECTOR_CLIENT_FACTORY: Callable[[], PgVectorClient] = get_default_client

--- a/ai_core/tests/test_logging_setup.py
+++ b/ai_core/tests/test_logging_setup.py
@@ -1,0 +1,55 @@
+"""Smoke tests for the structlog configuration."""
+
+from __future__ import annotations
+
+import json
+
+from opentelemetry import trace
+
+from common.logging import configure_logging, get_logger
+
+
+def _emit_log_line(capsys) -> dict[str, object]:
+    configure_logging()
+    tracer = trace.get_tracer(__name__)
+
+    with tracer.start_as_current_span("test-span"):
+        logger = get_logger(__name__)
+        logger.info("logging smoke test", foo="bar")
+
+    captured = capsys.readouterr()
+    line = captured.err.strip().splitlines()[-1]
+    payload: dict[str, object] = json.loads(line)
+
+    return payload
+
+
+def test_logging_emits_expected_json_fields(monkeypatch, capsys):
+    monkeypatch.delenv("GCP_PROJECT", raising=False)
+    payload = _emit_log_line(capsys)
+
+    for field in (
+        "timestamp",
+        "level",
+        "event",
+        "service.name",
+        "service.version",
+        "deployment.environment",
+        "trace_id",
+        "span_id",
+    ):
+        assert field in payload
+        assert isinstance(payload[field], str)
+
+    assert payload["event"] == "logging smoke test"
+    assert payload["foo"] == "bar"
+    assert "logging.googleapis.com/trace" not in payload
+
+
+def test_logging_adds_gcp_trace_when_project_present(monkeypatch, capsys):
+    monkeypatch.setenv("GCP_PROJECT", "demo-project")
+    payload = _emit_log_line(capsys)
+
+    assert payload["logging.googleapis.com/trace"].startswith(
+        "projects/demo-project/traces/"
+    )

--- a/ai_core/tests/test_rate_limit.py
+++ b/ai_core/tests/test_rate_limit.py
@@ -1,4 +1,5 @@
 import logging
+
 from redis.exceptions import RedisError
 
 from ai_core.infra import rate_limit

--- a/common/logging.py
+++ b/common/logging.py
@@ -1,31 +1,46 @@
-"""Logging helpers for enriching records with request/task context."""
+"""Structlog-based logging helpers with contextual enrichment."""
 
 from __future__ import annotations
 
 import contextlib
 import contextvars
 import logging
-from typing import Dict, Iterator
+import os
+from typing import Dict, Iterator, MutableMapping
 
-from django.conf import settings
+import structlog
+from opentelemetry import trace
+
+try:  # pragma: no cover - optional instrumentation
+    from opentelemetry.instrumentation.logging import LoggingInstrumentor
+except Exception:  # pragma: no cover - fallback when OTEL extras missing
+    LoggingInstrumentor = None  # type: ignore[assignment]
 
 __all__ = [
-    "RequestTaskContextFilter",
+    "configure_logging",
+    "get_logger",
     "bind_log_context",
     "clear_log_context",
     "get_log_context",
     "log_context",
     "mask_value",
+    "RequestTaskContextFilter",
 ]
 
 
 _CONTEXT_FIELDS: tuple[str, ...] = ("trace_id", "case_id", "tenant", "key_alias")
-
-# Store the current logging context using contextvars so it works across async
-# boundaries (Django ASGI, Celery tasks).
 _LOG_CONTEXT: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
     "log_context", default=None
 )
+
+_SERVICE_CONTEXT: dict[str, str] = {
+    "service.name": os.getenv("SERVICE_NAME", "noesis2"),
+    "service.version": os.getenv("SERVICE_VERSION", "unknown"),
+    "deployment.environment": os.getenv("DEPLOYMENT_ENVIRONMENT", "unknown"),
+}
+
+_TIME_STAMPER = structlog.processors.TimeStamper(fmt="iso", key="timestamp")
+_CONFIGURED = False
 
 
 def get_log_context() -> dict[str, str]:
@@ -63,7 +78,6 @@ def _reset_log_context(token: contextvars.Token[dict[str, str] | None]) -> None:
     try:
         _LOG_CONTEXT.reset(token)
     except ValueError:
-        # Token no longer applies; fall back to clearing the context.
         clear_log_context()
 
 
@@ -89,12 +103,161 @@ def mask_value(value: str | None) -> str:
     return f"{value[:2]}***{value[-2:]}"
 
 
+def _masking_enabled() -> bool:
+    from django.conf import settings  # imported lazily to avoid circular import
+
+    return not getattr(settings, "LOGGING_ALLOW_UNMASKED_CONTEXT", False)
+
+
+def _context_processor(
+    _: structlog.typing.WrappedLogger,
+    __: str,
+    event_dict: MutableMapping[str, object],
+) -> MutableMapping[str, object]:
+    context = get_log_context()
+    if not context:
+        return event_dict
+
+    mask = _masking_enabled()
+    for field in _CONTEXT_FIELDS:
+        raw_value = context.get(field)
+        if raw_value is None:
+            continue
+        event_dict[field] = mask_value(raw_value) if mask else str(raw_value)
+    return event_dict
+
+
+def _service_processor(
+    _: structlog.typing.WrappedLogger,
+    __: str,
+    event_dict: MutableMapping[str, object],
+) -> MutableMapping[str, object]:
+    for key, value in _SERVICE_CONTEXT.items():
+        if key not in event_dict:
+            event_dict[key] = value
+    return event_dict
+
+
+def _otel_trace_processor(
+    _: structlog.typing.WrappedLogger,
+    __: str,
+    event_dict: MutableMapping[str, object],
+) -> MutableMapping[str, object]:
+    span = trace.get_current_span()
+    span_context = span.get_span_context() if span else None
+
+    if span_context and span_context.is_valid:
+        trace_id = f"{span_context.trace_id:032x}"
+        span_id = f"{span_context.span_id:016x}"
+    else:
+        trace_id = "0" * 32
+        span_id = "0" * 16
+
+    event_dict.setdefault("trace_id", trace_id)
+    event_dict.setdefault("span_id", span_id)
+
+    gcp_project = os.getenv("GCP_PROJECT")
+    if gcp_project:
+        event_dict.setdefault(
+            "logging.googleapis.com/trace",
+            f"projects/{gcp_project}/traces/{trace_id}",
+        )
+    return event_dict
+
+
+def _redaction_processor(
+    _: structlog.typing.WrappedLogger,
+    __: str,
+    event_dict: MutableMapping[str, object],
+) -> MutableMapping[str, object]:
+    """Placeholder processor for future structured redaction hooks."""
+
+    return event_dict
+
+
+def _structlog_processors() -> list[structlog.types.Processor]:
+    return [
+        structlog.stdlib.filter_by_level,
+        _service_processor,
+        _context_processor,
+        structlog.stdlib.add_log_level,
+        _TIME_STAMPER,
+        _otel_trace_processor,
+        _redaction_processor,
+        structlog.processors.JSONRenderer(),
+    ]
+
+
+def _configure_stdlib_logging(level: int) -> None:
+    handler = logging.StreamHandler()
+    handler.setLevel(level)
+    handler.setFormatter(
+        structlog.stdlib.ProcessorFormatter(
+            processor=structlog.processors.JSONRenderer(),
+            foreign_pre_chain=[
+                _service_processor,
+                _context_processor,
+                structlog.stdlib.add_log_level,
+                _TIME_STAMPER,
+                _otel_trace_processor,
+                _redaction_processor,
+            ],
+        )
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.handlers = [handler]
+    root_logger.setLevel(level)
+
+
+def _instrument_logging() -> None:
+    if LoggingInstrumentor is None:
+        return
+    try:  # pragma: no cover - depends on optional instrumentation
+        LoggingInstrumentor().instrument(set_logging_format=False)
+    except Exception:
+        pass
+
+
+def _log_level_from_env() -> int:
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    return getattr(logging, level_name, logging.INFO)
+
+
+def configure_logging() -> None:
+    """Configure structlog and stdlib logging once."""
+
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+
+    level = _log_level_from_env()
+    _configure_stdlib_logging(level)
+
+    structlog.configure(
+        processors=_structlog_processors(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    _instrument_logging()
+    _CONFIGURED = True
+
+
+def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
+    """Return a structlog logger bound to service context."""
+
+    logger = structlog.get_logger(name) if name else structlog.get_logger()
+    return logger.bind(**_SERVICE_CONTEXT)
+
+
 class RequestTaskContextFilter(logging.Filter):
-    """Inject request/task context metadata into log records."""
+    """Inject request/task context metadata into stdlib log records."""
 
     def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
         context = get_log_context()
-        mask = not getattr(settings, "LOGGING_ALLOW_UNMASKED_CONTEXT", False)
+        mask = _masking_enabled()
 
         for field in _CONTEXT_FIELDS:
             raw_value = context.get(field)

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -1,14 +1,13 @@
-"""
-Base settings for noesis2 project.
-
-Split into base/development/production. Development and production import * from here.
-"""
+"""Base settings for noesis2 project."""
 
 import os
 from pathlib import Path
-import copy
+
 import environ
-from django.utils.log import DEFAULT_LOGGING
+
+from common.logging import configure_logging
+
+configure_logging()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 # This file is at noesis2/settings/base.py, so project root is three parents up
@@ -189,14 +188,7 @@ LOGGING_ALLOW_UNMASKED_CONTEXT = env.bool(
     "LOGGING_ALLOW_UNMASKED_CONTEXT", default=False
 )
 
-LOGGING = copy.deepcopy(DEFAULT_LOGGING)
-LOGGING["formatters"]["verbose"] = {
-    "format": (
-        "[%(asctime)s] %(levelname)s %(name)s "
-        "trace=%(trace_id)s case=%(case_id)s "
-        "tenant=%(tenant)s key_alias=%(key_alias)s %(message)s"
-    ),
-}
+LOGGING = {"version": 1, "disable_existing_loggers": False}
 
 # LiteLLM / AI Core
 LITELLM_BASE_URL = env("LITELLM_BASE_URL", default="http://localhost:4000")
@@ -204,36 +196,3 @@ LITELLM_MASTER_KEY = env("LITELLM_MASTER_KEY", default="")
 LANGFUSE_PUBLIC_KEY = env("LANGFUSE_PUBLIC_KEY", default="")
 LANGFUSE_SECRET_KEY = env("LANGFUSE_SECRET_KEY", default="")
 AI_CORE_RATE_LIMIT_QUOTA = int(env("AI_CORE_RATE_LIMIT_QUOTA", default=60))
-LOGGING["formatters"]["json"] = {
-    "()": "pythonjsonlogger.jsonlogger.JsonFormatter",
-    "fmt": (
-        "%(asctime)s %(levelname)s %(name)s %(trace_id)s %(case_id)s %(tenant)s "
-        "%(key_alias)s %(message)s"
-    ),
-}
-LOGGING.setdefault("filters", {})
-LOGGING["filters"]["request_task_context"] = {
-    "()": "common.logging.RequestTaskContextFilter",
-}
-LOGGING["handlers"]["json_console"] = {
-    "class": "logging.StreamHandler",
-    "formatter": "json",
-}
-LOGGING["handlers"]["json_console"].setdefault("filters", []).append(
-    "request_task_context"
-)
-LOGGING["handlers"]["console"].setdefault("filters", []).append("request_task_context")
-LOGGING["handlers"]["console"]["formatter"] = "verbose"
-LOGGING["root"] = {
-    "handlers": ["console"],
-    "level": "INFO",
-}
-LOGGING.setdefault("loggers", {})
-LOGGING["loggers"].setdefault(
-    "celery",
-    {
-        "handlers": ["console"],
-        "level": "INFO",
-        "propagate": False,
-    },
-)

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,9 @@ pyyaml
 redis
 requests
 gunicorn
+structlog>=24.1.0
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp
+opentelemetry-instrumentation-logging
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,6 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-colorama==0.4.6
-    # via click
 django==5.2.6
     # via
     #   -r requirements.in
@@ -38,18 +36,68 @@ django-environ==0.12.0
     # via -r requirements.in
 django-tenants==3.9.0
     # via -r requirements.in
+googleapis-common-protos==1.70.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.75.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 gunicorn==23.0.0
     # via -r requirements.in
 idna==3.10
     # via requests
+importlib-metadata==8.7.0
+    # via opentelemetry-api
 kombu==5.5.4
     # via celery
+opentelemetry-api==1.37.0
+    # via
+    #   -r requirements.in
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp==1.37.0
+    # via -r requirements.in
+opentelemetry-exporter-otlp-proto-common==1.37.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.37.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.37.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.58b0
+    # via opentelemetry-instrumentation-logging
+opentelemetry-instrumentation-logging==0.58b0
+    # via -r requirements.in
+opentelemetry-proto==1.37.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.37.0
+    # via
+    #   -r requirements.in
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.58b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
 packaging==25.0
     # via
     #   gunicorn
     #   kombu
+    #   opentelemetry-instrumentation
 prompt-toolkit==3.0.52
     # via click-repl
+protobuf==6.32.1
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psycopg2-binary==2.9.10
     # via -r requirements.in
 python-dateutil==2.9.0.post0
@@ -61,15 +109,25 @@ pyyaml==6.0.2
 redis==6.4.0
     # via -r requirements.in
 requests==2.32.5
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   opentelemetry-exporter-otlp-proto-http
 six==1.17.0
     # via python-dateutil
 sqlparse==0.5.3
     # via django
-tzdata==2025.2
+structlog==25.4.0
+    # via -r requirements.in
+typing-extensions==4.15.0
     # via
-    #   django
-    #   kombu
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+tzdata==2025.2
+    # via kombu
 urllib3==2.5.0
     # via requests
 vine==5.1.0
@@ -81,3 +139,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 whitenoise==6.9.0
     # via -r requirements.in
+wrapt==1.17.3
+    # via opentelemetry-instrumentation
+zipp==3.23.0
+    # via importlib-metadata


### PR DESCRIPTION
## Summary
- ensure the structlog OpenTelemetry processor always adds trace and span identifiers, even without an active span
- exercise the logging pipeline with a smoke test that asserts required JSON fields and optional GCP trace binding

## Testing
- pytest ai_core/tests/test_logging_setup.py *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdd39837c832ba8567ea0aba61af3