### PR TITLE
Adjust logging tests to respect configured log level

### DIFF
--- a/ai_core/tests/test_logging_setup.py
+++ b/ai_core/tests/test_logging_setup.py
@@ -29,7 +29,10 @@ def _emit_log_line(capsys) -> dict[str, object]:
 
     with tracer.start_as_current_span("test-span"):
         logger = get_logger(__name__)
-        logger.info("logging smoke test", foo="bar")
+        level = logging.getLogger().getEffectiveLevel()
+        if level < logging.INFO:
+            level = logging.INFO
+        logger.log(level, "logging smoke test", foo="bar")
 
     captured = capsys.readouterr()
     line = captured.err.strip().splitlines()[-1]


### PR DESCRIPTION
## Summary
- ensure the logging smoke test emits a record even when the global LOG_LEVEL is elevated by logging at the effective level

## Testing
- LOG_LEVEL=WARNING PYTEST_ADDOPTS= pytest ai_core/tests/test_logging_setup.py::test_logging_emits_expected_json_fields -q
- PYTEST_ADDOPTS= pytest ai_core/tests/test_logging_setup.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d67c3f0684832b96f8002fe1b99487