### PR TITLE
Add ELK stack development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+docker/elk/*.json
 
 # Local model routing override (for dev)
 MODEL_ROUTING.local.yaml

--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ Best Practice: In Dev einen gemeinsamen DB‑User für App und LiteLLM verwenden
 
 Hinweis: `MODEL_ROUTING.local.yaml` ist git‑ignored und überschreibt nur lokal. In Prod wird ausschließlich `MODEL_ROUTING.yaml` verwendet.
 
+## Observability
+
+- [Langfuse Guide](docs/observability/langfuse.md)
+- [ELK Stack für lokale Entwicklung](docs/observability/elk.md) — Oneshot-Bootstrap: `bash scripts/dev-up-all.sh`
+
 ## GCloud Bootstrap (Windows)
 Mit dem Skript `scripts/gcloud-bootstrap.ps1` kannst du dich per `gcloud` anmelden, ein Projekt/Region wählen und häufige Laufzeitwerte aus GCP sammeln (Redis, Cloud SQL, Cloud Run URLs). Die Werte werden sicher in `.env.gcloud` geschrieben (Git-ignored) und können selektiv in deine `.env` übernommen werden.
 

--- a/docker/elk/Dockerfile
+++ b/docker/elk/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.elastic.co/logstash/logstash:8.13.4
+
+USER root
+RUN /usr/share/logstash/bin/logstash-plugin install logstash-input-google_pubsub \
+    && mkdir -p /var/log/noesis \
+    && chown -R logstash:logstash /var/log/noesis
+USER logstash
+
+COPY pipeline.conf /usr/share/logstash/pipeline/pipeline.conf
+COPY logstash.yml /usr/share/logstash/config/logstash.yml
+
+VOLUME ["/var/log/noesis"]
+

--- a/docker/elk/docker-compose.gcloud.yml
+++ b/docker/elk/docker-compose.gcloud.yml
@@ -1,0 +1,12 @@
+services:
+  logstash:
+    environment:
+      GCP_PROJECT_ID: ${GCP_PROJECT_ID:?Set GCP_PROJECT_ID}
+      GCP_PUBSUB_TOPIC: ${GCP_PUBSUB_TOPIC:?Set GCP_PUBSUB_TOPIC}
+      GCP_PUBSUB_SUBSCRIPTION: ${GCP_PUBSUB_SUBSCRIPTION:?Set GCP_PUBSUB_SUBSCRIPTION}
+      GCP_CREDENTIALS_FILE: ${GCP_CREDENTIALS_FILE:-/usr/share/logstash/config/gcp-service-account.json}
+    volumes:
+      - type: bind
+        source: ${GCP_CREDENTIALS_PATH:?Point to service account JSON}
+        target: ${GCP_CREDENTIALS_FILE:-/usr/share/logstash/config/gcp-service-account.json}
+        read_only: true

--- a/docker/elk/docker-compose.yml
+++ b/docker/elk/docker-compose.yml
@@ -1,0 +1,66 @@
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: noesis-elasticsearch
+    environment:
+      - node.name=elasticsearch
+      - cluster.name=noesis-elk
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-changeme}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200 | grep -q 'cluster_name'"]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+      start_period: 20s
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.13.4
+    container_name: noesis-kibana
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD=${KIBANA_SYSTEM_PASSWORD:-changeme}
+      - SERVER_PUBLICBASEURL=${KIBANA_PUBLIC_URL:-http://localhost:5601}
+    ports:
+      - "5601:5601"
+
+  logstash:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: noesis-logstash:8.13.4
+    container_name: noesis-logstash
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-changeme}
+      ELASTICSEARCH_HOST: http://elasticsearch:9200
+      GCP_PROJECT_ID: ${GCP_PROJECT_ID:-}
+      GCP_PUBSUB_TOPIC: ${GCP_PUBSUB_TOPIC:-}
+      GCP_PUBSUB_SUBSCRIPTION: ${GCP_PUBSUB_SUBSCRIPTION:-}
+      GCP_CREDENTIALS_FILE: ${GCP_CREDENTIALS_FILE:-/usr/share/logstash/config/gcp-service-account.json}
+    volumes:
+      - ${APP_LOG_PATH:-../../logs/app}:/var/log/noesis:ro
+    ports:
+      - "5044:5044"
+
+volumes:
+  es-data:

--- a/docker/elk/logstash.yml
+++ b/docker/elk/logstash.yml
@@ -1,0 +1,5 @@
+http.host: "0.0.0.0"
+path.logs: /usr/share/logstash/logs
+log.level: info
+xpack.monitoring.enabled: false
+pipeline.ecs_compatibility: disabled

--- a/docker/elk/pipeline.conf
+++ b/docker/elk/pipeline.conf
@@ -1,0 +1,44 @@
+input {
+  beats {
+    port => 5044
+  }
+  file {
+    path => "/var/log/noesis/*.log"
+    start_position => "beginning"
+    sincedb_path => "/usr/share/logstash/data/plugins/inputs/file/.sincedb"
+  }
+  if "${GCP_PUBSUB_SUBSCRIPTION}" != "" {
+    google_pubsub {
+      project_id => "${GCP_PROJECT_ID}"
+      topic => "${GCP_PUBSUB_TOPIC}"
+      subscription => "${GCP_PUBSUB_SUBSCRIPTION}"
+      json_key_file => "${GCP_CREDENTIALS_FILE:/usr/share/logstash/config/gcp-service-account.json}"
+      include_metadata => true
+    }
+  }
+}
+
+filter {
+  json {
+    source => "message"
+    skip_on_invalid_json => true
+  }
+  date {
+    match => ["timestamp", "ISO8601", "yyyy-MM-dd HH:mm:ss,SSS"]
+    target => "@timestamp"
+    remove_if_invalid => true
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["${ELASTICSEARCH_HOST:http://elasticsearch:9200}"]
+    user => "elastic"
+    password => "${ELASTIC_PASSWORD}"
+    index => "noesis-app-%{+YYYY.MM.dd}"
+    ssl => false
+  }
+  stdout {
+    codec => json
+  }
+}

--- a/docs/observability/elk.md
+++ b/docs/observability/elk.md
@@ -1,0 +1,91 @@
+# ELK Stack für lokale Entwicklung
+
+Die Elastic-Komponenten laufen in einem separaten Compose-Stack unter `docker/elk`. Die Konfiguration ist für Entwicklungszwecke gedacht und verzichtet auf TLS-Zertifikate, erfordert aber Dev-Passwörter.
+
+## Voraussetzungen
+- Docker und Docker Compose v2
+- Ausreichend Arbeitsspeicher (mind. 4 GB RAM für Elasticsearch + Kibana)
+- Ein Verzeichnis mit Anwendungs-Logs im JSON-Format (Standard: `logs/app/*.log`)
+
+## Starten
+```bash
+# Gesamtes Dev-Setup (App + ELK) von Grund auf bauen & starten
+bash scripts/dev-up-all.sh
+
+# Nur den ELK-Stack starten (wenn App bereits läuft)
+docker compose -f docker/elk/docker-compose.yml up -d
+```
+
+Das Oneshot-Skript `scripts/dev-up-all.sh` führt folgende Schritte aus:
+
+1. Baut die lokalen Docker-Images für Anwendung und ELK-Stack.
+2. Startet beide Compose-Stacks.
+3. Wartet, bis der Web-Service reagiert, und führt `npm run dev:init` (Migrationen, Bootstrap) aus.
+
+Dabei legt es das Log-Verzeichnis (`APP_LOG_PATH`, Standard `logs/app`) automatisch an.
+
+Vor dem Start können folgende Variablen gesetzt werden:
+
+| Variable | Zweck | Default |
+| --- | --- | --- |
+| `ELASTIC_PASSWORD` | Passwort für den `elastic`-User | `changeme` |
+| `KIBANA_SYSTEM_PASSWORD` | Passwort für den `kibana_system`-Account | `changeme` |
+| `APP_LOG_PATH` | Pfad zum Log-Verzeichnis der Anwendung | `../../logs/app` relativ zu `docker/elk` |
+| `KIBANA_PUBLIC_URL` | Öffentliche URL (Proxy) für Kibana | `http://localhost:5601` |
+
+Die Logs werden schreibgeschützt unter `/var/log/noesis` im Logstash-Container gemountet. Der Stack öffnet folgende Ports:
+
+- `9200` für Elasticsearch (Basic Auth: `elastic` + `ELASTIC_PASSWORD`)
+- `5601` für Kibana (Login: `elastic` + `ELASTIC_PASSWORD`, oder `kibana_system` per API)
+- `5044` für Beats-Inputs (optional, z. B. Filebeat)
+
+## Nutzung
+1. Kibana ist nach dem Start unter [http://localhost:5601](http://localhost:5601) erreichbar. Melde dich mit dem `elastic`-Benutzer an.
+2. Logstash liest lokale JSON-Logs (`timestamp`-Feld empfohlen) aus dem gemounteten Verzeichnis und schreibt sie in Indizes `noesis-app-*`.
+3. Für Filebeat-Setups kann `localhost:5044` als Ziel genutzt werden. Zertifikate müssen ggf. ergänzt werden.
+
+## Betrieb in Google Cloud
+Für produktionsnahe Tests nutzen wir die Google-Cloud-Logging-Pipeline als Quelle. Die Logstash-Konfiguration enthält dafür einen optionalen `google_pubsub`-Input. Vorgehen:
+
+1. **Cloud Logging → Pub/Sub**
+   ```bash
+   gcloud logging sinks create noesis-elk \
+     pubsub.googleapis.com/projects/$PROJECT_ID/topics/noesis-elk \
+     --log-filter='resource.type=("cloud_run_revision" OR "k8s_container")'
+
+   gcloud pubsub subscriptions create noesis-elk-sub \
+     --topic=noesis-elk --ack-deadline=30
+   ```
+   Der Sink streamt Cloud-Run- bzw. GKE-Container-Logs in das Pub/Sub-Topic.
+
+2. **Service Account für Logstash**
+   ```bash
+   gcloud iam service-accounts create logstash-subscriber --project $PROJECT_ID
+   gcloud pubsub subscriptions add-iam-policy-binding noesis-elk-sub \
+     --member="serviceAccount:logstash-subscriber@$PROJECT_ID.iam.gserviceaccount.com" \
+     --role="roles/pubsub.subscriber"
+   gcloud iam service-accounts keys create ~/Downloads/noesis-logstash.json \
+     --iam-account logstash-subscriber@$PROJECT_ID.iam.gserviceaccount.com
+   ```
+   Die JSON-Datei bleibt außerhalb des Repos und wird später gemountet.
+
+3. **Compose-Stack mit Pub/Sub-Empfang starten**
+   ```bash
+   export GCP_PROJECT_ID=$PROJECT_ID
+   export GCP_PUBSUB_TOPIC=noesis-elk
+   export GCP_PUBSUB_SUBSCRIPTION=noesis-elk-sub
+   export GCP_CREDENTIALS_PATH=~/Downloads/noesis-logstash.json
+
+   docker compose \
+     -f docker/elk/docker-compose.yml \
+     -f docker/elk/docker-compose.gcloud.yml \
+     up
+   ```
+   Standardmäßig erwartet Logstash die Credentials unter `/usr/share/logstash/config/gcp-service-account.json`. Du kannst den Zielpfad mit `GCP_CREDENTIALS_FILE` überschreiben.
+
+Die GCP-Pfade ergänzen die lokale Volume-Quelle; beide Inputs (Datei + Pub/Sub) können parallel aktiv sein. Für produktive Workloads sollten Pub/Sub-Acks überwacht und Retention/Dead-Letter-Queues konfiguriert werden.
+
+## Bekannte Einschränkungen
+- Elasticsearch benötigt ca. 4 GB RAM; auf schwächeren Maschinen kann der Dienst nicht starten.
+- TLS ist deaktiviert. Für produktionsnahe Tests müssen Zertifikate und Transportverschlüsselung ergänzt werden.
+- Standard-Logformat erwartet JSON mit einem `timestamp`-Feld. Andere Formate erfordern Anpassungen in `docker/elk/pipeline.conf`.

--- a/scripts/dev-up-all.sh
+++ b/scripts/dev-up-all.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap both the application stack and the local ELK stack for development.
+
+if [ ! -f .env ]; then
+  echo "[dev-up-all] Fehler: Keine .env im Projektstamm gefunden." >&2
+  echo "[dev-up-all] Bitte .env.example nach .env kopieren und Werte anpassen." >&2
+  exit 1
+fi
+
+APP_COMPOSE="docker compose -f docker-compose.yml -f docker-compose.dev.yml"
+ELK_COMPOSE="docker compose -f docker/elk/docker-compose.yml"
+
+APP_LOG_PATH=${APP_LOG_PATH:-"$(pwd)/logs/app"}
+export APP_LOG_PATH
+
+mkdir -p "$APP_LOG_PATH"
+echo "[dev-up-all] Log-Verzeichnis: $APP_LOG_PATH"
+
+echo "[dev-up-all] Building application stack images"
+$APP_COMPOSE build
+
+echo "[dev-up-all] Building ELK stack images"
+$ELK_COMPOSE build
+
+echo "[dev-up-all] Starting application stack"
+$APP_COMPOSE up -d
+
+echo "[dev-up-all] Starting ELK stack"
+$ELK_COMPOSE up -d
+
+echo "[dev-up-all] Waiting for web to respond (warm-up)"
+for i in {1..20}; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/ai/ping/ || true)
+  if [ -n "$code" ] && [ "$code" -ge 200 ] && [ "$code" -lt 500 ]; then
+    echo "[dev-up-all] Web responded with HTTP $code"
+    break
+  fi
+  sleep 1
+
+done
+
+echo "[dev-up-all] Running migrations and bootstrap tasks"
+npm run dev:init
+
+echo "[dev-up-all] Done. Kibana läuft unter http://localhost:5601 (ELASTIC_PASSWORD erforderlich)."


### PR DESCRIPTION
## Summary
- add a dedicated Logstash image that bundles the pipeline and configuration for ingesting application logs
- provide a docker compose stack with Elasticsearch, Kibana and the custom Logstash service, including development credentials and volume mounts
- document the ELK setup, including Google Cloud Pub/Sub ingestion, and link it from the README’s Observability section
- add a one-shot development bootstrap script that builds and starts both the core stack and the ELK stack

## Testing
- `pytest -q` *(fails: PYTEST_ADDOPTS expects a config path in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d311b3b1a8832bb27e15a16f606e83