### PR TITLE
Import agent graphs into views

### DIFF
--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -40,6 +40,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .graphs import info_intake, needs_mapping, scope_check, system_description
 from .infra import rate_limit
 from .infra.object_store import read_json, sanitize_identifier, write_json
 from .infra.resp import apply_std_headers


### PR DESCRIPTION
## Summary
- import the agent graph modules into `ai_core.views` so graph lookups expose the expected attributes

## Testing
- PYTEST_ADDOPTS= pytest ai_core/tests/test_views.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d4e43cafcc832bb07112ad2ba63d17