### PR TITLE
Ensure structlog extra payload is merged into event context

### DIFF
--- a/common/logging.py
+++ b/common/logging.py
@@ -10,7 +10,7 @@ import logging.config
 import os
 import re
 import sys
-from typing import Any, Dict, Iterator, MutableMapping, Sequence, TextIO
+from typing import Any, Dict, Iterator, MutableMapping, Sequence, TextIO, Mapping
 
 import structlog
 from opentelemetry import trace
@@ -434,6 +434,10 @@ class _ContextAwareBoundLogger(structlog.stdlib.BoundLogger):
     ) -> tuple[Sequence[Any], MutableMapping[str, object]]:
         event_dict: Any = self._context.copy()
         event_dict.update(**event_kw)
+
+        extra_payload = event_dict.pop("extra", None)
+        if isinstance(extra_payload, Mapping):
+            event_dict.update(extra_payload)
 
         context = get_log_context()
         if context:


### PR DESCRIPTION
## Summary
- flatten legacy logging `extra` payloads in the context-aware structlog adapter so structured fields remain accessible
- keep compatibility for log assertions that expect keys like `picked_limit` at the top level

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_fallback_relaxes_trgm_limit_until_match -q *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68dd945a86e4832b81f1c0ad1d44d05c