### PR TITLE
Adjust structlog rendering for stdlib formatter

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -184,7 +184,9 @@ def _structlog_processors() -> list[structlog.types.Processor]:
         _TIME_STAMPER,
         _otel_trace_processor,
         _redaction_processor,
-        structlog.processors.JSONRenderer(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter(
+            structlog.processors.JSONRenderer()
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary
- update structlog processor chain to hand the event dict to the stdlib ProcessorFormatter for JSON rendering
- retain the stdlib ProcessorFormatter as the single JSON renderer to keep logging context consistent

## Testing
- pytest ai_core/tests/test_logging_setup.py common/tests/test_logging.py *(fails: requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe9bb7428832ba4cd3fadb31ca8ed