### PR TITLE
Reorder prompts module imports

### DIFF
--- a/ai_core/infra/prompts.py
+++ b/ai_core/infra/prompts.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import re
-from pathlib import Path
-from typing import Dict
-
 from functools import lru_cache
+from pathlib import Path
+import re
+from typing import Dict
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
## Summary
- reorder the standard library imports in `ai_core/infra/prompts.py`
- run Black to ensure formatting consistency

## Testing
- python -m black ai_core/infra/prompts.py

------
https://chatgpt.com/codex/tasks/task_e_68d05e5a0dfc832bbb7398b33e31cd66