### PR TITLE
Whitelist vector metadata filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,36 @@ Benötigte Variablen (siehe `.env.example` oder `.env.dev.sample`):
   Stelle sicher, dass [`docs/rag/schema.sql`](docs/rag/schema.sql) angewendet wurde und die `vector`-Extension aktiv ist.
   Mandanten-IDs müssen UUIDs sein; vorhandene Legacy-IDs werden deterministisch gemappt, sollten aber per Migration bereinigt
   werden, bevor produktive Daten geladen werden.
+- RAG_STATEMENT_TIMEOUT_MS (optional, default `15000`): maximale Laufzeit für SQL-Statements des pgvector-Clients. Höhere Werte
+  erhöhen das Timeout, niedrigere brechen Abfragen früher ab.
+- RAG_RETRY_ATTEMPTS (optional, default `3`): Anzahl der Wiederholungsversuche für fehlgeschlagene pgvector-Operationen.
+- RAG_RETRY_BASE_DELAY_MS (optional, default `50`): Basiswartezeit zwischen Wiederholungen; skaliert linear mit dem Versuch.
+
+> ⚠️ **Vector-Backend Auswahl:** `RAG_VECTOR_STORES` unterstützt aktuell nur
+> `pgvector`. Abweichende `backend`-Werte führen beim Start zu einem
+> `ValueError` aus `get_default_router()`, sodass Fehlkonfigurationen früh
+> auffallen.
+
+Beispielkonfiguration für getrennte Scopes (z. B. isolierte Großmandanten):
+
+```python
+RAG_VECTOR_STORES = {
+    "global": {
+        "backend": "pgvector",
+        "dsn_env": "RAG_DATABASE_URL",
+        "default": True,
+    },
+    "enterprise": {
+        "backend": "pgvector",
+        "schema": "rag_enterprise",
+        "tenants": ["f1d8f7af-4d4a-4f13-9d5b-a1c46b0d5b61"],
+        "schemas": ["acme_prod"],
+    },
+}
+```
+
+Der Router mappt automatisch alle aufgeführten Tenant-IDs oder Schema-Namen auf
+den jeweiligen Scope und fällt ansonsten auf `global` zurück.
 
 AI Core:
 - LITELLM_BASE_URL: Basis-URL des LiteLLM-Proxys

--- a/ai_core/nodes/retrieve.py
+++ b/ai_core/nodes/retrieve.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from common.logging import get_logger
 
