### PR TITLE
Forward traceparent header from response metadata

### DIFF
--- a/ai_core/infra/resp.py
+++ b/ai_core/infra/resp.py
@@ -12,11 +12,16 @@ from common.constants import (
 )
 
 
-Meta = Mapping[str, str]
+Meta = Mapping[str, str | None]
 
 
 def apply_std_headers(response: HttpResponse, meta: Meta) -> HttpResponse:
-    """Attach standard metadata headers to successful responses only."""
+    """Attach standard metadata headers to successful responses only.
+
+    The ``meta`` mapping may optionally include a ``traceparent`` entry. When
+    provided, the corresponding W3C trace context header is forwarded alongside
+    the standard ``X-*`` metadata headers.
+    """
 
     if not 200 <= response.status_code < 300:
         return response
@@ -26,6 +31,7 @@ def apply_std_headers(response: HttpResponse, meta: Meta) -> HttpResponse:
         X_CASE_ID_HEADER: meta.get("case"),
         X_TENANT_ID_HEADER: meta.get("tenant"),
         X_KEY_ALIAS_HEADER: meta.get("key_alias"),
+        "traceparent": meta.get("traceparent"),
     }
 
     for header, value in header_map.items():

--- a/ai_core/middleware/context.py
+++ b/ai_core/middleware/context.py
@@ -31,9 +31,6 @@ class RequestContextMiddleware:
         try:
             response = self.get_response(request)
             response = apply_std_headers(response, meta["response_meta"])
-            traceparent = meta["response_meta"].get("traceparent")
-            if traceparent:
-                response["traceparent"] = traceparent
             return response
         finally:
             clear_contextvars()

--- a/ai_core/tests/test_infra.py
+++ b/ai_core/tests/test_infra.py
@@ -40,6 +40,7 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
         "case": "case-1",
         "tenant": "tenant-1",
         "key_alias": "alias-1",
+        "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     }
 
     result = apply_std_headers(resp, meta)
@@ -48,6 +49,7 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
     assert result[X_CASE_ID_HEADER] == "case-1"
     assert result[X_TENANT_ID_HEADER] == "tenant-1"
     assert result[X_KEY_ALIAS_HEADER] == "alias-1"
+    assert result["traceparent"] == meta["traceparent"]
 
 
 def test_apply_std_headers_skips_missing_optional_headers():
@@ -58,10 +60,16 @@ def test_apply_std_headers_skips_missing_optional_headers():
 
     assert X_KEY_ALIAS_HEADER not in result
     assert result[X_TRACE_ID_HEADER] == "abc123"
+    assert "traceparent" not in result
 
 
 def test_apply_std_headers_ignores_non_success_responses():
-    meta = {"trace_id": "abc123", "case": "case-1", "tenant": "tenant-1"}
+    meta = {
+        "trace_id": "abc123",
+        "case": "case-1",
+        "tenant": "tenant-1",
+        "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    }
 
     for status in (400, 500):
         resp = HttpResponse("error", status=status)
@@ -70,6 +78,7 @@ def test_apply_std_headers_ignores_non_success_responses():
         assert X_CASE_ID_HEADER not in result
         assert X_TENANT_ID_HEADER not in result
         assert X_KEY_ALIAS_HEADER not in result
+        assert "traceparent" not in result
 
 
 def test_pii_mask_replaces_digits():


### PR DESCRIPTION
## Summary
- allow `apply_std_headers` to forward an optional `traceparent` header for successful responses
- simplify the request context middleware to rely on the shared header helper
- extend response header tests to cover `traceparent` propagation and omission

## Testing
- pytest ai_core/tests/test_infra.py *(skipped: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe6498c40832baaa0117524641b12