### PR TITLE
Fix credit card masking to preserve surrounding whitespace

### DIFF
--- a/common/redaction.py
+++ b/common/redaction.py
@@ -104,7 +104,7 @@ class Redactor:
         (re.compile(r"\bGOCSPX-[A-Za-z0-9_-]{10,}\b"), MASK),
     )
 
-    _CARD_PATTERN = re.compile(r"(?:\d[ -]?){13,19}")
+    _CARD_PATTERN = re.compile(r"\b(?:\d[ -]?){12,18}\d\b")
 
     def __init__(self, mask: str = MASK) -> None:
         self.mask = mask


### PR DESCRIPTION
## Summary
- update the credit card detection pattern to avoid consuming trailing whitespace when masking

## Testing
- PYTEST_ADDOPTS= pytest -q ai_core/tests/test_redaction.py::test_credit_card_and_bearer_tokens

------
https://chatgpt.com/codex/tasks/task_e_68d67c1e3ad0832b849efef5abc307e9