@@ -53,17 +53,52 @@ def run(
         raise ValueError("tenant_id required")
     case_id = meta.get("case") or meta.get("case_id")
     router = _get_router()
+    tenant_client = router
+    filters: Dict[str, Optional[str]] | None = None
+    for_tenant = getattr(router, "for_tenant", None)
+    if callable(for_tenant):
+        tenant_client = for_tenant(tenant_id)
+        # Tenant-scoped clients already enforce the tenant context, so we only
+        # inject the optional case filter here to avoid redundant constraints.
+        filters = {"case": case_id} if case_id else None
+    else:
+        filters = {"tenant": tenant_id}
+        if case_id:
+            filters["case"] = case_id
     logger.debug(
-        "Executing RAG retrieval", extra={"tenant_id": tenant_id, "top_k": top_k}
+        "Executing RAG retrieval",
+        extra={"tenant_id": tenant_id, "case_id": case_id, "top_k": top_k},
     )
-    chunks = router.search(
-        query,
-        tenant_id=tenant_id,
-        case_id=case_id,
-        top_k=top_k,
-        filters=None,
-    )
-    snippets = [{"text": c.content, "source": c.meta.get("source", "")} for c in chunks]
+    search_kwargs = {"case_id": case_id, "top_k": top_k, "filters": filters}
+    if tenant_client is router:
+        chunks = tenant_client.search(
+            query,
+            tenant_id=tenant_id,
+            **search_kwargs,
+        )
+    else:
+        chunks = tenant_client.search(
+            query,
+            **search_kwargs,
+        )
+    snippets = []
+    for chunk in chunks:
+        chunk_meta = chunk.meta or {}
+        snippet: Dict[str, Any] = {
+            "text": chunk.content,
+            "source": chunk_meta.get("source", ""),
+            "score": chunk_meta.get("score"),
+            "hash": chunk_meta.get("hash"),
+            "id": chunk_meta.get("id"),
+        }
+        extra_meta = {
+            key: value
+            for key, value in chunk_meta.items()
+            if key not in {"source", "score", "hash", "id"}
+        }
+        if extra_meta:
+            snippet["meta"] = extra_meta
+        snippets.append(snippet)
     new_state = dict(state)
     new_state["snippets"] = snippets
     confidence = 1.0 if snippets else 0.0

--- a/ai_core/rag/__init__.py
+++ b/ai_core/rag/__init__.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-from .vector_store import VectorStore, VectorStoreRouter, get_default_router
+from .vector_store import (
+    TenantScopedVectorStore,
+    VectorStore,
+    VectorStoreRouter,
+    get_default_router,
+)
 from . import vector_client as vector_client
 
 __all__ = [
     "VectorStore",
     "VectorStoreRouter",
+    "TenantScopedVectorStore",
     "get_default_router",
     "vector_client",
 ]

--- a/ai_core/rag/metrics.py
+++ b/ai_core/rag/metrics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List, Tuple
 
 try:  # pragma: no cover - optional dependency
     from prometheus_client import Counter as _PromCounter  # type: ignore
@@ -22,6 +22,25 @@ class _FallbackCounter:
     @property
     def value(self) -> float:
         return self._value
+
+
+class _FallbackCounterVec:
+    def __init__(self) -> None:
+        self._counters: Dict[Tuple[Tuple[str, str], ...], _FallbackCounter] = {}
+
+    def labels(self, **labels: str) -> _FallbackCounter:
+        key = tuple(sorted(labels.items()))
+        if key not in self._counters:
+            self._counters[key] = _FallbackCounter()
+        return self._counters[key]
+
+    def inc(self, amount: float = 1.0, **labels: str) -> None:
+        self.labels(**labels).inc(amount)
+
+    def value(self, **labels: str) -> float:
+        key = tuple(sorted(labels.items()))
+        counter = self._counters.get(key)
+        return counter.value if counter else 0.0
 
 
 class _FallbackHistogram:
@@ -54,4 +73,25 @@ else:  # pragma: no cover - covered via direct value inspection in tests
     RAG_SEARCH_MS = _FallbackHistogram()
 
 
-__all__ = ["RAG_UPSERT_CHUNKS", "RAG_SEARCH_MS"]
+if _PromCounter is not None:  # pragma: no cover - exercised in integration
+    RAG_RETRY_ATTEMPTS = _PromCounter(
+        "rag_retry_attempts_total",
+        "Number of retry attempts executed by pgvector operations.",
+        ["operation"],
+    )
+    RAG_HEALTH_CHECKS = _PromCounter(
+        "rag_vector_health_checks_total",
+        "Health check results per vector store scope.",
+        ["scope", "status"],
+    )
+else:  # pragma: no cover - covered via fallback value inspection in tests
+    RAG_RETRY_ATTEMPTS = _FallbackCounterVec()
+    RAG_HEALTH_CHECKS = _FallbackCounterVec()
+
+
+__all__ = [
+    "RAG_UPSERT_CHUNKS",
+    "RAG_SEARCH_MS",
+    "RAG_RETRY_ATTEMPTS",
+    "RAG_HEALTH_CHECKS",
+]

--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import atexit
 import json
+import math
 import os
 import threading
 import time
 import uuid
 from contextlib import contextmanager
-from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, cast
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, TypeVar, cast
 
 from psycopg2 import sql
 from psycopg2.extras import Json, register_default_jsonb
@@ -25,12 +26,28 @@ register_default_jsonb(loads=json.loads, globally=True)
 
 logger = get_logger(__name__)
 
-DEFAULT_STATEMENT_TIMEOUT_MS = 15000
+# Welche Filter-Schlüssel sind erlaubt und worauf mappen sie?
+# - "chunk_meta": JSONB c.metadata ->> '<key>'
+# - "document_hash": Spalte d.hash
+# - "document_id":  Spalte d.id::text
+SUPPORTED_METADATA_FILTERS = {
+    "case": "chunk_meta",
+    "source": "chunk_meta",
+    "doctype": "chunk_meta",
+    "published": "chunk_meta",
+    "hash": "document_hash",
+    "id": "document_id",
+}
+
+DEFAULT_STATEMENT_TIMEOUT_MS = int(os.getenv("RAG_STATEMENT_TIMEOUT_MS", "15000"))
+DEFAULT_RETRY_ATTEMPTS = int(os.getenv("RAG_RETRY_ATTEMPTS", "3"))
+DEFAULT_RETRY_BASE_DELAY_MS = int(os.getenv("RAG_RETRY_BASE_DELAY_MS", "50"))
 EMBEDDING_DIM = int(os.getenv("RAG_EMBEDDING_DIM", "1536"))
 
 
 DocumentKey = Tuple[str, str]
 GroupedDocuments = Dict[DocumentKey, Dict[str, object]]
+T = TypeVar("T")
 
 
 class PgVectorClient:
@@ -44,6 +61,8 @@ class PgVectorClient:
         minconn: int = 1,
         maxconn: int = 5,
         statement_timeout_ms: int = DEFAULT_STATEMENT_TIMEOUT_MS,
+        retries: int = DEFAULT_RETRY_ATTEMPTS,
+        retry_base_delay_ms: int = DEFAULT_RETRY_BASE_DELAY_MS,
     ) -> None:
         if minconn < 1 or maxconn < minconn:
             raise ValueError("Invalid connection pool configuration")
