### PR TITLE
Fix AI scope endpoint graph resolution

### DIFF
--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import json
 import re
+from importlib import import_module
 from uuid import uuid4
 
 from django.conf import settings
@@ -525,7 +526,12 @@ class _GraphView(_BaseAgentView):
     def get_graph(self):  # pragma: no cover - trivial indirection
         if not self.graph_name:
             raise NotImplementedError("graph_name must be configured on subclasses")
-        return globals()[self.graph_name]
+
+        module_path = f"ai_core.graphs.{self.graph_name}"
+        try:
+            return import_module(module_path)
+        except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+            raise KeyError(self.graph_name) from exc
 
     def post(self, request: Request) -> Response:
         return _run_graph(request, self.get_graph())


### PR DESCRIPTION
## Summary
- load graph modules with `import_module` so legacy scope endpoint resolves `scope_check`
- add the missing import for the dynamic loader

## Testing
- PYTEST_ADDOPTS= pytest ai_core/tests/test_views_min.py::test_scope_rate_limited -q

------
https://chatgpt.com/codex/tasks/task_e_68d67c5149ec832bab616c1dd53ec28c