### PR TITLE
Ensure retrieve node returns tenant metadata in snippets

### DIFF
--- a/ai_core/nodes/retrieve.py
+++ b/ai_core/nodes/retrieve.py
@@ -94,17 +94,7 @@ def run(
         extra_meta = {
             key: value
             for key, value in chunk_meta.items()
-            if key
-            not in {
-                "source",
-                "score",
-                "hash",
-                "id",
-                "tenant",
-                "case",
-                "tenant_id",
-                "case_id",
-            }
+            if key not in {"source", "score", "hash", "id"}
         }
         if extra_meta:
             snippet["meta"] = extra_meta


### PR DESCRIPTION
## Summary
- allow the retrieve node to keep tenant and case metadata when building snippets
- ensure additional chunk metadata remains available to consumers

## Testing
- pytest ai_core/tests/test_nodes.py::test_retrieve_returns_snippets -q

------
https://chatgpt.com/codex/tasks/task_e_68da7f1950ac832ba784bf537b238e72