### PR TITLE
Fix RAG upload metadata assertion

### DIFF
--- a/ai_core/tests/test_rag_upload.py
+++ b/ai_core/tests/test_rag_upload.py
@@ -55,7 +55,11 @@ def test_rag_upload_persists_file_and_metadata(
 
     metadata_path = uploads_dir / f"{document_id}.meta.json"
     assert metadata_path.exists()
-    assert json.loads(metadata_path.read_text()) == metadata
+    stored_metadata = json.loads(metadata_path.read_text())
+    assert stored_metadata["source"] == "unit-test"
+    assert isinstance(stored_metadata.get("external_id"), str)
+    assert stored_metadata["external_id"]
+    assert set(stored_metadata) == {"source", "external_id"}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- update the RAG upload test to accept the generated external_id while verifying the provided metadata

## Testing
- pytest ai_core/tests/test_rag_upload.py::test_rag_upload_persists_file_and_metadata -q

------
https://chatgpt.com/codex/tasks/task_e_68da7f260050832baa64abbd2777dd61