### PR TITLE
Add safeguards for empty embeddings and hybrid cutoff telemetry

### DIFF
--- a/ai_core/graphs/rag_demo.py
+++ b/ai_core/graphs/rag_demo.py
@@ -3,10 +3,21 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, Iterable, List, Tuple
 
+import time
+
+from django.conf import settings
+
+from ai_core.rag import metrics
+from ai_core.rag.normalization import normalise_text
+from common.logging import get_logger
+
 try:
     from ai_core.rag.vector_store import get_default_router
 except ImportError:  # pragma: no cover - optional dependency for demo mode
     get_default_router = None  # type: ignore[assignment]
+
+
+logger = get_logger(__name__)
 
 
 QueryState = Dict[str, Any]
@@ -55,10 +66,16 @@ def _chunk_matches(chunks: Iterable[Any]) -> List[Dict[str, Any]]:
             score_value = float(score) if score is not None else 0.0
         except (TypeError, ValueError):
             score_value = 0.0
+        vscore = float(meta.get("vscore", 0.0) or 0.0)
+        lscore = float(meta.get("lscore", 0.0) or 0.0)
+        fused = float(meta.get("fused", score_value) or score_value)
         matches.append(
             {
                 "id": str(identifier),
-                "score": score_value,
+                "score": fused,
+                "fused": fused,
+                "vscore": vscore,
+                "lscore": lscore,
                 "text": _truncate(str(content)),
                 "metadata": dict(meta),
             }
@@ -147,11 +164,23 @@ def run(state: QueryState, meta: Meta) -> Tuple[QueryState, GraphResult]:
     top_k = _coerce_top_k(state)
     project_id = state.get("project_id")
 
-    matches: List[Dict[str, Any]]
+    matches: List[Dict[str, Any]] = []
     router_error: str | None = None
+    retrieved_chunks: List[Any] = []
+    hybrid_result = None
+    latency_ms = 0.0
+
+    normalized_query = normalise_text(query)
+    search_input = normalized_query or query.strip()
+
+    index_kind = str(getattr(settings, "RAG_INDEX_KIND", "HNSW")).upper()
+    alpha = float(getattr(settings, "RAG_HYBRID_ALPHA", 0.7))
+    min_sim = float(getattr(settings, "RAG_MIN_SIM", 0.15))
+    ef_search = int(getattr(settings, "RAG_HNSW_EF_SEARCH", 80))
+    probes = int(getattr(settings, "RAG_IVF_PROBES", 64))
 
     if get_default_router is not None:
-        filters = {"tenant_id": tenant_id}
+        filters: Dict[str, Any] = {"tenant_id": tenant_id}
         if project_id:
             filters["project_id"] = project_id
 
@@ -167,7 +196,6 @@ def run(state: QueryState, meta: Meta) -> Tuple[QueryState, GraphResult]:
             scoped_router = router
             for_tenant = getattr(router, "for_tenant", None)
             if callable(for_tenant):
-
                 scoped_router, scoped_error = _resolve_tenant_router(
                     for_tenant, tenant_id, tenant_schema
                 )
@@ -176,38 +204,185 @@ def run(state: QueryState, meta: Meta) -> Tuple[QueryState, GraphResult]:
                 elif scoped_router is None:
                     scoped_router = router
 
-            search = (
-                getattr(scoped_router, "search", None)
-                if scoped_router is not None
-                else None
-            )
-            if callable(search):
-                case_id = meta.get("case_id") or meta.get("case")
-                try:
-                    chunks = search(
-                        query,
-                        tenant_id=tenant_id,
+            case_id = meta.get("case_id") or meta.get("case")
+            start_ts = time.perf_counter()
+            try:
+                hybrid_callable = getattr(scoped_router, "hybrid_search", None)
+                router_hybrid = getattr(router, "hybrid_search", None)
+                if callable(hybrid_callable):
+                    try:
+                        hybrid_result = hybrid_callable(
+                            search_input,
+                            tenant_id=str(tenant_id),
+                            case_id=case_id,
+                            top_k=top_k,
+                            filters=filters,
+                            alpha=alpha,
+                            min_sim=min_sim,
+                        )
+                    except TypeError:
+                        hybrid_result = hybrid_callable(
+                            search_input,
+                            case_id=case_id,
+                            top_k=top_k,
+                            filters=filters,
+                            alpha=alpha,
+                            min_sim=min_sim,
+                        )
+                    retrieved_chunks = list(getattr(hybrid_result, "chunks", []))
+                elif callable(router_hybrid):
+                    scope_name = getattr(scoped_router, "_scope", None)
+                    hybrid_result = router_hybrid(
+                        search_input,
+                        tenant_id=str(tenant_id),
                         case_id=case_id,
                         top_k=top_k,
                         filters=filters,
+                        scope=scope_name or router.default_scope,
+                        alpha=alpha,
+                        min_sim=min_sim,
                     )
-                    matches = _chunk_matches(chunks)
-                except Exception as exc:  # pragma: no cover - defensive fallback
-                    router_error = str(exc)
-                    matches = _demo_matches(query, str(tenant_id), top_k=top_k)
-            else:
-                if router_error is None:
-                    router_error = "router missing search"
-                matches = _demo_matches(query, str(tenant_id), top_k=top_k)
+                    retrieved_chunks = list(getattr(hybrid_result, "chunks", []))
+                else:
+                    search_method = getattr(scoped_router, "search", None)
+                    if not callable(search_method):
+                        raise AttributeError("router missing search")
+                    retrieved_chunks = list(
+                        search_method(
+                            search_input,
+                            tenant_id=tenant_id,
+                            case_id=case_id,
+                            top_k=top_k,
+                            filters=filters,
+                        )
+                    )
+                    hybrid_result = None
+                if hybrid_result is None:
+                    from ai_core.rag.vector_client import HybridSearchResult as _HybridSearchResult
+
+                    hybrid_result = _HybridSearchResult(
+                        chunks=retrieved_chunks,
+                        vector_candidates=len(retrieved_chunks),
+                        lexical_candidates=0,
+                        fused_candidates=len(retrieved_chunks),
+                        duration_ms=0.0,
+                        alpha=alpha,
+                        min_sim=min_sim,
+                        vec_limit=top_k,
+                        lex_limit=top_k,
+                    )
+                matches = _chunk_matches(retrieved_chunks)
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                router_error = str(exc)
+                retrieved_chunks = []
+                matches = []
+            finally:
+                latency_ms = (time.perf_counter() - start_ts) * 1000
         else:
             matches = _demo_matches(query, str(tenant_id), top_k=top_k)
     else:
         matches = _demo_matches(query, str(tenant_id), top_k=top_k)
 
+    tenant_label = str(tenant_id)
+    if hybrid_result is not None and getattr(hybrid_result, "duration_ms", None) == 0.0:
+        try:
+            hybrid_result.duration_ms = latency_ms
+        except Exception:  # pragma: no cover - defensive attribute set
+            pass
+    below_cutoff = 0
+    returned_after_cutoff = len(retrieved_chunks)
+    query_embedding_empty = False
+    no_hit_due_to_cutoff = False
+    if hybrid_result is not None:
+        metrics.RAG_QUERY_TOTAL.labels(
+            tenant=tenant_label, index_kind=index_kind, hybrid="true"
+        ).inc()
+        metrics.RAG_QUERY_LATENCY_MS.labels(
+            tenant=tenant_label, index_kind=index_kind, hybrid="true"
+        ).observe(latency_ms)
+        metrics.RAG_QUERY_CANDIDATES.labels(
+            tenant=tenant_label, type="semantic"
+        ).observe(float(hybrid_result.vector_candidates))
+        metrics.RAG_QUERY_CANDIDATES.labels(
+            tenant=tenant_label, type="lexical"
+        ).observe(float(hybrid_result.lexical_candidates))
+
+        top1_fused = 0.0
+        top1_vscore = 0.0
+        top1_lscore = 0.0
+        below_cutoff = int(getattr(hybrid_result, "below_cutoff", 0))
+        returned_after_cutoff = int(
+            getattr(hybrid_result, "returned_after_cutoff", len(retrieved_chunks))
+        )
+        query_embedding_empty = bool(
+            getattr(hybrid_result, "query_embedding_empty", False)
+        )
+        if retrieved_chunks:
+            top_meta = retrieved_chunks[0].meta or {}
+            top1_fused = float(top_meta.get("fused", top_meta.get("score", 0.0)) or 0.0)
+            top1_vscore = float(top_meta.get("vscore", 0.0) or 0.0)
+            top1_lscore = float(top_meta.get("lscore", 0.0) or 0.0)
+            metrics.RAG_QUERY_TOP1_SIM.labels(tenant=tenant_label).observe(top1_fused)
+        else:
+            metrics.RAG_QUERY_NO_HIT.labels(tenant=tenant_label).inc()
+            no_hit_due_to_cutoff = (
+                below_cutoff > 0
+                and hybrid_result.fused_candidates > 0
+                and returned_after_cutoff == 0
+            )
+
+        logger.info(
+            "rag.hybrid_query",
+            extra={
+                "tenant": tenant_label,
+                "index_kind": index_kind,
+                "alpha": alpha,
+                "min_sim": min_sim,
+                "ef_search": ef_search if index_kind == "HNSW" else None,
+                "probes": probes if index_kind == "IVFFLAT" else None,
+                "latency_ms": latency_ms,
+                "db_latency_ms": float(hybrid_result.duration_ms),
+                "top1_fused": top1_fused,
+                "top1_vscore": top1_vscore,
+                "top1_lscore": top1_lscore,
+                "topk": top_k,
+                "vec_limit": hybrid_result.vec_limit,
+                "lex_limit": hybrid_result.lex_limit,
+                "vector_candidates": hybrid_result.vector_candidates,
+                "lexical_candidates": hybrid_result.lexical_candidates,
+                "below_cutoff": below_cutoff,
+                "returned_after_cutoff": returned_after_cutoff,
+                "query_embedding_empty": query_embedding_empty,
+                "hybrid": True,
+                "case_id": meta.get("case_id") or meta.get("case"),
+                "project_id": project_id,
+                "query_length": len(query),
+                "normalized_query_length": len(search_input),
+                "query_norm_len": len(normalized_query),
+                "cutoff": min_sim if no_hit_due_to_cutoff else None,
+            },
+        )
+
     warnings: List[str] = []
-    if not matches:
+    if no_hit_due_to_cutoff:
+        warnings.append("no_hit_above_threshold")
+    if not matches and not no_hit_due_to_cutoff:
         matches = _demo_matches(query, str(tenant_id), top_k=top_k)
         warnings.append("no_vector_matches_demo_fallback")
+
+    response_meta: Dict[str, Any] = {
+        "index_kind": index_kind,
+        "alpha": alpha,
+        "min_sim": min_sim,
+        "latency_ms": latency_ms,
+    }
+    if hybrid_result is not None:
+        response_meta["db_latency_ms"] = float(hybrid_result.duration_ms)
+        response_meta["vector_candidates"] = hybrid_result.vector_candidates
+        response_meta["lexical_candidates"] = hybrid_result.lexical_candidates
+        response_meta["below_cutoff"] = below_cutoff
+        response_meta["returned_after_cutoff"] = returned_after_cutoff
+        response_meta["query_embedding_empty"] = query_embedding_empty
 
     new_state = dict(state)
     new_state["rag_demo"] = {
@@ -216,7 +391,12 @@ def run(state: QueryState, meta: Meta) -> Tuple[QueryState, GraphResult]:
         "retrieved_count": len(matches),
     }
 
-    result: GraphResult = {"ok": True, "query": query, "matches": matches}
+    result: GraphResult = {
+        "ok": True,
+        "query": query,
+        "matches": matches,
+        "meta": response_meta,
+    }
     if router_error:
         result["error"] = router_error
 

--- a/ai_core/management/commands/rebuild_rag_index.py
+++ b/ai_core/management/commands/rebuild_rag_index.py
@@ -1,0 +1,76 @@
+import re
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection
+
+
+class Command(BaseCommand):
+    help = "Rebuild the embeddings vector index according to RAG_INDEX_KIND."
+
+    def handle(self, *args, **_options):
+        index_kind = str(getattr(settings, "RAG_INDEX_KIND", "HNSW")).upper()
+        if index_kind not in {"HNSW", "IVFFLAT"}:
+            raise CommandError(f"Unsupported RAG_INDEX_KIND '{index_kind}'")
+
+        hnsw_m = int(getattr(settings, "RAG_HNSW_M", 32))
+        hnsw_ef = int(getattr(settings, "RAG_HNSW_EF_CONSTRUCTION", 200))
+        ivf_lists = int(getattr(settings, "RAG_IVF_LISTS", 2048))
+
+        with connection.cursor() as cur:
+            cur.execute("SET search_path TO rag, public")
+            cur.execute("DROP INDEX IF EXISTS embeddings_embedding_hnsw")
+            cur.execute("DROP INDEX IF EXISTS embeddings_embedding_ivfflat")
+            if index_kind == "HNSW":
+                cur.execute(
+                    """
+                    CREATE INDEX embeddings_embedding_hnsw
+                    ON embeddings USING hnsw (embedding vector_cosine_ops)
+                    WITH (m = %s, ef_construction = %s)
+                    """,
+                    (hnsw_m, hnsw_ef),
+                )
+            else:
+                cur.execute(
+                    """
+                    CREATE INDEX embeddings_embedding_ivfflat
+                    ON embeddings USING ivfflat (embedding vector_cosine_ops)
+                    WITH (lists = %s)
+                    """,
+                    (ivf_lists,),
+                )
+            cur.execute("ANALYZE embeddings")
+            expected_index = (
+                "embeddings_embedding_hnsw"
+                if index_kind == "HNSW"
+                else "embeddings_embedding_ivfflat"
+            )
+            cur.execute(
+                """
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE schemaname = current_schema()
+                  AND tablename = 'embeddings'
+                  AND indexname = %s
+                """,
+                (expected_index,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise CommandError(
+                    f"Reindex failed: expected index '{expected_index}' was not created"
+                )
+            indexdef = row[0] or ""
+            if index_kind == "HNSW":
+                m_match = re.search(r"m\s*=\s*(\d+)", indexdef)
+                ef_match = re.search(r"ef_construction\s*=\s*(\d+)", indexdef)
+                details = f"m={m_match.group(1) if m_match else hnsw_m} ef_construction={ef_match.group(1) if ef_match else hnsw_ef}"
+            else:
+                lists_match = re.search(r"lists\s*=\s*(\d+)", indexdef)
+                details = f"lists={lists_match.group(1) if lists_match else ivf_lists}"
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Rebuilt embeddings index using {index_kind} (scope: rag.embeddings, {details})"
+            )
+        )

--- a/ai_core/rag/normalization.py
+++ b/ai_core/rag/normalization.py
@@ -1,0 +1,45 @@
+"""Utilities for consistent text normalisation used by RAG pipelines."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Iterable
+
+__all__ = ["normalise_text"]
+
+_WHITESPACE_RE = re.compile(r"\s+", re.UNICODE)
+_WORD_RE = re.compile(r"[\wäöüÄÖÜß]+", re.UNICODE)
+
+
+def _strip_german_plural(token: str) -> str:
+    """Apply a lightweight plural heuristic for German nouns."""
+
+    candidate = token
+    if len(candidate) <= 4:
+        return candidate
+    if not _WORD_RE.fullmatch(candidate):
+        return candidate
+    for suffix in ("en", "n", "e"):
+        if candidate.endswith(suffix) and len(candidate) - len(suffix) >= 4:
+            return candidate[: -len(suffix)]
+    return candidate
+
+
+def _apply_plural_heuristic(tokens: Iterable[str]) -> list[str]:
+    return [_strip_german_plural(token) for token in tokens]
+
+
+def normalise_text(value: str | None) -> str:
+    """Return a normalised representation of ``value`` for embeddings/search."""
+
+    if not value:
+        return ""
+    text = unicodedata.normalize("NFC", value)
+    text = text.lower()
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    if not text:
+        return ""
+    tokens = text.split(" ")
+    return " ".join(_apply_plural_heuristic(tokens))
+

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -233,6 +233,16 @@ curl -X POST "https://api.noesis.example/ai/v1/rag-demo/" \
 | `RAG_STATEMENT_TIMEOUT_MS` | `15000` | Maximale Ausführungszeit (in Millisekunden) für SQL-Statements des pgvector Clients. |
 | `RAG_RETRY_ATTEMPTS` | `3` | Anzahl der Wiederholungsversuche für Datenbankoperationen, bevor der Fehler propagiert wird. |
 | `RAG_RETRY_BASE_DELAY_MS` | `50` | Basiswartezeit zwischen Wiederholungsversuchen (linear skaliert mit dem Versuchszähler). |
+| `RAG_INDEX_KIND` | `HNSW` | Auswahl des Vektorindex (HNSW oder IVFFLAT) für das Embedding-Backend. |
+| `RAG_HNSW_M` | `32` | Kantenfaktor `m` für HNSW-Indizes; bestimmt die Graph-Konnektivität. |
+| `RAG_HNSW_EF_CONSTRUCTION` | `200` | `ef_construction`-Parameter für HNSW beim Aufbau des Index. |
+| `RAG_HNSW_EF_SEARCH` | `80` | Laufzeit-Parameter `ef_search` für HNSW-Abfragen (per Session gesetzt). |
+| `RAG_IVF_LISTS` | `2048` | Anzahl der Listen (`lists`) für IVFFLAT-Indizes. |
+| `RAG_IVF_PROBES` | `64` | Anzahl der `probes` für IVFFLAT-Suchen (per Session gesetzt). |
+| `RAG_MIN_SIM` | `0.15` | Minimale Fused-Similarity für Treffer (Werte darunter werden verworfen). |
+| `RAG_HYBRID_ALPHA` | `0.7` | Gewichtung der semantischen Similarität in der Late-Fusion (0 = nur Lexikalik). |
+| `RAG_CHUNK_TARGET_TOKENS` | `450` | Zielgröße pro Chunk in Tokens für die Vorverarbeitung. |
+| `RAG_CHUNK_OVERLAP_TOKENS` | `80` | Token-Overlap zwischen aufeinanderfolgenden Chunks. |
 
 ## Agenten (Queue `agents`)
 

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -47,6 +47,17 @@ if "RAG_VECTOR_STORES" not in globals():
     #     },
     # }
 
+RAG_INDEX_KIND = env("RAG_INDEX_KIND", default="HNSW").upper()
+RAG_HNSW_M = env.int("RAG_HNSW_M", default=32)
+RAG_HNSW_EF_CONSTRUCTION = env.int("RAG_HNSW_EF_CONSTRUCTION", default=200)
+RAG_HNSW_EF_SEARCH = env.int("RAG_HNSW_EF_SEARCH", default=80)
+RAG_IVF_LISTS = env.int("RAG_IVF_LISTS", default=2048)
+RAG_IVF_PROBES = env.int("RAG_IVF_PROBES", default=64)
+RAG_MIN_SIM = env.float("RAG_MIN_SIM", default=0.15)
+RAG_HYBRID_ALPHA = env.float("RAG_HYBRID_ALPHA", default=0.7)
+RAG_CHUNK_TARGET_TOKENS = env.int("RAG_CHUNK_TARGET_TOKENS", default=450)
+RAG_CHUNK_OVERLAP_TOKENS = env.int("RAG_CHUNK_OVERLAP_TOKENS", default=80)
+
 
 def _load_common_headers_table() -> str:
     """Return the reference markdown table describing shared API headers."""


### PR DESCRIPTION
## Summary
- guard ingestion and query paths against empty embeddings, skipping zero vectors and emitting the new counters
- enrich hybrid search logging/response with fused score details, cutoff diagnostics, and per-query metadata
- update dummy embeddings, metrics instrumentation, and the reindex command to reflect the new safeguards

## Testing
- pytest ai_core/tests/test_vector_client.py ai_core/tests/test_tasks.py ai_core/tests/test_graph_rag_demo.py

------
https://chatgpt.com/codex/tasks/task_e_68dadab3b36c832bbfff30e4eec2ecc8