### PR TITLE
Handle missing vector scores without boosting fusion

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -936,15 +936,16 @@ class PgVectorClient:
                 },
             )
             entry["chunk_id"] = chunk_id if chunk_id is not None else key
-            distance_value = float(score_raw)
-            if distance_score_mode == "inverse":
-                distance_value = max(0.0, distance_value)
-                vscore = 1.0 / (1.0 + distance_value)
-            else:
-                vscore = max(0.0, 1.0 - float(distance_value))
-            entry["vscore"] = max(float(entry.get("vscore", 0.0)), vscore)
             if vector_score_missing:
                 entry["_allow_below_cutoff"] = True
+            else:
+                distance_value = float(score_raw)
+                if distance_score_mode == "inverse":
+                    distance_value = max(0.0, distance_value)
+                    vscore = 1.0 / (1.0 + distance_value)
+                else:
+                    vscore = max(0.0, 1.0 - float(distance_value))
+                entry["vscore"] = max(float(entry.get("vscore", 0.0)), vscore)
 
         for row in lexical_rows:
             lexical_score_missing = len(row) < 6


### PR DESCRIPTION
## Summary
- avoid computing a fused vector score when the pgvector row is missing a distance value so truncated rows do not inherit a bogus score

## Testing
- pytest tests/rag/test_vector_client.py::test_truncated_vector_row_populates_metadata -q

------
https://chatgpt.com/codex/tasks/task_e_68dd98112068832b8f40ef5748015a92