### PR TITLE
Use ProcessorFormatter for structlog rendering

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -184,13 +184,6 @@ def _otel_trace_processor(
 
 
 def _structlog_processors(redactor: Redactor) -> list[structlog.types.Processor]:
-    def _render_to_json(
-        logger: structlog.typing.WrappedLogger,
-        name: str,
-        event_dict: MutableMapping[str, object],
-    ) -> str:
-        return _JSON_RENDERER(logger, name, event_dict)
-
     return [
         structlog.stdlib.filter_by_level,
         _service_processor,
@@ -199,7 +192,7 @@ def _structlog_processors(redactor: Redactor) -> list[structlog.types.Processor]
         _TIME_STAMPER,
         _otel_trace_processor,
         redactor,
-        _render_to_json,
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ]
 
 


### PR DESCRIPTION
## Summary
- update structlog processor chain to hand off rendering to ProcessorFormatter
- keep stdlib ProcessorFormatter pre-chain enrichment for service, context, and tracing data

## Testing
- pytest ai_core/tests/test_logging_setup.py *(fails: skipped - requires django_tenants.postgresql_backend)*

------
https://chatgpt.com/codex/tasks/task_e_68cff09d3698832b979d25f9af37b74b