### PR TITLE
Fix legacy PII masking of numeric tokens

### DIFF
--- a/ai_core/infra/pii.py
+++ b/ai_core/infra/pii.py
@@ -194,8 +194,6 @@ def mask_text(
     )
 
     for tag, pattern in _PII_PATTERNS:
-        if rules is None and tag == "NUMBER":
-            continue
         if rules is not None and tag not in rules:
             continue
 


### PR DESCRIPTION
## Summary
- allow the legacy `pii.mask` helper to redact numeric sequences again by always iterating over the NUMBER detector

## Testing
- PYTEST_ADDOPTS="-c pytest.ini" pytest ai_core/tests/test_infra.py::test_pii_mask_replaces_digits -q

------
https://chatgpt.com/codex/tasks/task_e_68d3b73df424832b83d24ab9999600ae