### PR TITLE
Ensure configure_logging reconfigures logging handler

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -562,9 +562,8 @@ def configure_logging(stream: TextIO | None = None) -> None:
         if _REDACTOR is None:
             _REDACTOR = Redactor()
 
-        if _CONFIGURED_STREAM is not active_stream and _REDACTOR is not None:
-            _configure_stdlib_logging(level, _REDACTOR, active_stream, pii_processor)
-            _CONFIGURED_STREAM = active_stream
+        _configure_stdlib_logging(level, _REDACTOR, active_stream, pii_processor)
+        _CONFIGURED_STREAM = active_stream
         return
 
     redactor = Redactor()


### PR DESCRIPTION
## Summary
- always refresh the stdlib logging handler when configure_logging runs after the first configuration
- ensure stream switches (e.g. when tests replace stderr) are respected so log output is captured

## Testing
- PYTEST_ADDOPTS= pytest ai_core/tests/test_logging_setup.py::test_configure_logging_switches_streams -q

------
https://chatgpt.com/codex/tasks/task_e_68d67c23d448832bbd8bece680453ef8