### PR TITLE
Handle invalid OTEL span contexts gracefully

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -360,8 +360,8 @@ def _otel_trace_processor(
         return f"{value:0{width}x}"
 
     if not span_context or not span_context.is_valid:
-        event_dict["trace_id"] = ""
-        event_dict["span_id"] = ""
+        event_dict["trace_id"] = None
+        event_dict["span_id"] = None
         return event_dict
 
     trace_id = _format_hex(span_context.trace_id, 32)


### PR DESCRIPTION
## Summary
- ensure invalid OpenTelemetry span contexts populate `trace_id` and `span_id` as `None` instead of empty strings

## Testing
- `PYTEST_ADDOPTS="-c pytest.ini" pytest common/tests/test_logging.py -k invalid_span`


------
https://chatgpt.com/codex/tasks/task_e_68d6869b4f5c832bbe57253c7e1ca479