### PR TITLE
Relax trigram fallback threshold floor

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -789,6 +789,9 @@ class PgVectorClient:
                                         0.05,
                                         0.04,
                                         0.03,
+                                        0.02,
+                                        0.01,
+                                        0.0,
                                     ]
                                 )
                                 fallback_limits: List[float] = []
@@ -797,7 +800,7 @@ class PgVectorClient:
                                         limit_value = float(limit)
                                     except (TypeError, ValueError):
                                         continue
-                                    limit_value = max(0.03, limit_value)
+                                    limit_value = max(0.0, limit_value)
                                     if limit_value not in fallback_limits:
                                         fallback_limits.append(limit_value)
                                 picked_limit: float | None = None


### PR DESCRIPTION
## Summary
- extend the lexical fallback search to probe lower trigram similarity limits down to zero
- ensure fallback threshold candidates are deduplicated without enforcing a 0.03 minimum

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_search_pg_trgm_fallback_records_counts -q

------
https://chatgpt.com/codex/tasks/task_e_68dd9412cac8832baec7a8143fbf40b3