### PR TITLE
Ensure vector fallback rows do not contribute positive vscore

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -937,7 +937,9 @@ class PgVectorClient:
             )
             entry["chunk_id"] = chunk_id if chunk_id is not None else key
             distance_value = float(score_raw)
-            if distance_score_mode == "inverse":
+            if vector_score_missing:
+                vscore = 0.0
+            elif distance_score_mode == "inverse":
                 distance_value = max(0.0, distance_value)
                 vscore = 1.0 / (1.0 + distance_value)
             else:


### PR DESCRIPTION
## Summary
- ensure vector search rows missing a score default to a zero vector score
- prevent shape-mismatched vector rows from inflating fused scoring while still allowing results

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_row_shape_mismatch_does_not_crash

------
https://chatgpt.com/codex/tasks/task_e_68dd982d9c30832b9659fca307fa3991