### PR TITLE
Fix hybrid search cutoff fallback handling

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -1092,7 +1092,6 @@ class PgVectorClient:
             filtered_results = [chunk for chunk, _ in results]
         limited_results = filtered_results[:top_k]
         if not limited_results and results and min_sim_value > 0.0:
-            limited_results = [chunk for chunk, _ in results[:top_k]]
             try:
                 logger.info(
                     "rag.hybrid.cutoff_fallback",


### PR DESCRIPTION
## Summary
- avoid returning candidates that failed the minimum similarity cutoff when falling back to cutoff logging only

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_search_counts_candidates_below_min_sim_cutoff -q

------
https://chatgpt.com/codex/tasks/task_e_68dd982458dc832b8374c33b18057e64