### PR TITLE
Fix trigram normalization and fused scoring fallback

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -652,7 +652,11 @@ class PgVectorClient:
                                 """
                                 cur.execute(
                                     fallback_lexical_sql,
-                                    (query_norm, *where_params, lex_limit_value),
+                                    (
+                                        query_db_norm,
+                                        *where_params,
+                                        lex_limit_value,
+                                    ),
                                 )
                                 lexical_rows_local = cur.fetchall()
                                 try:
@@ -829,7 +833,9 @@ class PgVectorClient:
             except (TypeError, ValueError):
                 lscore = 0.0
             lscore = max(0.0, lscore)
-            if has_vector_signal:
+            if query_embedding_empty:
+                fused = max(0.0, min(1.0, lscore))
+            elif has_vector_signal:
                 fused = max(
                     0.0,
                     min(1.0, alpha_value * vscore + (1.0 - alpha_value) * lscore),

--- a/ai_core/tests/test_vector_client.py
+++ b/ai_core/tests/test_vector_client.py
@@ -525,6 +525,8 @@ class TestPgVectorClient:
         ][0]
         assert logged["alpha"] == 0.0
         assert logged["tenant"] == tenant
+        assert "case" in logged
+        assert logged["case"] is None
 
     def test_hybrid_search_lexical_matches_database_normalisation(
         self, monkeypatch


### PR DESCRIPTION
## Summary
- align pg_trgm lexical scoring to use `normalise_text_db` so search matches the stored normalization
- keep fused score equal to the lexical score whenever the query embedding is empty and extend the null-embedding log assertions

## Testing
- `pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_search_lexical_matches_database_normalisation` *(fails: ValueError: Plugin already registered under a different name for ai_core/tests/conftest.py)*
- `pytest tests/rag/test_vector_client.py::test_lexical_only_respects_min_sim_with_alpha` *(skipped: reported as skipped by pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68dccc99d3d0832b839ec51b1a5ba18d