### PR TITLE
Adjust hybrid fusion fallback for lexical results

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -746,9 +746,13 @@ class PgVectorClient:
             except (TypeError, ValueError):
                 lscore = 0.0
             lscore = max(0.0, lscore)
-            fused = max(
-                0.0, min(1.0, alpha_value * vscore + (1.0 - alpha_value) * lscore)
-            )
+            if has_vector_signal:
+                fused = max(
+                    0.0,
+                    min(1.0, alpha_value * vscore + (1.0 - alpha_value) * lscore),
+                )
+            else:
+                fused = max(0.0, min(1.0, lscore))
             meta["vscore"] = vscore
             meta["lscore"] = lscore
             meta["fused"] = fused


### PR DESCRIPTION
## Summary
- use the pure lexical score when no vector signal is available during hybrid fusion
- keep fused metadata aligned with the lexical score and respect existing cut-off logic
- add a regression test ensuring lexical-only results remain above the minimum similarity even with high alpha

## Testing
- `pytest tests/rag/test_vector_client.py -k lexical_only_respects -q`


------
https://chatgpt.com/codex/tasks/task_e_68dc49cae0c8832ba23d92cf7530d129