### PR TITLE
Fix cutoff fallback to return chunk objects

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -1088,7 +1088,7 @@ class PgVectorClient:
             filtered_results = [chunk for chunk, _ in results]
         limited_results = filtered_results[:top_k]
         if not limited_results and results and min_sim_value > 0.0:
-            limited_results = results[:top_k]
+            limited_results = [chunk for chunk, _ in results[:top_k]]
             try:
                 logger.info(
                     "rag.hybrid.cutoff_fallback",


### PR DESCRIPTION
## Summary
- ensure hybrid search cutoff fallback returns Chunk objects

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_search_counts_candidates_below_min_sim_cutoff -q

------
https://chatgpt.com/codex/tasks/task_e_68dd942f440c832baa011240786b99cf