@@ -52,6 +71,8 @@ class PgVectorClient:
         self._pool = SimpleConnectionPool(minconn, maxconn, dsn)
         self._prepare_lock = threading.Lock()
         self._indexes_ready = False
+        self._retries = max(1, retries)
+        self._retry_base_delay = max(0, retry_base_delay_ms) / 1000.0
 
     @classmethod
     def from_env(
@@ -118,23 +139,27 @@ class PgVectorClient:
             return 0
 
         grouped = self._group_by_document(chunk_list)
-        started = time.perf_counter()
-        with self._connection() as conn:
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        "SET LOCAL statement_timeout = %s",
-                        (str(self._statement_timeout_ms),),
-                    )
-                    document_ids = self._ensure_documents(cur, grouped)
-                    self._replace_chunks(cur, grouped, document_ids)
-                conn.commit()
-            except Exception:
-                conn.rollback()
-                raise
-
-        duration_ms = (time.perf_counter() - started) * 1000
         tenants = sorted({key[0] for key in grouped})
+
+        def _operation() -> float:
+            started = time.perf_counter()
+            with self._connection() as conn:
+                try:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SET LOCAL statement_timeout = %s",
+                            (str(self._statement_timeout_ms),),
+                        )
+                        document_ids = self._ensure_documents(cur, grouped)
+                        self._replace_chunks(cur, grouped, document_ids)
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                    raise
+            return (time.perf_counter() - started) * 1000
+
+        duration_ms = self._run_with_retries(_operation, op_name="upsert_chunks")
+
         metrics.RAG_UPSERT_CHUNKS.inc(len(chunk_list))
         logger.info(
             "RAG upsert completed: chunks=%d documents=%d tenants=%s duration_ms=%.2f",
@@ -152,15 +177,19 @@ class PgVectorClient:
         *,
         case_id: str | None = None,
         top_k: int = 5,
-        filters: Mapping[str, str | None] | None = None,
+        filters: Mapping[str, object | None] | None = None,
     ) -> List[Chunk]:
         top_k = min(max(1, top_k), 10)
         tenant_uuid = self._coerce_tenant_uuid(tenant_id)
         tenant = str(tenant_uuid)
-        normalized_filters: Dict[str, Optional[str]] = {}
+        normalized_filters: Dict[str, object | None] = {}
         if filters:
             normalized_filters = {
-                key: (value if value not in {"", None} else None)
+                key: (
+                    value
+                    if not (isinstance(value, str) and value == "") and value is not None
+                    else None
+                )
                 for key, value in filters.items()
             }
         case_value: Optional[str]
