### PR TITLE
Fix sentence splitting fallback for paragraph-only text

### DIFF
--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -123,8 +123,12 @@ def _split_sentences(text: str) -> List[str]:
 
     pattern = re.compile(r"[^.!?]+(?:[.!?]+|\Z)")
     sentences = [segment.strip() for segment in pattern.findall(text)]
+    sentences = [s for s in sentences if s]
     if sentences:
-        return [s for s in sentences if s]
+        if len(sentences) == 1 and not re.search(r"[.!?]", text):
+            sentences = []
+        else:
+            return sentences
     # Fallback: use paragraphs or lines if no sentence boundary detected
     parts = [part.strip() for part in text.splitlines() if part.strip()]
     return parts or [text.strip()]


### PR DESCRIPTION
## Summary
- ensure `_split_sentences` falls back to paragraph or line splitting when no punctuation-based boundaries are found

## Testing
- pytest ai_core/tests/test_tasks.py::test_split_sentences_falls_back_to_paragraphs -q

------
https://chatgpt.com/codex/tasks/task_e_68dc39483788832b9332778978142e92