### PR TITLE
Ensure trigram fallback honors requested threshold

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -754,6 +754,10 @@ class PgVectorClient:
                                     LIMIT %s
                                 """
                                 base_limits: List[float] = []
+                                if fallback_requested and (
+                                    requested_trgm_limit is not None
+                                ):
+                                    base_limits.append(float(requested_trgm_limit))
                                 if applied_trgm_limit is not None:
                                     base_limits.append(float(applied_trgm_limit))
                                 else:


### PR DESCRIPTION
## Summary
- ensure the lexical fallback attempts the explicitly requested trigram limit before server defaults

## Testing
- pytest tests/rag/test_vector_client.py::test_explicit_trgm_limit_fallback_uses_requested_threshold tests/rag/test_vector_client.py::test_applies_set_limit_and_logs_applied_value -q

------
https://chatgpt.com/codex/tasks/task_e_68dd8ec714e8832b9fe04c75c4d8c17c