### PR TITLE
Align app and ELK log path environment variables

### DIFF
--- a/.env.dev-elk
+++ b/.env.dev-elk
@@ -8,3 +8,4 @@ KIBANA_PASSWORD=changeme
 KIBANA_PUBLIC_URL=http://localhost:5601
 # Logs liegen standardmäßig unter logs/app (relativ zum Repo).
 APP_LOG_PATH=./logs/app
+APP_LOG_DIR=./logs/app

--- a/docs/observability/elk.md
+++ b/docs/observability/elk.md
@@ -51,6 +51,7 @@ Vor dem Start können folgende Variablen gesetzt werden:
 | `ELASTIC_PASSWORD` | Passwort für den `elastic`-User | `changeme` |
 | `KIBANA_SYSTEM_PASSWORD` | Passwort für den `kibana_system`-Account | `changeme` |
 | `APP_LOG_PATH` | Pfad zum Log-Verzeichnis der Anwendung | `../../logs/app` relativ zu `docker/elk` |
+| `APP_LOG_DIR` | Alias für denselben Host-Pfad; wird in den App-Compose-Files verwendet | `../../logs/app` relativ zu `docker/elk` |
 | `KIBANA_PUBLIC_URL` | Öffentliche URL (Proxy) für Kibana | `http://localhost:5601` |
 
 Die Logs werden schreibgeschützt unter `/var/log/noesis` im Logstash-Container gemountet. Der Stack öffnet folgende Ports:

--- a/scripts/dev-up-all.sh
+++ b/scripts/dev-up-all.sh
@@ -26,7 +26,8 @@ APP_LOG_PATH=${APP_LOG_PATH:-"$(pwd)/logs/app"}
 if [ "${APP_LOG_PATH#/}" = "$APP_LOG_PATH" ]; then
   APP_LOG_PATH="$(pwd)/${APP_LOG_PATH#./}"
 fi
-export APP_LOG_PATH
+APP_LOG_DIR="$APP_LOG_PATH"
+export APP_LOG_PATH APP_LOG_DIR
 
 mkdir -p "$APP_LOG_PATH"
 echo "[dev-up-all] Log-Verzeichnis: $APP_LOG_PATH"

--- a/scripts/dev-up.ps1
+++ b/scripts/dev-up.ps1
@@ -69,6 +69,7 @@ if ($IncludeElk) {
         $AppLogPath = Join-Path -Path (Get-Location) -ChildPath $relativeLogPath
     }
     $env:APP_LOG_PATH = $AppLogPath
+    $env:APP_LOG_DIR = $AppLogPath
 
     if (-not (Test-Path -Path $AppLogPath)) {
         New-Item -ItemType Directory -Path $AppLogPath | Out-Null


### PR DESCRIPTION
## Summary
- export the same host log directory to APP_LOG_PATH and APP_LOG_DIR in the dev bootstrap scripts
- extend the ELK environment template so both variables default to the same logs/app directory
- document APP_LOG_DIR as the app stack alias for the shared log volume

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d56e8098ec832ba2b2c909b13ccc70