### PR TITLE
Harden rag demo router integration

### DIFF
--- a/ai_core/graph/bootstrap.py
+++ b/ai_core/graph/bootstrap.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from ai_core.graphs import info_intake, needs_mapping, scope_check, system_description
+from ai_core.graphs import (
+    info_intake,
+    needs_mapping,
+    rag_demo,
+    scope_check,
+    system_description,
+)
 
 from .adapters import module_runner
 from .registry import register
@@ -19,3 +25,4 @@ def bootstrap() -> None:
     register("scope_check", module_runner(scope_check))
     register("needs_mapping", module_runner(needs_mapping))
     register("system_description", module_runner(system_description))
+    register("rag_demo", module_runner(rag_demo))

--- a/ai_core/graphs/rag_demo.py
+++ b/ai_core/graphs/rag_demo.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Tuple
+
+try:
+    from ai_core.rag.vector_store import get_default_router
+except ImportError:  # pragma: no cover - optional dependency for demo mode
+    get_default_router = None  # type: ignore[assignment]
+
+
+QueryState = Dict[str, Any]
+Meta = Dict[str, Any]
+GraphResult = Dict[str, Any]
+
+
+_QUERY_KEYS: Tuple[str, ...] = ("query", "question", "q", "text")
+
+
+def _extract_query(state: QueryState) -> str | None:
+    for key in _QUERY_KEYS:
+        value = state.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+        if value:
+            return str(value)
+    return None
+
+
+def _coerce_top_k(state: QueryState, default: int = 5) -> int:
+    candidate = state.get("top_k") or state.get("k")
+    if candidate is None:
+        return default
+    try:
+        top_k = int(candidate)
+    except (TypeError, ValueError):
+        return default
+    return max(1, top_k)
+
+
+def _truncate(text: str, limit: int = 500) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit]
+
+
+def _chunk_matches(chunks: Iterable[Any]) -> List[Dict[str, Any]]:
+    matches: List[Dict[str, Any]] = []
+    for index, chunk in enumerate(chunks):
+        content = getattr(chunk, "content", "") or ""
+        meta = getattr(chunk, "meta", {}) or {}
+        identifier = meta.get("id") or meta.get("hash") or f"chunk-{index}"
+        score = meta.get("score")
+        try:
+            score_value = float(score) if score is not None else 0.0
+        except (TypeError, ValueError):
+            score_value = 0.0
+        matches.append(
+            {
+                "id": str(identifier),
+                "score": score_value,
+                "text": _truncate(str(content)),
+                "metadata": dict(meta),
+            }
+        )
+    return matches
+
+
+def _demo_matches(query: str, tenant_id: str, *, top_k: int) -> List[Dict[str, Any]]:
+    demo_corpus = [
+        {
+            "id": "demo-1",
+            "score": 0.42,
+            "text": _truncate(
+                (
+                    "Demo knowledge base entry describing how retrieval works for "
+                    "tenant '%s'. Query: '%s'."
+                )
+                % (tenant_id, query)
+            ),
+            "metadata": {"tenant_id": tenant_id, "source": "demo"},
+        },
+        {
+            "id": "demo-2",
+            "score": 0.36,
+            "text": _truncate(
+                "Second demo snippet outlining the behaviour of the RAG demo node."
+            ),
+            "metadata": {"tenant_id": tenant_id, "source": "demo"},
+        },
+    ]
+    return demo_corpus[:top_k]
+
+
+def run(state: QueryState, meta: Meta) -> Tuple[QueryState, GraphResult]:
+    query = _extract_query(state)
+    if not query:
+        return state, {"ok": False, "query": None, "matches": [], "error": "missing_query"}
+
+    tenant_id = meta.get("tenant_id") or meta.get("tenant")
+    if not tenant_id:
+        raise ValueError("tenant_id missing in meta")
+
+    top_k = _coerce_top_k(state)
+    project_id = state.get("project_id")
+
+    matches: List[Dict[str, Any]]
+    router_error: str | None = None
+
+    if get_default_router is not None:
+        filters = {"tenant_id": tenant_id}
+        if project_id:
+            filters["project_id"] = project_id
+
+        try:
+            router = get_default_router()
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            router = None
+            router_error = str(exc)
+
+        if router is not None:
+            scoped_router = router
+            for_tenant = getattr(router, "for_tenant", None)
+            if callable(for_tenant):
+                try:
+                    scoped_router = for_tenant(tenant_id)
+                except TypeError:
+                    try:
+                        scoped_router = for_tenant(tenant_id=tenant_id)
+                    except TypeError:
+                        scoped_router = for_tenant()
+                except Exception as exc:  # pragma: no cover - defensive fallback
+                    router_error = str(exc)
+                    scoped_router = None
+
+            search = getattr(scoped_router, "search", None) if scoped_router is not None else None
+            if callable(search):
+                case_id = meta.get("case_id") or meta.get("case")
+                try:
+                    chunks = search(
+                        query,
+                        tenant_id=tenant_id,
+                        case_id=case_id,
+                        top_k=top_k,
+                        filters=filters,
+                    )
+                    matches = _chunk_matches(chunks)
+                except Exception as exc:  # pragma: no cover - defensive fallback
+                    router_error = str(exc)
+                    matches = _demo_matches(query, str(tenant_id), top_k=top_k)
+            else:
+                if router_error is None:
+                    router_error = "router missing search"
+                matches = _demo_matches(query, str(tenant_id), top_k=top_k)
+        else:
+            matches = _demo_matches(query, str(tenant_id), top_k=top_k)
+    else:
+        matches = _demo_matches(query, str(tenant_id), top_k=top_k)
+
+    new_state = dict(state)
+    new_state["rag_demo"] = {
+        "query": query,
+        "top_k": top_k,
+        "retrieved_count": len(matches),
+    }
+
+    result: GraphResult = {"ok": True, "query": query, "matches": matches}
+    if router_error:
+        result["error"] = router_error
+
+    return new_state, result
+
+
+__all__ = ["run"]

