### PR TITLE
Handle missing Django settings when masking log context

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -155,8 +155,14 @@ def mask_value(value: str | None) -> str:
 
 def _masking_enabled() -> bool:
     from django.conf import settings  # imported lazily to avoid circular import
+    from django.core.exceptions import ImproperlyConfigured
 
-    return not getattr(settings, "LOGGING_ALLOW_UNMASKED_CONTEXT", False)
+    try:
+        allow_unmasked = getattr(settings, "LOGGING_ALLOW_UNMASKED_CONTEXT", False)
+    except ImproperlyConfigured:
+        return True
+
+    return not bool(allow_unmasked)
 
 
 def _context_processor(


### PR DESCRIPTION
## Summary
- ensure log masking defaults to enabled when Django settings are unavailable
- coerce LOGGING_ALLOW_UNMASKED_CONTEXT to a boolean to avoid truthy string leaks

## Testing
- pytest common/tests/test_logging.py::test_structlog_logger_includes_context_and_service -q
- pytest common/tests/test_logging.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc38b9525c832b96d3168281d7818d