### PR TITLE
Update pytest coverage script to include all modules

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,9 +2,10 @@
 branch = True
 source = .
 omit =
+    */migrations/*
+    */settings/*
     noesis2/asgi.py
     noesis2/wsgi.py
-    noesis2/settings/production.py
 
 [report]
 show_missing = True

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Windows-Varianten (PowerShell) stehen als `npm run win:<script>` zur Verfügung 
 | `npm run e2e` | Playwright E2E-Tests |
 | `npm run test` | Vitest-Unit-Tests für Frontend |
 | `npm run test:py` | Python-Tests innerhalb des Web-Containers |
-| `npm run test:py:cov` | Python-Tests inkl. Coverage |
+| `npm run test:py:cov` | Python-Tests inkl. Coverage für `ai_core`, `common`, `customers`, `documents`, `organizations`, `profiles`, `projects`, `users`, `theme` und `noesis2` |
 | `npm run lint` | Ruff + Black (Check-Modus) |
 | `npm run lint:fix` | Ruff (Fix) + Black Formatierung |
 | `npm run format` | Prettier für JS/TS/CSS/MD/JSON |
@@ -162,6 +162,8 @@ npm run e2e            # Playwright E2E
 ```
 
 Der Python-Test-Runner installiert die benötigten Abhängigkeiten on-the-fly in einem temporären Container und räumt nach dem Lauf automatisch auf.
+
+`npm run test:py:cov` ruft `pytest` mit gezielten `--cov`-Parametern für alle relevanten Django- und Service-Module auf. Die `.coveragerc` blendet Migrations- und Settings-Pfade aus, sodass der Bericht nur produktiven Quellcode berücksichtigt.
 
 ### Chaos-Tests (Fault Injection)
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "win:jobs:rag": "docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm rag",
     "win:jobs:rag:health": "docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm rag-health",
     "test:py": "docker compose -f docker-compose.dev.yml run --rm web sh -c \"pip install -r requirements.txt -r requirements-dev.txt && python -m pytest -q\"",
-    "test:py:cov": "docker compose -f docker-compose.dev.yml run --rm web sh -c \"pip install -r requirements.txt -r requirements-dev.txt && python -m pytest -q --cov=noesis2 --cov-report=term-missing\"",
+    "test:py:cov": "docker compose -f docker-compose.dev.yml run --rm web sh -c \"pip install -r requirements.txt -r requirements-dev.txt && python -m pytest -q --cov=ai_core --cov=common --cov=customers --cov=documents --cov=organizations --cov=profiles --cov=projects --cov=users --cov=theme --cov=noesis2 --cov-report=term-missing\"",
     "lint": "python -m ruff check . && python -m black --check .",
     "lint:fix": "python -m ruff check --fix . && python -m black .",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css,md,json}\"",


### PR DESCRIPTION
## Summary
- update the Python coverage npm script to collect metrics for all application modules
- refine the coverage configuration to skip migrations and settings folders
- document the broader coverage scope in the README

## Testing
- npm run test:py:cov *(fails: docker not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a1d7eabc832b938e8638af4f5ade