### PR TITLE
Ensure logging emits empty trace IDs for invalid spans

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -357,8 +357,8 @@ def _otel_trace_processor(
         return f"{value:0{width}x}"
 
     if not span_context or not span_context.is_valid:
-        event_dict["trace_id"] = None
-        event_dict["span_id"] = None
+        event_dict["trace_id"] = ""
+        event_dict["span_id"] = ""
         return event_dict
 
     trace_id = _format_hex(span_context.trace_id, 32)


### PR DESCRIPTION
## Summary
- return empty strings for trace and span identifiers when no valid OpenTelemetry span is active so JSON logs always contain string values

## Testing
- `PYTEST_ADDOPTS= pytest ai_core/tests/test_logging_setup.py::test_logging_uses_string_ids_when_span_invalid -q`


------
https://chatgpt.com/codex/tasks/task_e_68d67c2acabc832baa68856d73e02269