### PR TITLE
Ensure rebuild_rag_index targets configured schema

### DIFF
--- a/ai_core/management/commands/rebuild_rag_index.py
+++ b/ai_core/management/commands/rebuild_rag_index.py
@@ -2,7 +2,7 @@ import re
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from psycopg2 import errors
+from psycopg2 import errors, sql
 
 from ai_core.rag import vector_client
 
@@ -20,6 +20,8 @@ class Command(BaseCommand):
         ivf_lists = int(getattr(settings, "RAG_IVF_LISTS", 2048))
 
         client = vector_client.get_default_client()
+        schema_name = getattr(client, "_schema", "rag")
+        scope = f"{schema_name}.embeddings"
         expected_index = (
             "embeddings_embedding_hnsw"
             if index_kind == "HNSW"
@@ -29,36 +31,67 @@ class Command(BaseCommand):
         with client._connection() as conn:  # type: ignore[attr-defined]
             try:
                 with conn.cursor() as cur:
-                    cur.execute("DROP INDEX IF EXISTS embeddings_embedding_hnsw")
-                    cur.execute("DROP INDEX IF EXISTS embeddings_embedding_ivfflat")
+                    cur.execute(
+                        sql.SQL("SET search_path TO {}, public").format(
+                            sql.Identifier(schema_name)
+                        )
+                    )
+                    cur.execute(
+                        sql.SQL("DROP INDEX IF EXISTS {}").format(
+                            sql.Identifier(schema_name, "embeddings_embedding_hnsw")
+                        )
+                    )
+                    cur.execute(
+                        sql.SQL("DROP INDEX IF EXISTS {}").format(
+                            sql.Identifier(
+                                schema_name, "embeddings_embedding_ivfflat"
+                            )
+                        )
+                    )
                     if index_kind == "HNSW":
                         cur.execute(
-                            """
-                            CREATE INDEX embeddings_embedding_hnsw
-                            ON embeddings USING hnsw (embedding vector_cosine_ops)
-                            WITH (m = %s, ef_construction = %s)
-                            """,
+                            sql.SQL(
+                                """
+                                CREATE INDEX {} ON {} USING hnsw (embedding vector_cosine_ops)
+                                WITH (m = %s, ef_construction = %s)
+                                """
+                            ).format(
+                                sql.Identifier(
+                                    schema_name, "embeddings_embedding_hnsw"
+                                ),
+                                sql.Identifier(schema_name, "embeddings"),
+                            ),
                             (hnsw_m, hnsw_ef),
                         )
                     else:
                         cur.execute(
-                            """
-                            CREATE INDEX embeddings_embedding_ivfflat
-                            ON embeddings USING ivfflat (embedding vector_cosine_ops)
-                            WITH (lists = %s)
-                            """,
+                            sql.SQL(
+                                """
+                                CREATE INDEX {} ON {} USING ivfflat (embedding vector_cosine_ops)
+                                WITH (lists = %s)
+                                """
+                            ).format(
+                                sql.Identifier(
+                                    schema_name, "embeddings_embedding_ivfflat"
+                                ),
+                                sql.Identifier(schema_name, "embeddings"),
+                            ),
                             (ivf_lists,),
                         )
-                    cur.execute("ANALYZE embeddings")
+                    cur.execute(
+                        sql.SQL("ANALYZE {}").format(
+                            sql.Identifier(schema_name, "embeddings")
+                        )
+                    )
                     cur.execute(
                         """
                         SELECT indexdef
                         FROM pg_indexes
-                        WHERE schemaname = current_schema()
+                        WHERE schemaname = %s
                           AND tablename = 'embeddings'
                           AND indexname = %s
                         """,
-                        (expected_index,),
+                        (schema_name, expected_index),
                     )
                     row = cur.fetchone()
                 conn.commit()
@@ -86,6 +119,6 @@ class Command(BaseCommand):
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"Rebuilt embeddings index using {index_kind} (scope: rag.embeddings, {details})"
+                f"Rebuilt embeddings index using {index_kind} (scope: {scope}, {details})"
             )
         )


### PR DESCRIPTION
## Summary
- ensure the rebuild_rag_index command uses schema-qualified SQL when dropping and recreating vector indexes
- include the configured schema in the success message for greater clarity

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py::test_rebuild_rag_index_creates_expected_index[IVFFLAT-settings_overrides1-embeddings_embedding_ivfflat-expected_params1] *(skipped: PostgreSQL with pgvector extension is required for RAG tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9c02594c832b80d1c23e694c0978