### PR TITLE
Flatten structlog extras into structured log entries

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 from typing import Any, Dict, Iterator, MutableMapping, Sequence, TextIO
+from collections.abc import Mapping
 
 import structlog
 from opentelemetry import trace
@@ -434,6 +435,11 @@ class _ContextAwareBoundLogger(structlog.stdlib.BoundLogger):
     ) -> tuple[Sequence[Any], MutableMapping[str, object]]:
         event_dict: Any = self._context.copy()
         event_dict.update(**event_kw)
+
+        extra_payload = event_dict.pop("extra", None)
+        if isinstance(extra_payload, Mapping):
+            for key, value in extra_payload.items():
+                event_dict.setdefault(key, value)
 
         context = get_log_context()
         if context:


### PR DESCRIPTION
## Summary
- flatten structlog `extra` payloads into the structured event context for our bound logger
- ensure log assertions can access fields such as `picked_limit` directly on the captured entries

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_fallback_runs_when_show_limit_empty_and_primary_errors -vv -s


------
https://chatgpt.com/codex/tasks/task_e_68dd94523b2c832b9152018d40a91af3