### PR TITLE
Allow fallback lexical matches to bypass minimum similarity filtering

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -1014,6 +1014,11 @@ class PgVectorClient:
             entry["lscore"] = max(float(entry.get("lscore", 0.0)), lscore_value)
             if lexical_score_missing:
                 entry["_allow_below_cutoff"] = True
+            elif (
+                fallback_limit_used_value is not None
+                and fallback_limit_used_value < min_sim_value
+            ):
+                entry["_allow_below_cutoff"] = True
 
         fused_candidates = len(candidates)
         logger.info(


### PR DESCRIPTION
## Summary
- allow lexical fallback candidates picked with relaxed trigram limits to bypass the minimum similarity cutoff so they are returned to callers
- ensure hybrid search still yields lexical matches when only the trigram fallback fires

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_search_pg_trgm_fallback_records_counts -q

------
https://chatgpt.com/codex/tasks/task_e_68dd9bded928832ba16d7e56d62cc0f4