### PR TITLE
Allow trigram fallback results below cutoff

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -1067,6 +1067,12 @@ class PgVectorClient:
             entry["chunk_id"] = chunk_id if chunk_id is not None else key
             lscore_value = max(0.0, float(score_raw))
             entry["lscore"] = max(float(entry.get("lscore", 0.0)), lscore_value)
+            if (
+                not entry.get("_allow_below_cutoff")
+                and fallback_limit_used_value is not None
+                and fallback_limit_used_value + 1e-9 < min_sim_value
+            ):
+                entry["_allow_below_cutoff"] = True
             if lexical_score_missing:
                 entry["_allow_below_cutoff"] = True
 


### PR DESCRIPTION
## Summary
- allow lexical fallback candidates produced by pg_trgm similarity fallback to bypass the minimum similarity cutoff when necessary

## Testing
- pytest ai_core/tests/test_vector_client.py -k "hybrid_search_uses_similarity_fallback_when_trigram_has_no_match or hybrid_search_pg_trgm_fallback_records_counts" -q

------
https://chatgpt.com/codex/tasks/task_e_68dda736cf48832b9c3b2535f6ffec35