### PR TITLE
Refactor prompt-driven nodes with shared helper

### DIFF
--- a/ai_core/nodes/_prompt_runner.py
+++ b/ai_core/nodes/_prompt_runner.py
@@ -1,0 +1,52 @@
+"""Utilities for running simple prompt-based nodes."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from ai_core.infra.prompts import load
+from ai_core.infra.pii import mask_prompt
+from ai_core.infra.tracing import trace
+from ai_core.llm import client
+
+
+ResultShaper = Callable[[Dict[str, Any]], Tuple[Any, Dict[str, Any]]]
+
+
+def run_prompt_node(
+    *,
+    trace_name: str,
+    prompt_alias: str,
+    llm_label: str,
+    state_key: str,
+    state: Dict[str, Any],
+    meta: Dict[str, str],
+    result_shaper: Optional[ResultShaper] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Execute a prompt-driven node with shared boilerplate logic."""
+
+    prompt = load(prompt_alias)
+    meta["prompt_version"] = prompt["version"]
+    meta_with_version = dict(meta)
+
+    @trace(trace_name)
+    def _execute(
+        current_state: Dict[str, Any], *, meta: Dict[str, str]
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        base = current_state.get("text", "")
+        full_prompt = f"{prompt['text']}\n\n{base}"
+        masked = mask_prompt(full_prompt)
+        result = client.call(llm_label, masked, meta)
+
+        if result_shaper is not None:
+            value, metadata_extra = result_shaper(result)
+        else:
+            value, metadata_extra = result["text"], {}
+
+        new_state = dict(current_state)
+        new_state[state_key] = value
+
+        node_meta = {state_key: value, **metadata_extra, "prompt_version": prompt["version"]}
+        return new_state, node_meta
+
+    return _execute(state, meta=meta_with_version)

--- a/ai_core/nodes/assess.py
+++ b/ai_core/nodes/assess.py
@@ -2,30 +2,18 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple
 
-from ai_core.infra.prompts import load
-from ai_core.infra.pii import mask_prompt
-from ai_core.infra.tracing import trace
-from ai_core.llm import client
+from ai_core.nodes._prompt_runner import run_prompt_node
 
 
 def run(
     state: Dict[str, Any], meta: Dict[str, str]
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Assess risks for the provided text."""
-    prompt = load("assess/risk")
-    meta["prompt_version"] = prompt["version"]
-    meta_with_version = dict(meta)
-    return _run(prompt, state, meta=meta_with_version)
-
-
-@trace("assess")
-def _run(
-    prompt: Dict[str, str], state: Dict[str, Any], *, meta: Dict[str, str]
-) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    base = state.get("text", "")
-    full_prompt = f"{prompt['text']}\n\n{base}"
-    masked = mask_prompt(full_prompt)
-    result = client.call("analyze", masked, meta)
-    new_state = dict(state)
-    new_state["risk"] = result["text"]
-    return new_state, {"risk": result["text"], "prompt_version": prompt["version"]}
+    return run_prompt_node(
+        trace_name="assess",
+        prompt_alias="assess/risk",
+        llm_label="analyze",
+        state_key="risk",
+        state=state,
+        meta=meta,
+    )

--- a/ai_core/nodes/classify.py
+++ b/ai_core/nodes/classify.py
@@ -2,33 +2,18 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple
 
-from ai_core.infra.prompts import load
-from ai_core.infra.pii import mask_prompt
-from ai_core.infra.tracing import trace
-from ai_core.llm import client
+from ai_core.nodes._prompt_runner import run_prompt_node
 
 
 def run(
     state: Dict[str, Any], meta: Dict[str, str]
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Classify text regarding co-determination."""
-    prompt = load("classify/mitbestimmung")
-    meta["prompt_version"] = prompt["version"]
-    meta_with_version = dict(meta)
-    return _run(prompt, state, meta=meta_with_version)
-
-
-@trace("classify")
-def _run(
-    prompt: Dict[str, str], state: Dict[str, Any], *, meta: Dict[str, str]
-) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    base = state.get("text", "")
-    full_prompt = f"{prompt['text']}\n\n{base}"
-    masked = mask_prompt(full_prompt)
-    result = client.call("classify", masked, meta)
-    new_state = dict(state)
-    new_state["classification"] = result["text"]
-    return new_state, {
-        "classification": result["text"],
-        "prompt_version": prompt["version"],
-    }
+    return run_prompt_node(
+        trace_name="classify",
+        prompt_alias="classify/mitbestimmung",
+        llm_label="classify",
+        state_key="classification",
+        state=state,
+        meta=meta,
+    )

--- a/ai_core/nodes/extract.py
+++ b/ai_core/nodes/extract.py
@@ -2,30 +2,18 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple
 
-from ai_core.infra.prompts import load
-from ai_core.infra.pii import mask_prompt
-from ai_core.infra.tracing import trace
-from ai_core.llm import client
+from ai_core.nodes._prompt_runner import run_prompt_node
 
 
 def run(
     state: Dict[str, Any], meta: Dict[str, str]
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Extract items and facts from text using the LLM."""
-    prompt = load("extract/items")
-    meta["prompt_version"] = prompt["version"]
-    meta_with_version = dict(meta)
-    return _run(prompt, state, meta=meta_with_version)
-
-
-@trace("extract")
-def _run(
-    prompt: Dict[str, str], state: Dict[str, Any], *, meta: Dict[str, str]
-) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    base = state.get("text", "")
-    full_prompt = f"{prompt['text']}\n\n{base}"
-    masked = mask_prompt(full_prompt)
-    result = client.call("extract", masked, meta)
-    new_state = dict(state)
-    new_state["items"] = result["text"]
-    return new_state, {"items": result["text"], "prompt_version": prompt["version"]}
+    return run_prompt_node(
+        trace_name="extract",
+        prompt_alias="extract/items",
+        llm_label="extract",
+        state_key="items",
+        state=state,
+        meta=meta,
+    )

--- a/ai_core/tests/test_nodes.py
+++ b/ai_core/tests/test_nodes.py
@@ -9,6 +9,7 @@ from ai_core.nodes import (
     draft_blocks,
     needs,
 )
+from ai_core.nodes._prompt_runner import run_prompt_node
 from ai_core.rag.schemas import Chunk
 
 META = {"tenant": "t1", "case": "c1", "trace_id": "tr"}
@@ -91,6 +92,77 @@ def test_extract_classify_assess(monkeypatch):
     new_state, _ = assess.run(state, META.copy())
     assert called["label"] == "analyze"
     assert new_state["risk"] == "resp"
+
+
+def test_prompt_runner_default(monkeypatch):
+    called = {}
+
+    def fake_load(alias):
+        called["alias"] = alias
+        return {"text": "Prompt", "version": "v42"}
+
+    def fake_mask(value):
+        called["masked"] = value
+        return value
+
+    def fake_call(label, prompt, metadata):
+        called["label"] = label
+        called["prompt"] = prompt
+        called["meta"] = metadata
+        return {"text": "resp"}
+
+    monkeypatch.setattr("ai_core.nodes._prompt_runner.load", fake_load)
+    monkeypatch.setattr("ai_core.nodes._prompt_runner.mask_prompt", fake_mask)
+    monkeypatch.setattr("ai_core.nodes._prompt_runner.client.call", fake_call)
+
+    state = {"text": "Sensitive"}
+    meta = META.copy()
+    new_state, node_meta = run_prompt_node(
+        trace_name="unit",
+        prompt_alias="scope/test",
+        llm_label="label",
+        state_key="result",
+        state=state,
+        meta=meta,
+    )
+
+    assert called["alias"] == "scope/test"
+    assert called["label"] == "label"
+    assert called["prompt"].endswith("\n\nSensitive")
+    assert called["meta"]["prompt_version"] == "v42"
+    assert meta["prompt_version"] == "v42"
+    assert new_state["result"] == "resp"
+    assert node_meta == {"result": "resp", "prompt_version": "v42"}
+
+
+def test_prompt_runner_with_result_shaper(monkeypatch):
+    monkeypatch.setattr(
+        "ai_core.nodes._prompt_runner.load",
+        lambda alias: {"text": "Prompt", "version": "v1"},
+    )
+    monkeypatch.setattr(
+        "ai_core.nodes._prompt_runner.mask_prompt", lambda value: value
+    )
+
+    def fake_call(label, prompt, metadata):
+        return {"text": "resp", "usage": {}}
+
+    monkeypatch.setattr("ai_core.nodes._prompt_runner.client.call", fake_call)
+
+    shaped_state, shaped_meta = run_prompt_node(
+        trace_name="unit",
+        prompt_alias="alias",
+        llm_label="label",
+        state_key="value",
+        state={},
+        meta=META.copy(),
+        result_shaper=lambda result: (result["text"].upper(), {"raw": result["text"]}),
+    )
+
+    assert shaped_state["value"] == "RESP"
+    assert shaped_meta["value"] == "RESP"
+    assert shaped_meta["raw"] == "resp"
+    assert shaped_meta["prompt_version"] == "v1"
 
 
 def test_draft_blocks(monkeypatch):


### PR DESCRIPTION
## Summary
- add a reusable `run_prompt_node` helper that loads prompts, handles tracing, and updates node state consistently
- refactor the assess, classify, and extract nodes to delegate to the helper instead of duplicating prompt orchestration logic
- extend node unit tests to exercise the helper (default and shaped results) while ensuring the existing nodes behave the same

## Testing
- SECRET_KEY=dummy DATABASE_URL=postgres://user:pass@localhost:5432/db REDIS_URL=redis://localhost:6379/0 DJANGO_SETTINGS_MODULE=noesis2.settings.base pytest ai_core/tests/test_nodes.py -q *(fails: requires running PostgreSQL instance)*

------
https://chatgpt.com/codex/tasks/task_e_68d05e879ad0832baa37b678965309a4