### PR TITLE
Allow trigram fallback to include zero-similarity matches

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -797,9 +797,14 @@ class PgVectorClient:
                                         limit_value = float(limit)
                                     except (TypeError, ValueError):
                                         continue
-                                    limit_value = max(0.03, limit_value)
+                                    if limit_value <= 0.0:
+                                        limit_value = 0.0
+                                    elif limit_value < 0.03:
+                                        limit_value = 0.03
                                     if limit_value not in fallback_limits:
                                         fallback_limits.append(limit_value)
+                                if 0.0 not in fallback_limits:
+                                    fallback_limits.append(0.0)
                                 picked_limit: float | None = None
                                 last_attempt_rows: List[tuple] = []
                                 for limit_value in fallback_limits:


### PR DESCRIPTION
## Summary
- allow the trigram fallback flow to include a zero-similarity threshold when all other limits fail
- ensure lexical hybrid search can still surface a candidate when the query has no trigram overlap

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_search_uses_similarity_fallback_when_trigram_has_no_match -q


------
https://chatgpt.com/codex/tasks/task_e_68dd946633e0832bb9324c0aef762108