### PR TITLE
Fix null embedding log fields

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -515,7 +515,9 @@ class PgVectorClient:
             metrics.RAG_QUERY_EMPTY_VEC_TOTAL.labels(tenant=tenant).inc()
             logger.info(
                 "rag.hybrid.null_embedding",
-                extra={"alpha": alpha_value, "tenant": tenant, "case": case_value},
+                alpha=alpha_value,
+                tenant=tenant,
+                case=case_value,
             )
         index_kind = str(_get_setting("RAG_INDEX_KIND", "HNSW")).upper()
         ef_search = int(_get_setting("RAG_HNSW_EF_SEARCH", 80))


### PR DESCRIPTION
## Summary
- ensure the null-embedding hybrid search log exposes alpha, tenant, and case at the top level for easier inspection

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_search_falls_back_on_empty_query_embedding -q


------
https://chatgpt.com/codex/tasks/task_e_68dd94a0d140832b9090cce7f029c463