### PR TITLE
Skip Langfuse dispatch without trace id

### DIFF
--- a/ai_core/infra/tracing.py
+++ b/ai_core/infra/tracing.py
@@ -142,15 +142,20 @@ def trace(node_name: str) -> Callable[[F], F]:
                 }
                 _log(end_payload)
 
-                _dispatch_langfuse(
-                    trace_id=str(meta_enriched.get("trace_id")),
-                    node_name=node_name,
-                    metadata={
-                        "tenant": meta_enriched.get("tenant"),
-                        "case": meta_enriched.get("case"),
-                        "prompt_version": meta_enriched.get("prompt_version"),
-                    },
-                )
+                trace_id = meta_enriched.get("trace_id")
+                if isinstance(trace_id, str):
+                    trace_id = trace_id.strip()
+
+                if trace_id:
+                    _dispatch_langfuse(
+                        trace_id=str(trace_id),
+                        node_name=node_name,
+                        metadata={
+                            "tenant": meta_enriched.get("tenant"),
+                            "case": meta_enriched.get("case"),
+                            "prompt_version": meta_enriched.get("prompt_version"),
+                        },
+                    )
 
         return cast(F, wrapped)
 


### PR DESCRIPTION
## Summary
- ensure Langfuse dispatch is only triggered when a non-empty trace id is available
- cover the missing trace-id scenario with a dedicated tracing unit test

## Testing
- `pytest ai_core/tests/test_infra.py`

------
https://chatgpt.com/codex/tasks/task_e_68d0686f3d68832bbbfe5f798fa7758d