@@ -172,10 +201,20 @@ class PgVectorClient:
             case_value = str(case_value)
         normalized_filters["tenant"] = tenant
         normalized_filters["case"] = case_value
-        filter_debug = {
-            key: ("<set>" if value is not None else None)
+        metadata_filters = [
+            (key, value)
             for key, value in normalized_filters.items()
-        }
+            if key not in {"tenant"}
+            and value is not None
+            and key in SUPPORTED_METADATA_FILTERS
+        ]
+        filter_debug: Dict[str, object | None] = {"tenant": "<set>"}
+        for key, value in normalized_filters.items():
+            if key == "tenant":
+                continue
+            filter_debug[key] = (
+                "<set>" if value is not None and key in SUPPORTED_METADATA_FILTERS else None
+            )
         logger.debug(
             "RAG search normalised inputs: tenant=%s top_k=%d filters=%s",
             tenant,
@@ -183,30 +222,60 @@ class PgVectorClient:
             filter_debug,
         )
         query_vec = self._format_vector(self._embed_query(query))
-        started = time.perf_counter()
-        with self._connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
+
+        def _operation() -> Tuple[
+            List[Tuple[str, Mapping[str, object], Optional[str], object, float]],
+            float,
+        ]:
+            started = time.perf_counter()
+            with self._connection() as conn:
+                with conn.cursor() as cur:
+                    where_clauses = ["d.tenant_id::text = %s"]
+                    where_params: List[object] = [tenant]
+                    for key, value in metadata_filters:
+                        kind = SUPPORTED_METADATA_FILTERS[key]
+                        normalised = self._normalise_filter_value(value)
+                        if kind == "chunk_meta":
+                            where_clauses.append("c.metadata ->> %s = %s")
+                            where_params.extend([key, normalised])
+                        elif kind == "document_hash":
+                            where_clauses.append("d.hash = %s")
+                            where_params.append(normalised)
+                        elif kind == "document_id":
+                            where_clauses.append("d.id::text = %s")
+                            where_params.append(normalised)
+                    where_sql = "\n          AND ".join(where_clauses)
+                    query_sql = f"""
+                        SELECT
+                            c.text,
+                            c.metadata,
+                            d.hash,
+                            d.id,
+                            e.embedding <-> %s::vector AS distance
+                        FROM embeddings e
+                        JOIN chunks c ON e.chunk_id = c.id
+                        JOIN documents d ON c.document_id = d.id
+                        WHERE {where_sql}
+                        ORDER BY distance
+                        LIMIT %s
                     """