--- a/ai_core/tests/test_graph_rag_demo.py
+++ b/ai_core/tests/test_graph_rag_demo.py
@@ -1,0 +1,135 @@
+"""Tests for the rag_demo graph node and HTTP endpoint."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable, List
+
+import pytest
+
+from ai_core.graph import registry
+from ai_core.graph.adapters import module_runner
+from ai_core.graphs import rag_demo
+from ai_core.rag.schemas import Chunk
+
+
+pytestmark = pytest.mark.django_db
+
+
+class _TenantRouter:
+    """Fake tenant-scoped router returning deterministic matches."""
+
+    def __init__(self) -> None:
+        self._matches: List[tuple[str, str]] = [
+            ("First tenant scoped match", "fake-1"),
+            ("Second tenant scoped match", "fake-2"),
+        ]
+
+    def search(
+        self,
+        query: str,
+        tenant_id: str,
+        *,
+        case_id: str | None = None,
+        top_k: int = 5,
+        filters: dict[str, object] | None = None,
+    ) -> Iterable[Chunk]:
+        assert filters is not None, "filters must be provided"
+        assert (
+            filters.get("tenant_id") == tenant_id
+        ), "tenant_id filter must match requested tenant"
+        del case_id  # not used in the fake router
+        del query  # the fake router does not evaluate query semantics
+        chunks = [
+            Chunk(content=text, meta={"id": match_id, "tenant_id": tenant_id})
+            for text, match_id in self._matches
+        ]
+        return chunks[:top_k]
+
+
+@pytest.fixture(autouse=True)
+def _configure_rag_demo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    """Ensure the rag_demo graph uses a fake router during tests."""
+
+    class FakeRouter:
+        def for_tenant(self) -> _TenantRouter:
+            return _TenantRouter()
+
+    store_path = tmp_path_factory.mktemp("rag-demo-store")
+    monkeypatch.setattr("ai_core.infra.object_store.BASE_PATH", store_path)
+    monkeypatch.setattr(
+        rag_demo,
+        "get_default_router",
+        lambda: FakeRouter().for_tenant(),
+    )
+    monkeypatch.setattr("ai_core.infra.rate_limit.check", lambda *args, **kwargs: True)
+    registry.register("rag_demo", module_runner(rag_demo))
+
+
+def test_rag_demo_route_returns_matches(client) -> None:
+    response = client.post(
+        "/ai/v1/rag-demo/",
+        data=json.dumps({"query": "Alpha"}),
+        content_type="application/json",
+        **{"HTTP_X_TENANT_ID": "dev", "HTTP_X_CASE_ID": "local"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["query"] == "Alpha"
+    assert len(data["matches"]) >= 2
+
+
+def test_rag_demo_missing_query_returns_error(client) -> None:
+    response = client.post(
+        "/ai/v1/rag-demo/",
+        data=json.dumps({}),
+        content_type="application/json",
+        **{"HTTP_X_TENANT_ID": "dev", "HTTP_X_CASE_ID": "missing"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert data["error"] == "missing_query"
+    assert data["matches"] == []
+
+
+def test_rag_demo_run_falls_back_to_demo_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rag_demo, "get_default_router", lambda: object())
+
+    state = {"query": "Alpha"}
+    meta = {"tenant_id": "dev"}
+
+    new_state, result = rag_demo.run(state, meta)
+
+    assert result["ok"] is True
+    assert result["query"] == "Alpha"
+    assert len(result["matches"]) == 2
+    assert result["error"] == "router missing search"
+    assert new_state["rag_demo"]["retrieved_count"] == 2
+
+
+def test_rag_demo_run_handles_for_tenant_router(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Router:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def for_tenant(self, tenant_id: str) -> _TenantRouter:
+            self.calls.append(tenant_id)
+            return _TenantRouter()
+
+    router = Router()
+    monkeypatch.setattr(rag_demo, "get_default_router", lambda: router)
+
+    state = {"query": "Alpha"}
+    meta = {"tenant_id": "dev", "case_id": "case"}
+
+    _, result = rag_demo.run(state, meta)
+
+    assert result["ok"] is True
+    assert len(result["matches"]) == 2
+    assert router.calls == ["dev"]

--- a/ai_core/urls.py
+++ b/ai_core/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path("scope/", views.scope, name="scope"),
     path("needs/", views.needs, name="needs"),
     path("sysdesc/", views.sysdesc, name="sysdesc"),
+    path("v1/rag-demo/", views.rag_demo, name="rag_demo"),
 ]

--- a/ai_core/urls_v1.py
+++ b/ai_core/urls_v1.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path("scope/", views.scope_v1, name="scope"),
     path("needs/", views.needs_v1, name="needs"),
     path("sysdesc/", views.sysdesc_v1, name="sysdesc"),
+    path("rag-demo/", views.rag_demo_v1, name="rag_demo"),
 ]

--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -52,6 +52,7 @@ from ai_core.graph.schemas import merge_state, normalize_meta
 from ai_core.graphs import (
     info_intake,
     needs_mapping,
+    rag_demo,
     scope_check,
     system_description,
 )  # noqa: F401
@@ -696,6 +697,27 @@ class LegacySysDescView(_GraphView):
         return super().post(request)
 
 
+class RagDemoViewV1(_GraphView):
+    """Minimal RAG retrieval demo: returns top-k matches for a query."""
+
+    graph_name = "rag_demo"
+
+    @default_extend_schema(
+        request=IntakeRequestSerializer,
+        responses={200: IntakeResponseSerializer},
+        examples=[
+            OpenApiExample(
+                name="RagDemo",
+                summary="RAG demo",
+                description="Send {'query': 'your question'} to retrieve top-k matches",
+                value={"query": "Wie konfiguriere ich Tenant-Filter?"},
+            )
+        ],
+    )
+    def post(self, request: Request) -> Response:
+        return super().post(request)
+
+
 ping_v1 = PingViewV1.as_view()
 ping_legacy = LegacyPingView.as_view()
 ping = ping_legacy
@@ -715,3 +737,6 @@ needs = needs_legacy
 sysdesc_v1 = SysDescViewV1.as_view()
 sysdesc_legacy = LegacySysDescView.as_view()
 sysdesc = sysdesc_legacy
+
+rag_demo_v1 = RagDemoViewV1.as_view()
+rag_demo = rag_demo_v1

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -164,6 +164,51 @@ Startet einen Ingestion-Workflow für zuvor hochgeladene Dokumente. Der Prozess 
 - `400 Bad Request`: Leere Dokumentliste.
 - `429 Too Many Requests`: Rate-Limit auf Tenant-Level erreicht.
 
+### POST `/ai/v1/rag-demo/`
+Die „RAG Demo“ stellt einen rein retrieval-basierten Beispiel-Graphen bereit. Er beantwortet eine Query ohne LLM-Beteiligung, liest die Anfrage aus `{"query": ...}` (bzw. kompatiblen Alias-Feldern) und liefert die Top-K Treffer aus dem mandantenspezifisch gefilterten Vektor-Index. Ohne angebundenen Vektorstore werden deterministische Demo-Matches zurückgegeben.
+
+**Headers**
+- `X-Tenant-Schema` (required)
+- `X-Tenant-Id` (required)
+- `X-Case-Id` (required)
+- `Content-Type: application/json`
+
+**Body Schema**
+```json
+{
+  "query": "Wie konfiguriere ich Tenant-Filter?",
+  "top_k": 5
+}
+```
+
+**Response 200 Beispiel**
+```json
+{
+  "ok": true,
+  "query": "Wie konfiguriere ich Tenant-Filter?",
+  "matches": [
+    {
+      "id": "demo-1",
+      "score": 0.42,
+      "text": "Tenant-scoped Retrieval Beispiel …",
+      "metadata": {
+        "tenant_id": "acme"
+      }
+    }
+  ]
+}
+```
+
+**cURL Beispiel**
+```bash
+curl -X POST "https://api.noesis.example/ai/v1/rag-demo/" \
+  -H "X-Tenant-Schema: acme_prod" \
+  -H "X-Tenant-Id: acme" \
+  -H "X-Case-Id: crm-7421" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Wie konfiguriere ich Tenant-Filter?", "top_k": 3}'
+```
+
 ## Agenten (Queue `agents`)
 
 ### POST `/ai/scope/`


### PR DESCRIPTION
## Summary
- make the rag demo graph resilient to routers that require tenant scoping or are missing search capabilities while keeping a deterministic fallback
- exercise the new router branches with dedicated unit-style tests and streamline the view imports

## Testing
- PYTEST_ADDOPTS= pytest ai_core/tests/test_graph_rag_demo.py

------
https://chatgpt.com/codex/tasks/task_e_68d7d7a181f8832b815a4dccabdc1240