### PR TITLE
Fix vector schema selection for rebuild_rag_index command

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -1541,10 +1541,68 @@ class PgVectorClient:
 _DEFAULT_CLIENT: Optional[VectorStore] = None
 
 
+def _resolve_vector_schema() -> str:
+    """Return the schema configured for the default vector store.
+
+    The management commands rely on :func:`get_default_client` to run SQL
+    statements such as index rebuilds. In multi-store setups we determine the
+    schema according to the active default scope, honouring the ``default``
+    flag used by :class:`~ai_core.rag.vector_store.VectorStoreRouter`.
+    """
+
+    schema_env = os.getenv("RAG_VECTOR_SCHEMA")
+    if schema_env:
+        return schema_env
+
+    stores_config: Mapping[str, Mapping[str, object]] | None = None
+    configured_default_scope: str | None = None
+    try:  # pragma: no cover - requires Django settings
+        from django.conf import settings  # type: ignore
+
+        configured = getattr(settings, "RAG_VECTOR_STORES", None)
+        if isinstance(configured, Mapping):
+            stores_config = configured
+        configured_default_scope = getattr(
+            settings, "RAG_VECTOR_DEFAULT_SCOPE", None
+        )
+    except Exception:
+        stores_config = None
+
+    if stores_config:
+        target_scope: str | None = None
+        if (
+            configured_default_scope
+            and configured_default_scope in stores_config
+        ):
+            target_scope = configured_default_scope
+        else:
+            for scope_name, config in stores_config.items():
+                if isinstance(config, Mapping) and config.get("default"):
+                    target_scope = scope_name
+                    break
+        if target_scope is None:
+            if "global" in stores_config:
+                target_scope = "global"
+            else:
+                try:
+                    target_scope = next(iter(stores_config))
+                except StopIteration:  # pragma: no cover - defensive
+                    target_scope = None
+        if target_scope and target_scope in stores_config:
+            config = stores_config[target_scope]
+            schema_value = config.get("schema") if isinstance(config, Mapping) else None
+            if schema_value:
+                return str(schema_value)
+
+    return "rag"
+
+
 def get_default_client() -> PgVectorClient:
     global _DEFAULT_CLIENT
     if _DEFAULT_CLIENT is None:
-        _DEFAULT_CLIENT = PgVectorClient.from_env()
+        _DEFAULT_CLIENT = PgVectorClient.from_env(
+            schema=_resolve_vector_schema()
+        )
     return cast(PgVectorClient, _DEFAULT_CLIENT)
 
 

--- a/ai_core/tests/test_management_rebuild_rag_index.py
+++ b/ai_core/tests/test_management_rebuild_rag_index.py
@@ -7,6 +7,9 @@ import pytest
 from django.core.management import call_command
 from django.db import connection
 
+from ai_core.rag import vector_client
+from tests.plugins.rag_db import SCHEMA_SQL
+
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("rag_database")
@@ -63,3 +66,47 @@ def test_rebuild_rag_index_creates_expected_index(
     for param, value in expected_params.items():
         pattern = rf"{param}\s*=\s*'?{value}'?(?:::\w+)?"
         assert re.search(pattern, indexdef), f"missing {param}={value} in {indexdef!r}"
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("rag_database")
+def test_rebuild_rag_index_uses_scope_with_default_flag(settings) -> None:
+    settings.RAG_VECTOR_STORES = {
+        "global": {"backend": "pgvector", "schema": "rag"},
+        "enterprise": {
+            "backend": "pgvector",
+            "schema": "rag_enterprise",
+            "default": True,
+        },
+    }
+    if hasattr(settings, "RAG_VECTOR_DEFAULT_SCOPE"):
+        delattr(settings, "RAG_VECTOR_DEFAULT_SCOPE")
+
+    vector_client.reset_default_client()
+
+    with connection.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS rag_enterprise CASCADE")
+        cur.execute("CREATE SCHEMA rag_enterprise")
+        cur.execute("SET search_path TO rag_enterprise, public")
+        cur.execute(SCHEMA_SQL)
+
+    try:
+        stdout = io.StringIO()
+        call_command("rebuild_rag_index", stdout=stdout)
+
+        with connection.cursor() as cur:
+            cur.execute("SET search_path TO rag_enterprise, public")
+            cur.execute(
+                """
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE schemaname = current_schema()
+                  AND tablename = 'embeddings'
+                  AND indexname = 'embeddings_embedding_hnsw'
+                """
+            )
+            row = cur.fetchone()
+        assert row is not None, "expected HNSW index in rag_enterprise schema"
+    finally:
+        with connection.cursor() as cur:
+            cur.execute("DROP SCHEMA IF EXISTS rag_enterprise CASCADE")


### PR DESCRIPTION
## Summary
- ensure the default pgvector client picks the schema from the configured default scope
- add coverage for rebuild_rag_index when a non-global scope is marked as default

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py -k default_flag -q

------
https://chatgpt.com/codex/tasks/task_e_68dd9d822970832b913792780ee507a3