### PR TITLE
Ensure lexical fallback log exposes count field

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -870,10 +870,8 @@ class PgVectorClient:
             try:
                 logger.warning(
                     "rag.debug.rows.lexical.final",
-                    extra={
-                        "count": len(lexical_rows),
-                        "first_len": (len(lexical_rows[0]) if lexical_rows else 0),
-                    },
+                    count=len(lexical_rows),
+                    first_len=(len(lexical_rows[0]) if lexical_rows else 0),
                 )
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- log lexical row counts using structlog keyword arguments so capture_logs can see them

## Testing
- pytest tests/rag/test_vector_client.py::test_lexical_fallback_populates_rows -q

------
https://chatgpt.com/codex/tasks/task_e_68dd93f61004832bb9969dd3c4f1e077