### PR TITLE
Fix rag index rebuild command to use schema-qualified names

### DIFF
--- a/ai_core/management/commands/rebuild_rag_index.py
+++ b/ai_core/management/commands/rebuild_rag_index.py
@@ -1,8 +1,11 @@
 import re
+from collections.abc import Mapping
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
+
+from psycopg2 import sql
 
 
 class Command(BaseCommand):
@@ -17,29 +20,37 @@ class Command(BaseCommand):
         hnsw_ef = int(getattr(settings, "RAG_HNSW_EF_CONSTRUCTION", 200))
         ivf_lists = int(getattr(settings, "RAG_IVF_LISTS", 2048))
 
+        schema = self._resolve_vector_schema()
+        embeddings_table = sql.Identifier(schema, "embeddings")
+        hnsw_index = sql.Identifier(schema, "embeddings_embedding_hnsw")
+        ivfflat_index = sql.Identifier(schema, "embeddings_embedding_ivfflat")
+
         with connection.cursor() as cur:
-            cur.execute("SET search_path TO rag, public")
-            cur.execute("DROP INDEX IF EXISTS embeddings_embedding_hnsw")
-            cur.execute("DROP INDEX IF EXISTS embeddings_embedding_ivfflat")
+            cur.execute(sql.SQL("DROP INDEX IF EXISTS {}").format(hnsw_index))
+            cur.execute(sql.SQL("DROP INDEX IF EXISTS {}").format(ivfflat_index))
             if index_kind == "HNSW":
                 cur.execute(
-                    """
-                    CREATE INDEX embeddings_embedding_hnsw
-                    ON embeddings USING hnsw (embedding vector_cosine_ops)
-                    WITH (m = %s, ef_construction = %s)
-                    """,
+                    sql.SQL(
+                        """
+                        CREATE INDEX {index}
+                        ON {table} USING hnsw (embedding vector_cosine_ops)
+                        WITH (m = %s, ef_construction = %s)
+                        """
+                    ).format(index=hnsw_index, table=embeddings_table),
                     (hnsw_m, hnsw_ef),
                 )
             else:
                 cur.execute(
-                    """
-                    CREATE INDEX embeddings_embedding_ivfflat
-                    ON embeddings USING ivfflat (embedding vector_cosine_ops)
-                    WITH (lists = %s)
-                    """,
+                    sql.SQL(
+                        """
+                        CREATE INDEX {index}
+                        ON {table} USING ivfflat (embedding vector_cosine_ops)
+                        WITH (lists = %s)
+                        """
+                    ).format(index=ivfflat_index, table=embeddings_table),
                     (ivf_lists,),
                 )
-            cur.execute("ANALYZE embeddings")
+            cur.execute(sql.SQL("ANALYZE {}").format(embeddings_table))
             expected_index = (
                 "embeddings_embedding_hnsw"
                 if index_kind == "HNSW"
@@ -49,11 +60,11 @@ class Command(BaseCommand):
                 """
                 SELECT indexdef
                 FROM pg_indexes
-                WHERE schemaname = current_schema()
-                  AND tablename = 'embeddings'
+                WHERE schemaname = %s
+                  AND tablename = %s
                   AND indexname = %s
                 """,
-                (expected_index,),
+                (schema, "embeddings", expected_index),
             )
             row = cur.fetchone()
             if not row:
@@ -64,13 +75,34 @@ class Command(BaseCommand):
             if index_kind == "HNSW":
                 m_match = re.search(r"m\s*=\s*(\d+)", indexdef)
                 ef_match = re.search(r"ef_construction\s*=\s*(\d+)", indexdef)
-                details = f"m={m_match.group(1) if m_match else hnsw_m} ef_construction={ef_match.group(1) if ef_match else hnsw_ef}"
+                m_value = m_match.group(1) if m_match else hnsw_m
+                ef_value = ef_match.group(1) if ef_match else hnsw_ef
+                details = f"m={m_value} ef_construction={ef_value}"
             else:
                 lists_match = re.search(r"lists\s*=\s*(\d+)", indexdef)
-                details = f"lists={lists_match.group(1) if lists_match else ivf_lists}"
+                lists_value = lists_match.group(1) if lists_match else ivf_lists
+                details = f"lists={lists_value}"
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"Rebuilt embeddings index using {index_kind} (scope: rag.embeddings, {details})"
+                f"Rebuilt embeddings index using {index_kind} (scope: {schema}.embeddings, {details})"
             )
         )
+
+    def _resolve_vector_schema(self) -> str:
+        stores = getattr(settings, "RAG_VECTOR_STORES", {})
+        default_scope = getattr(settings, "RAG_VECTOR_DEFAULT_SCOPE", None)
+
+        if isinstance(stores, Mapping) and stores:
+            scope = (
+                default_scope
+                if isinstance(default_scope, str) and default_scope in stores
+                else ("global" if "global" in stores else next(iter(stores), ""))
+            )
+            config = stores.get(scope, {}) if scope else {}
+            if isinstance(config, Mapping):
+                schema = config.get("schema")
+                if isinstance(schema, str) and schema:
+                    return schema
+
+        return "rag"


### PR DESCRIPTION
## Summary
- ensure the `rebuild_rag_index` management command uses schema-qualified identifiers when dropping and creating vector indexes
- derive the target schema from the configured RAG vector stores and include it in the success message

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py -k expected_index -q *(skipped: PostgreSQL with pgvector extension is required for RAG tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dd985ea638832b9e7e8389de46461c