### PR TITLE
Use pre-sanitized prompts in LLM client

### DIFF
--- a/ai_core/llm/client.py
+++ b/ai_core/llm/client.py
@@ -10,7 +10,6 @@ from typing import Any, Dict
 import requests
 
 from ai_core.infra.config import get_config
-from ai_core.infra.pii import mask_prompt
 from ai_core.infra import ledger
 from common.logging import get_logger, mask_value
 from common.constants import (
@@ -87,8 +86,6 @@ def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
     """
 
     model_id = resolve(label)
-    prompt_safe = mask_prompt(prompt, placeholder_only=True)
-
     cfg = get_config()
     url = f"{cfg.litellm_base_url.rstrip('/')}/v1/chat/completions"
     headers = {"Authorization": f"Bearer {cfg.litellm_api_key}"}
@@ -103,7 +100,7 @@ def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
     headers.update({k: v for k, v in propagated_headers.items() if v})
     payload = {
         "model": model_id,
-        "messages": [{"role": "user", "content": prompt_safe}],
+        "messages": [{"role": "user", "content": prompt}],
     }
 
     max_retries = 3


### PR DESCRIPTION
## Summary
- stop re-masking prompts in the LLM client and rely on the sanitized input from upstream nodes
- update LLM and node unit tests to validate the full sanitized prompt content

## Testing
- `pytest ai_core/tests/test_llm.py ai_core/tests/test_nodes.py` *(fails: repository expects the django-tenants PostgreSQL backend which is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d05dfbed48832bbf0a8dedbe6a98e5