-                    SELECT c.text, c.metadata
-                    FROM embeddings e
-                    JOIN chunks c ON e.chunk_id = c.id
-                    JOIN documents d ON c.document_id = d.id
-                    WHERE d.tenant_id::text = %s
-                      AND (%s IS NULL OR c.metadata ->> 'case' = %s)
-                    ORDER BY e.embedding <-> %s::vector
-                    LIMIT %s
-                    """,
-                    (tenant, case_value, case_value, query_vec, top_k),
-                )
-                rows = cur.fetchall()
+                    cur.execute(query_sql, (query_vec, *where_params, top_k))
+                    rows = cur.fetchall()
+            return rows, (time.perf_counter() - started) * 1000
+
+        rows, duration_ms = self._run_with_retries(_operation, op_name="search")
+
         results: List[Chunk] = []
-        for text, metadata in rows:
+        for text, metadata, doc_hash, doc_id, distance in rows:
             meta = dict(metadata or {})
+            if doc_hash and not meta.get("hash"):
+                meta["hash"] = doc_hash
+            if doc_id is not None and "id" not in meta:
+                meta["id"] = str(doc_id)
             if not strict_match(meta, tenant, case_value):
                 continue
+            meta["score"] = self._distance_to_score(distance)
             results.append(Chunk(content=text, meta=meta))
-        duration_ms = (time.perf_counter() - started) * 1000
         metrics.RAG_SEARCH_MS.observe(duration_ms)
         logger.info(
             "RAG search executed: tenant=%s case=%s query_chars=%d results=%d duration_ms=%.2f",
@@ -217,6 +286,18 @@ class PgVectorClient:
             duration_ms,
         )
         return results
+
+    def health_check(self) -> bool:
+        """Run a lightweight query to assert connectivity."""
+
+        def _operation() -> bool:
+            with self._connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1")
+                    cur.fetchone()
+            return True
+
+        return bool(self._run_with_retries(_operation, op_name="health_check"))
 
     def _group_by_document(self, chunks: Sequence[Chunk]) -> GroupedDocuments:
         grouped: GroupedDocuments = {}
@@ -349,6 +430,54 @@ class PgVectorClient:
     def _embed_query(self, query: str) -> List[float]:
         base = float(len(query.strip()) or 1)
         return [base] + [0.0] * (EMBEDDING_DIM - 1)
+
+    def _distance_to_score(self, distance: float) -> float:
+        try:
+            value = float(distance)
+        except (TypeError, ValueError):
+            return 0.0
+        if math.isnan(value) or math.isinf(value):
+            return 0.0
+        if value < 0:
+            value = 0.0
+        return 1.0 / (1.0 + value)
+
+    def _normalise_filter_value(self, value: object) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+        if isinstance(value, uuid.UUID):
+            return str(value)
+        return str(value)
+
+    def _run_with_retries(self, fn: Callable[[], T], *, op_name: str) -> T:
+        """Execute ``fn`` with retry semantics and return its ``TypeVar`` result.
+
+        The callable ``fn`` is invoked until it succeeds or the configured
+        number of attempts is exhausted. Each retry waits ``attempt *
+        self._retry_base_delay`` seconds, providing a linear backoff. Using the
+        ``Callable[[], T]`` signature together with ``TypeVar('T')`` preserves
+        the original return type (float, tuple, bool, ...), so callers receive
+        the exact value produced by ``fn`` once it finally succeeds.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(1, self._retries + 1):
+            try:
+                return fn()
+            except Exception as exc:  # pragma: no cover - requires failure injection
+                last_exc = exc
+                logger.warning(
+                    "pgvector operation failed, retrying",
+                    extra={"operation": op_name, "attempt": attempt},
+                )
+                metrics.RAG_RETRY_ATTEMPTS.labels(operation=op_name).inc()
+                if attempt == self._retries:
+                    raise
+                time.sleep(self._retry_base_delay * attempt)
+        if last_exc is not None:  # pragma: no cover - defensive
+            raise last_exc
+        raise RuntimeError("retry loop exited without result")
 
 
 _DEFAULT_CLIENT: Optional[VectorStore] = None

--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -114,7 +114,11 @@ def upsert(meta: Dict[str, str], embeddings_path: str) -> int:
             raise ValueError("chunk tenant mismatch")
 
     router = get_default_router()
-    written = router.upsert_chunks(chunk_objs)
+    tenant_client = router
+    for_tenant = getattr(router, "for_tenant", None)
+    if callable(for_tenant):
+        tenant_client = for_tenant(tenant_id)
+    written = tenant_client.upsert_chunks(chunk_objs)
     return written
 
 

--- a/ai_core/tests/conftest.py
+++ b/ai_core/tests/conftest.py
@@ -8,6 +8,7 @@ from psycopg2 import OperationalError, errors
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 from ai_core.rag import vector_client as rag_vector_client
+from ai_core.rag.vector_store import reset_default_router
 from common import logging as common_logging
 
 os.environ.setdefault("RAG_EMBEDDING_DIM", "1536")
@@ -78,7 +79,9 @@ def rag_database(rag_test_dsn: str, monkeypatch) -> Iterator[str]:
     monkeypatch.setenv("DATABASE_URL", rag_test_dsn)
     monkeypatch.setenv("RAG_DATABASE_URL", rag_test_dsn)
     rag_vector_client.reset_default_client()
+    reset_default_router()
     try:
         yield rag_test_dsn
     finally:
         rag_vector_client.reset_default_client()
+        reset_default_router()

--- a/ai_core/tests/test_graph_rag_demo.py
+++ b/ai_core/tests/test_graph_rag_demo.py
@@ -81,6 +81,7 @@ def test_rag_demo_route_returns_matches(client) -> None:
     assert data["ok"] is True
     assert data["query"] == "Alpha"
     assert len(data["matches"]) >= 2
