### PR TITLE
Handle logging reconfiguration streams

### DIFF
--- a/ai_core/tests/test_logging_setup.py
+++ b/ai_core/tests/test_logging_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 
 from opentelemetry import trace
@@ -53,3 +54,19 @@ def test_logging_adds_gcp_trace_when_project_present(monkeypatch, capsys):
     assert payload["logging.googleapis.com/trace"].startswith(
         "projects/demo-project/traces/"
     )
+
+
+def test_configure_logging_switches_streams(capsys):
+    configure_logging()
+    logger = get_logger(__name__)
+    logger.info("first-capture")
+
+    first_capture = capsys.readouterr().err
+    assert "first-capture" in first_capture
+
+    alt_stream = io.StringIO()
+    configure_logging(stream=alt_stream)
+    logger.info("second-capture")
+
+    assert "second-capture" in alt_stream.getvalue()
+    assert "second-capture" not in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- track the currently configured logging stream and re-run stdlib setup when it changes
- allow the stdlib handler to be rebuilt or retargeted for the active stream
- extend logging smoke tests to cover multiple configure_logging invocations

## Testing
- pytest ai_core/tests/test_logging_setup.py


------
https://chatgpt.com/codex/tasks/task_e_68cff097be24832b8fbb53b3b272806f