### PR TITLE
Update logging deployment environment handling

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -33,10 +33,20 @@ _LOG_CONTEXT: contextvars.ContextVar[dict[str, str] | None] = contextvars.Contex
     "log_context", default=None
 )
 
+def _deployment_environment() -> str:
+    """Return the deployment environment from supported environment variables."""
+
+    return (
+        os.getenv("DEPLOY_ENV")
+        or os.getenv("DEPLOYMENT_ENVIRONMENT")
+        or "unknown"
+    )
+
+
 _SERVICE_CONTEXT: dict[str, str] = {
     "service.name": os.getenv("SERVICE_NAME", "noesis2"),
     "service.version": os.getenv("SERVICE_VERSION", "unknown"),
-    "deployment.environment": os.getenv("DEPLOYMENT_ENVIRONMENT", "unknown"),
+    "deployment.environment": _deployment_environment(),
 }
 
 _TIME_STAMPER = structlog.processors.TimeStamper(fmt="iso", key="timestamp")


### PR DESCRIPTION
## Summary
- read the deployment environment from DEPLOY_ENV with a fallback to the legacy name
- default the logging deployment metadata to "unknown" when no environment variable is present
- cover the environment variable handling with tests that reload the logging module

## Testing
- pytest common/tests/test_logging.py *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe7f31650832bbfde515913da5aa2