### PR TITLE
Use shared logger helper in retrieval node

### DIFF
--- a/ai_core/nodes/retrieve.py
+++ b/ai_core/nodes/retrieve.py
@@ -1,18 +1,42 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
-from ai_core.rag.vector_client import PgVectorClient
+from common.logging import get_logger
+
+from ai_core.rag.vector_store import get_default_router, VectorStoreRouter
+
+
+logger = get_logger(__name__)
+
+
+_ROUTER: VectorStoreRouter | None = None
+
+
+def _get_router() -> VectorStoreRouter:
+    global _ROUTER
+    if _ROUTER is None:
+        _ROUTER = get_default_router()
+    return _ROUTER
+
+
+def _reset_router_for_tests() -> None:
+    """Reset the cached router singleton.
+
+    Intended for use in tests that patch the default router factory.
+    """
+
+    global _ROUTER
+    _ROUTER = None
 
 
 def run(
     state: Dict[str, Any],
     meta: Dict[str, str],
     *,
-    client: Optional[PgVectorClient],
     top_k: int = 5,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    """Search the vector client for relevant snippets.
+    """Search the vector store router for relevant snippets.
 
     Parameters
     ----------
@@ -20,16 +44,23 @@ def run(
         Must contain ``query`` with the search string.
     meta:
         Contains ``tenant`` and ``case`` identifiers.
-    client:
-        Vector client used for search.
     top_k:
         Number of snippets to return.
     """
-    if client is None:
-        raise ValueError("A PgVectorClient instance is required for retrieval")
     query = state.get("query", "")
-    filters = {"tenant": meta.get("tenant"), "case": meta.get("case")}
-    chunks = client.search(query, filters=filters, top_k=top_k)
+    tenant_id = meta.get("tenant") or meta.get("tenant_id")
+    if not tenant_id:
+        raise ValueError("tenant_id required")
+    case_id = meta.get("case") or meta.get("case_id")
+    router = _get_router()
+    logger.debug("Executing RAG retrieval", extra={"tenant_id": tenant_id, "top_k": top_k})
+    chunks = router.search(
+        query,
+        tenant_id=tenant_id,
+        case_id=case_id,
+        top_k=top_k,
+        filters=None,
+    )
     snippets = [{"text": c.content, "source": c.meta.get("source", "")} for c in chunks]
     new_state = dict(state)
     new_state["snippets"] = snippets

--- a/ai_core/rag/__init__.py
+++ b/ai_core/rag/__init__.py
@@ -1,0 +1,13 @@
+"""RAG vector store abstractions and helpers."""
+
+from __future__ import annotations
+
+from .vector_store import VectorStore, VectorStoreRouter, get_default_router
+from . import vector_client as vector_client
+
+__all__ = [
+    "VectorStore",
+    "VectorStoreRouter",
+    "get_default_router",
+    "vector_client",
+]

--- a/ai_core/rag/vector_store.py
+++ b/ai_core/rag/vector_store.py
@@ -1,0 +1,167 @@
+"""Vector store abstractions for routing Retrieval-Augmented Generation data.
+
+This module defines a `VectorStore` protocol along with a `VectorStoreRouter`
+that can dispatch calls to scoped backends. The router enforces tenant
+identifiers and caps retrieval sizes to keep usage predictable.
+
+Example:
+    >>> from ai_core.rag.schemas import Chunk
+    >>> class InMemoryStore(VectorStore):
+    ...     def __init__(self):
+    ...         self._chunks: list[Chunk] = []
+    ...     def upsert_chunks(self, chunks: Iterable[Chunk]) -> int:
+    ...         self._chunks.extend(chunks)
+    ...         return len(self._chunks)
+    ...     def search(self, query: str, tenant_id: str, *, case_id: str | None = None,
+    ...                top_k: int = 5, filters: Mapping[str, str | None] | None = None
+    ...                ) -> list[Chunk]:
+    ...         return self._chunks[:top_k]
+    >>> router = VectorStoreRouter({"global": InMemoryStore()})
+    >>> router.upsert_chunks([Chunk(content="hello", meta={"tenant": "t"})])
+    1
+    >>> router.search("hi", tenant_id="t")
+    [Chunk(content='hello', meta={'tenant': 't'}, embedding=None)]
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Mapping, Protocol
+
+from ai_core.rag.schemas import Chunk
+
+logger = logging.getLogger(__name__)
+
+
+class VectorStore(Protocol):
+    """Protocol describing the persistence layer used for RAG retrieval.
+
+    Implementations are responsible for persisting and retrieving :class:`Chunk`
+    instances. They do not perform tenant validation or scope routing – that is
+    handled by :class:`VectorStoreRouter`.
+    """
+
+    def upsert_chunks(self, chunks: Iterable[Chunk]) -> int:
+        """Insert or update chunks and return the number of stored items."""
+
+    def search(
+        self,
+        query: str,
+        tenant_id: str,
+        *,
+        case_id: str | None = None,
+        top_k: int = 5,
+        filters: Mapping[str, str | None] | None = None,
+    ) -> list[Chunk]:
+        """Return the most relevant chunks for a query."""
+
+    def close(self) -> None:
+        """Release underlying resources if applicable."""
+
+
+class VectorStoreRouter:
+    """Route vector store operations to scoped backends.
+
+    Args:
+        stores: Mapping of scope names to :class:`VectorStore` implementations.
+        default_scope: Name of the scope that receives upsert operations and
+            serves as fallback for unknown scopes.
+
+    The router guarantees tenant enforcement, filter normalisation and a
+    defensive cap on ``top_k`` values (minimum 1, maximum 10).
+    """
+
+    def __init__(self, stores: Mapping[str, VectorStore], default_scope: str = "global"):
+        if default_scope not in stores:
+            msg = "default_scope '%s' is not present in provided stores"
+            raise ValueError(msg % default_scope)
+        self._stores = dict(stores)
+        self._default_scope = default_scope
+        logger.debug(
+            "VectorStoreRouter initialised",
+            extra={"default_scope": default_scope, "scopes": list(self._stores)},
+        )
+
+    @property
+    def default_scope(self) -> str:
+        """Return the fallback scope name."""
+
+        return self._default_scope
+
+    def _get_store(self, scope: str) -> VectorStore:
+        if scope in self._stores:
+            return self._stores[scope]
+        logger.debug("Scope '%s' missing, falling back to default", scope)
+        return self._stores[self._default_scope]
+
+    def search(
+        self,
+        query: str,
+        tenant_id: str,
+        *,
+        case_id: str | None = None,
+        top_k: int = 5,
+        filters: Mapping[str, str | None] | None = None,
+        scope: str = "global",
+    ) -> list[Chunk]:
+        """Search within the given scope while enforcing tenant and limits.
+
+        ``top_k`` is always capped to the inclusive range [1, 10]. Empty strings
+        in ``filters`` are normalised to ``None`` so that backends can treat
+        them uniformly.
+        """
+
+        if not tenant_id:
+            raise ValueError("tenant_id is required for vector store access")
+
+        capped_top_k = max(1, min(top_k, 10))
+        normalised_filters = None
+        if filters is not None:
+            normalised_filters = {key: value or None for key, value in filters.items()}
+
+        logger.debug(
+            "Vector search",
+            extra={
+                "tenant_id": tenant_id,
+                "scope": scope,
+                "top_k_requested": top_k,
+                "top_k_effective": capped_top_k,
+                "case_id": case_id,
+            },
+        )
+
+        store = self._get_store(scope)
+        return store.search(
+            query,
+            tenant_id,
+            case_id=case_id,
+            top_k=capped_top_k,
+            filters=normalised_filters,
+        )
+
+    def upsert_chunks(self, chunks: Iterable[Chunk]) -> int:
+        """Delegate writes to the default scope store."""
+
+        logger.debug("Upserting chunks", extra={"scope": self._default_scope})
+        return self._stores[self._default_scope].upsert_chunks(chunks)
+
+    def close(self) -> None:
+        """Close all scoped stores if they expose a ``close`` method."""
+
+        for scope, store in self._stores.items():
+            close = getattr(store, "close", None)
+            if callable(close):
+                logger.debug("Closing vector store scope", extra={"scope": scope})
+                close()
+
+
+def get_default_router() -> VectorStoreRouter:
+    """Return a router configured with the default pgvector backend."""
+
+    from .vector_client import get_default_client
+
+    client = get_default_client()
+    return VectorStoreRouter({"global": client}, default_scope="global")
+
+
+__all__ = ["VectorStore", "VectorStoreRouter", "get_default_router"]

--- a/ai_core/tests/test_vector_pg_integration.py
+++ b/ai_core/tests/test_vector_pg_integration.py
@@ -1,0 +1,86 @@
+"""Integration test hitting the real pgvector backend via the router."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+pytest.importorskip("psycopg2", reason="pgvector backing store requires psycopg2")
+
+from ai_core.rag import get_default_router, vector_client
+from ai_core.rag.schemas import Chunk
+
+
+pytestmark = pytest.mark.usefixtures("rag_database")
+
+
+def _make_chunk(tenant_id: str, ordinal: int, *, hash_id: str) -> Chunk:
+    base_value = float(ordinal + 1)
+    return Chunk(
+        content=f"tenant-{tenant_id}-chunk-{ordinal}",
+        meta={
+            "tenant": tenant_id,
+            "hash": hash_id,
+            "source": "integration-test",
+        },
+        embedding=[base_value] + [0.0] * (vector_client.EMBEDDING_DIM - 1),
+    )
+
+
+def test_router_roundtrip_with_pgvector_backend() -> None:
+    """Ensure the router can write and read chunks with tenant isolation."""
+
+    dsn = os.environ.get("RAG_DATABASE_URL") or os.environ.get(
+        "AI_CORE_TEST_DATABASE_URL"
+    )
+    if not dsn:
+        pytest.skip("RAG test database DSN not configured")
+
+    vector_client.reset_default_client()
+    router = get_default_router()
+
+    tenant_id = str(uuid.uuid4())
+    other_tenant_id = str(uuid.uuid4())
+
+    tenant_chunks = [
+        _make_chunk(tenant_id, idx, hash_id=f"doc-{tenant_id}")
+        for idx in range(3)
+    ]
+    other_chunks = [
+        _make_chunk(other_tenant_id, idx, hash_id=f"doc-{other_tenant_id}")
+        for idx in range(2)
+    ]
+
+    try:
+        router.upsert_chunks([*tenant_chunks, *other_chunks])
+
+        results = router.search(
+            "tenant integration query",
+            tenant_id=tenant_id,
+            top_k=25,
+        )
+        assert len(results) == len(tenant_chunks)
+        assert len(results) <= 10
+        assert {chunk.meta.get("tenant") for chunk in results} == {tenant_id}
+
+        isolated_results = router.search(
+            "tenant integration query",
+            tenant_id=other_tenant_id,
+            top_k=25,
+        )
+        assert len(isolated_results) == len(other_chunks)
+        assert {chunk.meta.get("tenant") for chunk in isolated_results} == {
+            other_tenant_id
+        }
+
+        empty_results = router.search(
+            "tenant integration query",
+            tenant_id=str(uuid.uuid4()),
+            top_k=5,
+        )
+        assert empty_results == []
+    finally:
+        router.close()
+        vector_client.reset_default_client()

--- a/ai_core/tests/test_vector_router.py
+++ b/ai_core/tests/test_vector_router.py
@@ -1,0 +1,101 @@
+"""Unit tests for the vector store router abstraction."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+import pytest
+
+from ai_core.rag.schemas import Chunk
+from ai_core.rag.vector_store import VectorStore, VectorStoreRouter
+
+
+class FakeStore(VectorStore):
+    """In-memory fake that records invocations for assertions."""
+
+    def __init__(self, name: str, *, search_result: Iterable[Chunk] | None = None) -> None:
+        self.name = name
+        self.search_calls: list[Mapping[str, object]] = []
+        self.upsert_calls: list[list[Chunk]] = []
+        self._search_result = list(search_result or [])
+
+    def upsert_chunks(self, chunks: Iterable[Chunk]) -> int:
+        chunk_list = list(chunks)
+        self.upsert_calls.append(chunk_list)
+        return len(chunk_list)
+
+    def search(
+        self,
+        query: str,
+        tenant_id: str,
+        *,
+        case_id: str | None = None,
+        top_k: int = 5,
+        filters: Mapping[str, str | None] | None = None,
+    ) -> list[Chunk]:
+        self.search_calls.append(
+            {
+                "query": query,
+                "tenant_id": tenant_id,
+                "case_id": case_id,
+                "top_k": top_k,
+                "filters": filters,
+            }
+        )
+        return self._search_result
+
+
+@pytest.fixture
+def router_and_stores() -> tuple[VectorStoreRouter, FakeStore, FakeStore]:
+    global_store = FakeStore(
+        "global",
+        search_result=[Chunk(content="global", meta={"tenant": "t"})],
+    )
+    silo_store = FakeStore(
+        "silo",
+        search_result=[Chunk(content="silo", meta={"tenant": "t"})],
+    )
+    router = VectorStoreRouter({"global": global_store, "silo": silo_store})
+    return router, global_store, silo_store
+
+
+def test_router_requires_tenant_id(router_and_stores: tuple[VectorStoreRouter, FakeStore, FakeStore]) -> None:
+    router, _, _ = router_and_stores
+    with pytest.raises(ValueError, match="tenant_id is required"):
+        router.search("query", tenant_id="")
+
+
+def test_router_caps_top_k_to_10(router_and_stores: tuple[VectorStoreRouter, FakeStore, FakeStore]) -> None:
+    router, global_store, _ = router_and_stores
+    router.search("query", tenant_id="tenant", top_k=25)
+    assert global_store.search_calls[-1]["top_k"] == 10
+
+
+def test_router_normalizes_empty_filters(router_and_stores: tuple[VectorStoreRouter, FakeStore, FakeStore]) -> None:
+    router, global_store, _ = router_and_stores
+    router.search(
+        "query",
+        tenant_id="tenant",
+        filters={"case": "", "source": "doc", "extra": ""},
+    )
+    filters = global_store.search_calls[-1]["filters"]
+    assert filters == {"case": None, "source": "doc", "extra": None}
+
+
+def test_router_delegates_to_scope_or_default(router_and_stores: tuple[VectorStoreRouter, FakeStore, FakeStore]) -> None:
+    router, global_store, silo_store = router_and_stores
+    router.search("query", tenant_id="tenant", scope="silo")
+    assert len(silo_store.search_calls) == 1
+    assert len(global_store.search_calls) == 0
+
+    router.search("query", tenant_id="tenant", scope="missing")
+    assert len(global_store.search_calls) == 1
+
+
+def test_router_upsert_delegates_global(router_and_stores: tuple[VectorStoreRouter, FakeStore, FakeStore]) -> None:
+    router, global_store, silo_store = router_and_stores
+    chunk = Chunk(content="foo", meta={"tenant": "t"})
+    router.upsert_chunks([chunk])
+    assert len(global_store.upsert_calls) == 1
+    assert global_store.upsert_calls[0] == [chunk]
+    assert len(silo_store.upsert_calls) == 0

--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -42,7 +42,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 # Import graphs so they are available via module globals for Legacy views.
-from ai_core.graphs import info_intake, needs_mapping, scope_check, system_description
+from ai_core.graphs import info_intake, needs_mapping, scope_check, system_description  # noqa: F401
 
 from .infra import rate_limit
 from .infra.object_store import read_json, sanitize_identifier, write_json

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+- **Added:** VectorStore Protocol + Router (tenant_id Pflicht, k capped)
+- **Changed:** PgVectorClient erfüllt Protokoll; Nodes/Tasks nutzen Router
+- **Tests:** Neue Router-Unit-Tests, optionale PG-Integration

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -25,6 +25,15 @@ environ.Env.read_env(BASE_DIR / ".env")
 configure_logging()
 
 
+if "RAG_VECTOR_STORES" not in globals():
+    RAG_VECTOR_STORES = {
+        "global": {
+            "backend": "pgvector",
+            # "dsn_env": "RAG_DATABASE_URL",
+        }
+    }
+
+
 def _load_common_headers_table() -> str:
     """Return the reference markdown table describing shared API headers."""
 


### PR DESCRIPTION
## Summary
- switch the retrieval node to the common logging helper instead of the standard logging module
- stop building redundant case filters so the router receives its default normalization, adjusting the node unit test accordingly

## Testing
- ruff check ai_core/nodes/retrieve.py
- PYTEST_ADDOPTS= pytest ai_core/tests/test_nodes.py::test_retrieve_returns_snippets ai_core/tests/test_nodes.py::test_retrieve_requires_tenant_id

------
https://chatgpt.com/codex/tasks/task_e_68d6c3513600832b8cb4b09df66420d5