+    assert "warnings" not in data
 
 
 def test_rag_demo_missing_query_returns_error(client) -> None:

--- a/ai_core/tests/test_nodes.py
+++ b/ai_core/tests/test_nodes.py
@@ -41,19 +41,35 @@ def test_retrieve_returns_snippets(monkeypatch):
             return self._chunks
 
     chunk = Chunk(
-        "Hello 123", {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h"}
+        "Hello 123",
+        {
+            "tenant": "t1",
+            "case": "c1",
+            "source": "s1",
+            "hash": "h",
+            "id": "doc-1",
+            "score": 0.42,
+            "category": "demo",
+        },
     )
     router = _Router([chunk])
     monkeypatch.setattr("ai_core.nodes.retrieve._get_router", lambda: router)
     state, result = retrieve.run({"query": "Hello"}, META.copy(), top_k=3)
-    assert result["snippets"][0]["text"] == "Hello 123"
-    assert result["snippets"][0]["source"] == "s1"
+    snippet = result["snippets"][0]
+    assert snippet == {
+        "text": "Hello 123",
+        "source": "s1",
+        "score": 0.42,
+        "hash": "h",
+        "id": "doc-1",
+        "meta": {"tenant": "t1", "case": "c1", "category": "demo"},
+    }
     assert state["snippets"] == result["snippets"]
     assert router.last_call == {
         "tenant_id": "t1",
         "case_id": "c1",
         "top_k": 3,
-        "filters": None,
+        "filters": {"tenant": "t1", "case": "c1"},
     }
 
 

--- a/ai_core/tests/test_tasks.py
+++ b/ai_core/tests/test_tasks.py
@@ -29,9 +29,11 @@ def test_upsert_persists_chunks(tmp_path, monkeypatch):
     assert count == 1
 
     client = vector_client.get_default_client()
-    results = client.search("User", {"tenant": tenant, "case": case})
+    results = client.search("User", tenant_id=tenant, case_id=case, top_k=5)
     assert len(results) == 1
     assert results[0].content == "User XXX"
+    assert results[0].meta.get("hash")
+    assert 0.0 <= results[0].meta.get("score", 0.0) <= 1.0
 
     vector_client.reset_default_client()
 

--- a/ai_core/tests/test_vector_client.py
+++ b/ai_core/tests/test_vector_client.py
@@ -73,6 +73,8 @@ class TestPgVectorClient:
         assert len(results) == 1
         assert histogram.samples
         assert uuid.UUID(results[0].meta["tenant"])  # tenant ids are normalised
+        assert 0.0 <= results[0].meta["score"] <= 1.0
+        assert results[0].meta.get("hash") == chunk.meta["hash"]
 
     def test_upsert_replaces_existing_chunks_in_batches(self):
         client = vector_client.get_default_client()
@@ -135,3 +137,144 @@ class TestPgVectorClient:
 
         results = client.search("Result", tenant_id=tenant, top_k=25)
         assert len(results) == 10
+
+    def test_search_applies_metadata_filters(self):
+        client = vector_client.get_default_client()
+        tenant = str(uuid.uuid4())
+        chunks = [
+            Chunk(
+                content="Filtered",
+                meta={
+                    "tenant": tenant,
+                    "hash": "doc-a",
+                    "source": "alpha",
+                    "doctype": "contract",
+                },
+                embedding=[0.03] + [0.0] * (vector_client.EMBEDDING_DIM - 1),
+            ),
+            Chunk(
+                content="Filtered",
+                meta={
+                    "tenant": tenant,
+                    "hash": "doc-b",
+                    "source": "beta",
+                    "doctype": "contract",
+                },
+                embedding=[0.03] + [0.0] * (vector_client.EMBEDDING_DIM - 1),
+            ),
+        ]
+        written = client.upsert_chunks(chunks)
+        assert written == len(chunks)
+
+        results = client.search(
+            "Filtered",
+            tenant_id=tenant,
+            filters={"source": "alpha"},
+            top_k=5,
+        )
+        assert [chunk.meta.get("hash") for chunk in results] == ["doc-a"]
+        assert all(chunk.meta.get("source") == "alpha" for chunk in results)
+
+        empty = client.search(
+            "Filtered",
+            tenant_id=tenant,
+            filters={"source": "gamma"},
+            top_k=5,
+        )
+        assert empty == []
+
+    def test_search_supports_boolean_filters(self):
+        client = vector_client.get_default_client()
+        tenant = str(uuid.uuid4())
+        chunk = Chunk(
+            content="Boolean",
+            meta={
+                "tenant": tenant,
+                "hash": "doc-bool",
+                "source": "gamma",
+                "published": True,
+            },
+            embedding=[0.04] + [0.0] * (vector_client.EMBEDDING_DIM - 1),
+        )
+        client.upsert_chunks([chunk])
+
+        positive = client.search(
+            "Boolean",
+            tenant_id=tenant,
+            filters={"published": True},
+            top_k=5,
+        )
+        assert [c.meta.get("hash") for c in positive] == ["doc-bool"]
+
+        negative = client.search(
+            "Boolean",
+            tenant_id=tenant,
+            filters={"published": False},
+            top_k=5,
+        )
+        assert negative == []
+
+    def test_search_ignores_unknown_filters(self):
+        client = vector_client.get_default_client()
+        tenant = str(uuid.uuid4())
+        chunk = Chunk(
+            content="Filter tolerant",
+            meta={
+                "tenant": tenant,
+                "hash": "doc-filter-tolerant",
+                "source": "alpha",
+            },
+            embedding=[0.05] + [0.0] * (vector_client.EMBEDDING_DIM - 1),
+        )
+        client.upsert_chunks([chunk])
+
+        results = client.search(
+            "Filter tolerant",
+            tenant_id=tenant,
+            filters={
+                "source": "alpha",
+                "project_id": "legacy",  # unbekannter Key, sollte ignoriert werden
+                "some_unknown_key": "value",
+            },
+            top_k=5,
+        )
+
+        assert results, "Erwartet mindestens ein Ergebnis trotz unbekannter Filter"
+        assert any(r.meta.get("hash") == "doc-filter-tolerant" for r in results)
+
+    def test_retry_metrics_record_attempts(self, monkeypatch):
+        client = vector_client.get_default_client()
+        client._retries = 2  # type: ignore[attr-defined]
+
+        class _RetryCounter:
+            def __init__(self) -> None:
+                self.calls: list[dict[str, str]] = []
+                self.value = 0.0
+
+            def labels(self, **labels: str) -> "_RetryCounter":
+                self.calls.append(labels)
+                return self
+
+            def inc(self, amount: float = 1.0) -> None:
+                self.value += amount
+
+        counter = _RetryCounter()
+        monkeypatch.setattr(metrics, "RAG_RETRY_ATTEMPTS", counter)
+        monkeypatch.setattr(vector_client.time, "sleep", lambda _x: None)
+
+        attempts = {"count": 0}
+
+        def _sometimes_fails() -> str:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("transient")
+            return "ok"
+
+        result = client._run_with_retries(_sometimes_fails, op_name="search")
+        assert result == "ok"
+        assert counter.value == 1.0
+        assert counter.calls == [{"operation": "search"}]
+
+    def test_health_check_runs_simple_query(self):
+        client = vector_client.get_default_client()
+        assert client.health_check() is True

--- a/ai_core/tests/test_vector_pg_integration.py
+++ b/ai_core/tests/test_vector_pg_integration.py
@@ -63,6 +63,8 @@ def test_router_roundtrip_with_pgvector_backend() -> None:
         assert len(results) == len(tenant_chunks)
         assert len(results) <= 10
         assert {chunk.meta.get("tenant") for chunk in results} == {tenant_id}
+        assert all("hash" in chunk.meta for chunk in results)
+        assert all(0.0 <= chunk.meta.get("score", 0.0) <= 1.0 for chunk in results)
 
         isolated_results = router.search(
             "tenant integration query",

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -198,6 +198,24 @@ Die „RAG Demo“ stellt einen rein retrieval-basierten Beispiel-Graphen bereit
 }
 ```
 
+#### Result-Metadaten
+
+> ℹ️ **Response-Formate:** Graph-Nodes wie `retrieve` liefern Snippets mit
+> flachen Feldern (`text`, `source`, `score`, `hash`, `id`) und einem optionalen
+> `meta`-Dictionary, das zusätzliche Schlüssel aus dem Chunk (z. B.
+> `doctype`, `published`) unverändert durchreicht. HTTP-Endpunkte wie
+> `/ai/v1/rag-demo/` bündeln dieselben Informationen dagegen im Feld
+> `metadata` und verwenden `snippets[].metadata.score` statt eines Top-Level
+> Keys. Prüfen Sie daher stets den spezifischen Endpoint-Contract, bevor Sie
+> Felder downstream weiterverarbeiten. Beide Varianten enthalten Hash und
+> Dokument-ID zur nachträglichen Deduplication sowie den Similarity-Score.
+
+> 📈 **Score-Interpretation:** Die Ähnlichkeitswerte basieren auf
+> `1 / (1 + distance)` aus der pgvector-Metrik. Höhere Werte bedeuten größere
+> Nähe zum Query-Embedding, die Skala ist aber nicht linear normalisiert.
+> Deklarieren Sie Scores im UI daher als „Similarity Score“ statt als Prozent-
+> oder Qualitätswert.
+
 **cURL Beispiel**
 ```bash
 curl -X POST "https://api.noesis.example/ai/v1/rag-demo/" \
@@ -207,6 +225,14 @@ curl -X POST "https://api.noesis.example/ai/v1/rag-demo/" \
   -H "Content-Type: application/json" \
   -d '{"query": "Wie konfiguriere ich Tenant-Filter?", "top_k": 3}'
 ```
+
+### RAG Umgebungsvariablen
+
+| Variable | Default | Beschreibung |
+| --- | --- | --- |
+| `RAG_STATEMENT_TIMEOUT_MS` | `15000` | Maximale Ausführungszeit (in Millisekunden) für SQL-Statements des pgvector Clients. |
+| `RAG_RETRY_ATTEMPTS` | `3` | Anzahl der Wiederholungsversuche für Datenbankoperationen, bevor der Fehler propagiert wird. |
+| `RAG_RETRY_BASE_DELAY_MS` | `50` | Basiswartezeit zwischen Wiederholungsversuchen (linear skaliert mit dem Versuchszähler). |
 
 ## Agenten (Queue `agents`)
 

--- a/docs/rag/schema.sql
+++ b/docs/rag/schema.sql
@@ -39,6 +39,10 @@ CREATE INDEX IF NOT EXISTS chunks_document_ord_idx
 CREATE INDEX IF NOT EXISTS chunks_metadata_gin_idx
     ON chunks USING GIN (metadata);
 
+-- Targeted index to accelerate equality filters on common metadata keys
+CREATE INDEX IF NOT EXISTS chunks_metadata_case_idx
+    ON chunks ((metadata->>'case'));
+
 CREATE TABLE IF NOT EXISTS embeddings (
     id UUID PRIMARY KEY,
     chunk_id UUID NOT NULL REFERENCES chunks(id) ON DELETE CASCADE,

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -33,6 +33,20 @@ if "RAG_VECTOR_STORES" not in globals():
         }
     }
 
+    # Beispiel für ein Setup mit dediziertem Scope:
+    # RAG_VECTOR_STORES = {
+    #     "global": {
+    #         "backend": "pgvector",
+    #         "default": True,
+    #     },
+    #     "enterprise": {
+    #         "backend": "pgvector",
+    #         "schema": "rag_enterprise",
+    #         "tenants": ["<uuid-tenant-id>"],
+    #         "schemas": ["acme_prod"],
+    #     },
+    # }
+
 
 def _load_common_headers_table() -> str:
     """Return the reference markdown table describing shared API headers."""


### PR DESCRIPTION
## Summary
- whitelist the pgvector metadata filters so only known keys map to SQL predicates and keep document hash/id lookups explicit
- normalise scalar filter values before binding them to tenant-aware queries
- add a regression test that ensures unknown filters are ignored while supported keys still return matches

## Testing
- PYTEST_ADDOPTS= pytest -q ai_core/tests/test_vector_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d90192ea98832ba772d08b1329489d