### PR TITLE
Add external IDs to pgvector integration test chunks

### DIFF
--- a/ai_core/tests/test_vector_pg_integration.py
+++ b/ai_core/tests/test_vector_pg_integration.py
@@ -24,6 +24,7 @@ def _make_chunk(tenant_id: str, ordinal: int, *, hash_id: str) -> Chunk:
             "tenant": tenant_id,
             "hash": hash_id,
             "source": "integration-test",
+            "external_id": f"{hash_id}-external",
         },
         embedding=[base_value] + [0.0] * (vector_client.EMBEDDING_DIM - 1),
     )


### PR DESCRIPTION
## Summary
- include an `external_id` in the integration test chunk metadata to satisfy pgvector client validation

## Testing
- pytest ai_core/tests/test_vector_pg_integration.py::test_router_roundtrip_with_pgvector_backend -q (skipped: RAG test database DSN not configured)


------
https://chatgpt.com/codex/tasks/task_e_68dd90c27680832b9e34a3e8133acfb7