### PR TITLE
Ensure structlog configuration runs after Django logging init

### DIFF
--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -8,9 +8,6 @@ from typing import Dict, List
 import environ
 
 from noesis2.api import schema as api_schema
-from common.logging import configure_logging
-
-configure_logging()
 
 logger = logging.getLogger(__name__)
 
@@ -240,6 +237,8 @@ ADMINS = [
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # Logging / observability
+LOGGING_CONFIG = "common.logging.configure_django_logging"
+
 LOGGING_ALLOW_UNMASKED_CONTEXT = env.bool(
     "LOGGING_ALLOW_UNMASKED_CONTEXT", default=False
 )


### PR DESCRIPTION
## Summary
- register `common.logging.configure_django_logging` as Django's `LOGGING_CONFIG` hook so structlog reconfigures after settings import
- drop the eager `configure_logging()` call from settings so environment-provided file paths are available when the hook runs

## Testing
- `ruff check .`
- `black --check .`
- `mypy .` *(fails: repository lacks stubs for Django, requests, psycopg2, etc.)*
- `PYTEST_ADDOPTS="" pytest -q` *(fails: missing LangGraph graph definitions such as `info_intake`/`scope_check`)*

------
https://chatgpt.com/codex/tasks/task_e_68d5983a2478832b80d80c2adb4433ff