### PR TITLE
Fix struct log fields for strict reject event

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -980,16 +980,14 @@ class PgVectorClient:
                         reasons.append("case_mismatch")
                 logger.info(
                     "rag.strict.reject",
-                    extra={
-                        "tenant": tenant,
-                        "case": case_value,
-                        "candidate_tenant": candidate_tenant,
-                        "candidate_case": candidate_case,
-                        "doc_hash": doc_hash,
-                        "doc_id": doc_id,
-                        "chunk_id": entry["chunk_id"],
-                        "reasons": reasons or ["unknown"],
-                    },
+                    tenant=tenant,
+                    case=case_value,
+                    candidate_tenant=candidate_tenant,
+                    candidate_case=candidate_case,
+                    doc_hash=doc_hash,
+                    doc_id=doc_id,
+                    chunk_id=entry["chunk_id"],
+                    reasons=reasons or ["unknown"],
                 )
                 continue
             try:


### PR DESCRIPTION
## Summary
- bind rag.strict.reject log metadata as structlog fields instead of an extra payload
- ensure reject reasons and candidate metadata are emitted for hybrid search logs

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_search_logs_strict_reject_reason -q

------
https://chatgpt.com/codex/tasks/task_e_68dd90fa6c58832bbfd8895230ebe85e