### PR TITLE
Ensure OTEL trace IDs fallback to strings

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -172,8 +172,11 @@ def _otel_trace_processor(
         trace_id = f"{span_context.trace_id:032x}"
         span_id = f"{span_context.span_id:016x}"
 
-    event_dict.setdefault("trace_id", trace_id)
-    event_dict.setdefault("span_id", span_id)
+    trace_id_value = trace_id if trace_id is not None else ""
+    span_id_value = span_id if span_id is not None else ""
+
+    event_dict.setdefault("trace_id", trace_id_value)
+    event_dict.setdefault("span_id", span_id_value)
 
     if trace_id:
         gcp_project = os.getenv("GCP_PROJECT")


### PR DESCRIPTION
## Summary
- ensure the OTEL trace processor injects empty-string defaults when no valid span context exists
- extend logging setup tests to cover invalid span contexts and enforce string-based IDs

## Testing
- pytest ai_core/tests/test_logging_setup.py *(fails: missing customers_tenant relation in test database)*

------
https://chatgpt.com/codex/tasks/task_e_68d11e7a5d10832bb4533c420c1de355