### PR TITLE
Ensure prompt loader uses numeric version ordering

### DIFF
--- a/ai_core/infra/prompts.py
+++ b/ai_core/infra/prompts.py
@@ -21,10 +21,20 @@ def load(alias: str) -> Dict[str, str]:
     if not candidates:
         raise FileNotFoundError(f"No prompt for alias '{alias}'")
 
-    prompt_file = candidates[-1]
-    match = re.search(r"\.v(\d+)\.md$", prompt_file.name)
-    if not match:
-        raise ValueError(f"Invalid prompt filename: {prompt_file.name}")
-    version = f"v{match.group(1)}"
+    valid_candidates = []
+    for candidate in candidates:
+        match = re.search(r"\.v(\d+)\.md$", candidate.name)
+        if not match:
+            continue
+        valid_candidates.append((int(match.group(1)), match.group(1), candidate))
+
+    if not valid_candidates:
+        invalid_files = ", ".join(path.name for path in candidates)
+        raise ValueError(
+            f"No valid prompt filename found for alias '{alias}'. Candidates: {invalid_files}"
+        )
+
+    _, version_str, prompt_file = max(valid_candidates, key=lambda item: item[0])
+    version = f"v{version_str}"
     text = prompt_file.read_text(encoding="utf-8")
     return {"version": version, "text": text}

--- a/ai_core/prompts/testdata/multi.v1.md
+++ b/ai_core/prompts/testdata/multi.v1.md
@@ -1,0 +1,1 @@
+Test prompt version 1

--- a/ai_core/prompts/testdata/multi.v10.md
+++ b/ai_core/prompts/testdata/multi.v10.md
@@ -1,0 +1,1 @@
+Test prompt version 10

--- a/ai_core/prompts/testdata/multi.v11.md
+++ b/ai_core/prompts/testdata/multi.v11.md
@@ -1,0 +1,1 @@
+Test prompt version 11

--- a/ai_core/prompts/testdata/multi.v2.md
+++ b/ai_core/prompts/testdata/multi.v2.md
@@ -1,0 +1,1 @@
+Test prompt version 2

--- a/ai_core/prompts/testdata/multi.v3.md
+++ b/ai_core/prompts/testdata/multi.v3.md
@@ -1,0 +1,1 @@
+Test prompt version 3

--- a/ai_core/prompts/testdata/multi.v4.md
+++ b/ai_core/prompts/testdata/multi.v4.md
@@ -1,0 +1,1 @@
+Test prompt version 4

--- a/ai_core/prompts/testdata/multi.v5.md
+++ b/ai_core/prompts/testdata/multi.v5.md
@@ -1,0 +1,1 @@
+Test prompt version 5

--- a/ai_core/prompts/testdata/multi.v6.md
+++ b/ai_core/prompts/testdata/multi.v6.md
@@ -1,0 +1,1 @@
+Test prompt version 6

--- a/ai_core/prompts/testdata/multi.v7.md
+++ b/ai_core/prompts/testdata/multi.v7.md
@@ -1,0 +1,1 @@
+Test prompt version 7

--- a/ai_core/prompts/testdata/multi.v8.md
+++ b/ai_core/prompts/testdata/multi.v8.md
@@ -1,0 +1,1 @@
+Test prompt version 8

--- a/ai_core/prompts/testdata/multi.v9.md
+++ b/ai_core/prompts/testdata/multi.v9.md
@@ -1,0 +1,1 @@
+Test prompt version 9

--- a/ai_core/tests/test_prompts.py
+++ b/ai_core/tests/test_prompts.py
@@ -5,3 +5,9 @@ def test_load_finds_prompt_and_version():
     data = load("retriever/answer")
     assert data["version"] == "v1"
     assert "Beantworte die Frage faktenbasiert" in data["text"]
+
+
+def test_load_prefers_highest_numeric_version():
+    data = load("testdata/multi")
+    assert data["version"] == "v11"
+    assert "Test prompt version 11" in data["text"]


### PR DESCRIPTION
## Summary
- select prompt files by the highest numeric version suffix instead of lexical order
- add test prompt fixtures and a regression test covering two-digit versions

## Testing
- pytest ai_core/tests/test_prompts.py *(fails: skipped by environment requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68d05dfdf738832b9339cf6c9ede3717