### PR TITLE
Add plan and automation script for hybrid RAG demo walkthrough

### DIFF
--- a/docs/rag/hybrid_demo_plan.md
+++ b/docs/rag/hybrid_demo_plan.md
@@ -1,0 +1,128 @@
+# Hybrid-RAG-Demo von Grund auf einrichten
+
+Dieser Plan führt von einer leeren lokalen Umgebung („alles neu, inklusive Datenbank“)
+zu einer funktionsfähigen Demo, die den Upload eines Testdokuments, die
+Ingestion-Pipeline und die hybride Suche über den `rag-demo`-Endpoint abdeckt. Er
+orientiert sich an den Vorgaben aus [`docs/rag/ingestion.md`](ingestion.md), der
+API-Referenz und den vorhandenen Dev-Skripten.
+
+## 1. Voraussetzungen schaffen
+- **Tooling**: `docker`, `docker compose`, `npm`, `curl`, `jq`, `psql`.
+- **Repo vorbereiten**: `cp .env.example .env` und alle benötigten Secrets/Keys
+  gemäß README eintragen (u. a. Embeddings-Provider für pgvector).
+- **Hosts-Datei**: `127.0.0.1 demo.localhost` eintragen, damit der Demo-Hostname
+  auf die lokale Maschine zeigt.
+
+## 2. Umgebung & Datenbank neu aufsetzen
+1. Alte Container und Volumes entfernen:
+   ```bash
+   ./scripts/dev-reset.sh
+   ```
+   Das Skript baut Images neu, startet Web/Worker/DB und führt `npm run dev:init`
+   (Migrationen, Tenants, Seeds) sowie `npm run dev:check` aus.
+2. Prüfen, dass die Dienste laufen:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml ps
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml logs -f worker
+   ```
+   Der Worker muss die Queue `ingestion` horchen; auftretende Fehler sofort
+   beseitigen.
+3. Sicherstellen, dass das RAG-Schema vorhanden ist:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml exec postgres \
+     psql -U noesis -d noesis -c "\dn" | grep rag
+   ```
+   Fehlt das Schema, `docs/rag/schema.sql` gegen die Datenbank ausführen.
+
+## 3. Testdatei vorbereiten
+1. `hello.txt` mit eindeutigem Inhalt erzeugen (Beispiel):
+   ```bash
+   cat <<'TXT' > hello.txt
+   Hallo ZEBRAGURKE,
+   dies ist ein End-to-End-Test für die RAG-Demo.
+   TXT
+   ```
+2. Externe ID für die Nachverfolgung festlegen, z. B. `demo-hello-$(date +%s)`.
+
+## 4. Dokument hochladen
+1. Upload per `curl` ausführen:
+   ```bash
+   EXTERNAL_ID="demo-hello-$(date +%s)"
+   curl -sS -X POST "http://demo.localhost:8000/ai/rag/documents/upload/" \
+     -H "X-Tenant-Schema: demo" \
+     -H "X-Tenant-Id: demo" \
+     -H "X-Case-Id: local" \
+     -F "file=@hello.txt" \
+     -F "metadata={\"external_id\":\"$EXTERNAL_ID\",\"label\":\"smoke\"}" \
+     | tee /tmp/upload.json | jq .
+   ```
+2. Erwartetes Ergebnis: HTTP `202`, Felder `document_id`, `external_id`, `trace_id`.
+   `document_id` für den nächsten Schritt notieren.
+
+## 5. Ingestion starten und überwachen
+1. Ingestion-Run anstoßen:
+   ```bash
+   DOCUMENT_ID=$(jq -r '.document_id' /tmp/upload.json)
+   curl -sS -X POST "http://demo.localhost:8000/ai/rag/ingestion/run/" \
+     -H "Content-Type: application/json" \
+     -H "X-Tenant-Schema: demo" \
+     -H "X-Tenant-Id: demo" \
+     -H "X-Case-Id: local" \
+     -d "{\"document_ids\":[\"$DOCUMENT_ID\"],\"priority\":\"normal\"}" \
+     | tee /tmp/ingestion.json | jq .
+   ```
+   Antwort: HTTP `202` mit `ingestion_run_id` und optional `invalid_ids`.
+2. Worker-Logs beobachten, bis `ingestion_run` abgeschlossen ist:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+     logs -f --tail=100 worker | grep -E "ingestion_run|process_document"
+   ```
+   Erfolgsindikator: Meldungen wie `written=...` ohne Fehlerstacktrace.
+3. Datenbankprüfung (optional, aber empfohlen):
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml exec postgres \
+     psql -U noesis -d noesis <<'SQL'
+   SET search_path TO rag, public;
+   SELECT id, external_id, metadata FROM documents ORDER BY created_at DESC LIMIT 5;
+   SELECT document_id, ord, LEFT(text, 60) FROM chunks ORDER BY created_at DESC LIMIT 5;
+   SELECT COUNT(*) FROM embeddings;
+   SQL
+   ```
+   Die neue `external_id` muss erscheinen, `chunks`/`embeddings` dürfen nicht 0 sein.
+
+## 6. Hybride Suche validieren
+1. Anfrage mit bewusst gesetzten Parametern schicken:
+   ```bash
+   curl -sS -X POST "http://demo.localhost:8000/ai/v1/rag-demo/" \
+     -H "Content-Type: application/json" \
+     -H "X-Tenant-Schema: demo" \
+     -H "X-Tenant-Id: demo" \
+     -H "X-Case-Id: local" \
+     -d '{
+       "query": "ZEBRAGURKE",
+       "top_k": 5,
+       "alpha": 0.6,
+       "min_sim": 0.15,
+       "vec_limit": 20,
+       "lex_limit": 30,
+       "trgm_limit": 0.30
+     }' | tee /tmp/hybrid.json | jq .
+   ```
+2. Prüfpunkte:
+   - `matches` enthält das neue Dokument (`metadata.external_id == $EXTERNAL_ID`).
+   - Feld `error` fehlt; `meta.alpha` und `meta.min_sim` entsprechen den gesetzten
+     Werten.
+   - `meta.vector_candidates`/`meta.lexical_candidates` > 0 (Beweis für Hybrid).
+   - `score` plausibel (> 0) und nicht der Demo-Fallbackwert `0.42`/`0.36`.
+3. Variationstests: `alpha=0.0` (nur lexical) und `alpha=1.0` (nur vector) senden
+   und Score-/Kandidatenverhalten vergleichen.
+
+## 7. Aufräumen
+- Temporäre JSONs (`/tmp/upload.json`, `/tmp/ingestion.json`, `/tmp/hybrid.json`)
+  löschen.
+- Optional: `docker compose ... down -v` zum Zurücksetzen.
+
+## 8. Automatisierung
+Das Skript [`scripts/rag_demo_walkthrough.sh`](../../scripts/rag_demo_walkthrough.sh)
+führt die Schritte 3–6 automatisiert aus (inkl. Polling auf Treffer). Vorher muss
+Schritt 2 abgeschlossen sein und der Worker laufen. Details siehe Skript-Header.

--- a/scripts/rag_demo_walkthrough.sh
+++ b/scripts/rag_demo_walkthrough.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${NO_COLOR:-}" == "1" ]]; then
+  BOLD=""
+  RESET=""
+else
+  BOLD="\033[1m"
+  RESET="\033[0m"
+fi
+
+HOST=${NOESIS_HOST:-"http://demo.localhost:8000"}
+TENANT_SCHEMA=${TENANT_SCHEMA:-"demo"}
+TENANT_ID=${TENANT_ID:-"demo"}
+CASE_ID=${CASE_ID:-"local"}
+FILE_PATH=${RAG_DEMO_FILE:-"hello.txt"}
+QUERY=${RAG_DEMO_QUERY:-"ZEBRAGURKE"}
+ALPHA=${RAG_DEMO_ALPHA:-"0.6"}
+MIN_SIM=${RAG_DEMO_MIN_SIM:-"0.15"}
+VEC_LIMIT=${RAG_DEMO_VEC_LIMIT:-"20"}
+LEX_LIMIT=${RAG_DEMO_LEX_LIMIT:-"30"}
+TRGM_LIMIT=${RAG_DEMO_TRGM_LIMIT:-"0.30"}
+TOP_K=${RAG_DEMO_TOP_K:-"5"}
+MAX_POLLS=${RAG_DEMO_MAX_POLLS:-"12"}
+SLEEP_SECONDS=${RAG_DEMO_POLL_INTERVAL:-"5"}
+METADATA_JSON=${RAG_DEMO_METADATA:-"{\"external_id\":\"demo-hello\",\"label\":\"smoke\"}"}
+
+usage() {
+  cat <<USAGE
+${BOLD}RAG Demo Walkthrough${RESET}
+
+Dieses Skript automatisiert Upload → Ingestion → Hybrid-Suche gegen die lokale
+Demo-Instanz. Voraussetzung: docker-compose Umgebung läuft, Worker bedient die
+Queue \'ingestion\'.
+
+Umgebung anpassen:
+  NOESIS_HOST, TENANT_SCHEMA, TENANT_ID, CASE_ID
+  RAG_DEMO_FILE, RAG_DEMO_METADATA, RAG_DEMO_QUERY
+  RAG_DEMO_ALPHA, RAG_DEMO_MIN_SIM, RAG_DEMO_VEC_LIMIT, RAG_DEMO_LEX_LIMIT,
+  RAG_DEMO_TRGM_LIMIT, RAG_DEMO_TOP_K, RAG_DEMO_MAX_POLLS, RAG_DEMO_POLL_INTERVAL
+
+Beispiel:
+  TENANT_SCHEMA=demo TENANT_ID=demo CASE_ID=local \\
+    ./scripts/rag_demo_walkthrough.sh
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+for cmd in curl jq mktemp; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[rag-demo] Fehler: benötigtes Programm '$cmd' fehlt." >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -f "$FILE_PATH" ]]; then
+  echo "[rag-demo] Hinweis: '$FILE_PATH' existiert nicht – Beispielinhalt wird erstellt."
+  cat <<'TXT' > "$FILE_PATH"
+Hallo ZEBRAGURKE,
+dies ist ein End-to-End-Test für die RAG-Demo.
+TXT
+fi
+
+if [[ ! -s "$FILE_PATH" ]]; then
+  echo "[rag-demo] Fehler: '$FILE_PATH' ist leer." >&2
+  exit 1
+fi
+
+TMP_METADATA=$(mktemp)
+printf '%s' "$METADATA_JSON" > "$TMP_METADATA"
+
+printf '%b[1/4] Upload %s%b\n' "$BOLD" "$FILE_PATH" "$RESET"
+UPLOAD_JSON=$(curl --fail-with-body -sS -X POST "$HOST/ai/rag/documents/upload/" \
+  -H "X-Tenant-Schema: $TENANT_SCHEMA" \
+  -H "X-Tenant-Id: $TENANT_ID" \
+  -H "X-Case-Id: $CASE_ID" \
+  -F "file=@$FILE_PATH" \
+  -F "metadata=@$TMP_METADATA;type=application/json")
+
+document_id=$(jq -r '.document_id // empty' <<<"$UPLOAD_JSON")
+external_id=$(jq -r '.external_id // empty' <<<"$UPLOAD_JSON")
+if [[ -z "$document_id" ]]; then
+  echo "[rag-demo] Fehler: Upload-Antwort enthält keine document_id." >&2
+  echo "$UPLOAD_JSON" | jq . >&2
+  exit 1
+fi
+
+printf '%bUpload Response:%b\n%s\n' "$BOLD" "$RESET" "$(jq . <<<"$UPLOAD_JSON")"
+
+TMP_PAYLOAD=$(mktemp)
+jq --arg doc "$document_id" '{document_ids:[$doc], priority:"normal"}' > "$TMP_PAYLOAD"
+
+printf '%b[2/4] Ingestion-Run für %s%b\n' "$BOLD" "$document_id" "$RESET"
+INGESTION_JSON=$(curl --fail-with-body -sS -X POST "$HOST/ai/rag/ingestion/run/" \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-Schema: $TENANT_SCHEMA" \
+  -H "X-Tenant-Id: $TENANT_ID" \
+  -H "X-Case-Id: $CASE_ID" \
+  -d @"$TMP_PAYLOAD")
+
+printf '%bIngestion Response:%b\n%s\n' "$BOLD" "$RESET" "$(jq . <<<"$INGESTION_JSON")"
+invalid_ids=$(jq -r '.invalid_ids | @csv' <<<"$INGESTION_JSON" 2>/dev/null || true)
+if [[ -n "${invalid_ids:-}" && "${invalid_ids}" != "null" ]]; then
+  echo "[rag-demo] Warnung: Ungültige Dokument-IDs -> ${invalid_ids}" >&2
+fi
+
+printf '%b[3/4] Warte auf RAG-Treffer für external_id=%s%b\n' "$BOLD" "${external_id:-<unbekannt>}" "$RESET"
+
+TMP_SEARCH=$(mktemp)
+SUCCESS=0
+for ((i=1; i<=MAX_POLLS; i++)); do
+  jq -n \
+    --arg query "$QUERY" \
+    --argjson top_k "$TOP_K" \
+    --argjson alpha "$ALPHA" \
+    --argjson min_sim "$MIN_SIM" \
+    --argjson vec_limit "$VEC_LIMIT" \
+    --argjson lex_limit "$LEX_LIMIT" \
+    --argjson trgm_limit "$TRGM_LIMIT" \
+    '{query:$query, top_k:$top_k, alpha:$alpha, min_sim:$min_sim, vec_limit:$vec_limit, lex_limit:$lex_limit, trgm_limit:$trgm_limit}' \
+    > "$TMP_SEARCH"
+
+  RESPONSE=$(curl --fail-with-body -sS -X POST "$HOST/ai/v1/rag-demo/" \
+    -H "Content-Type: application/json" \
+    -H "X-Tenant-Schema: $TENANT_SCHEMA" \
+    -H "X-Tenant-Id: $TENANT_ID" \
+    -H "X-Case-Id: $CASE_ID" \
+    -d @"$TMP_SEARCH")
+
+  error_field=$(jq -r '.error // empty' <<<"$RESPONSE")
+  matches_with_external=$(jq --arg ext "$external_id" '(.matches // []) | map(select((.metadata.external_id // "") == $ext)) | length' <<<"$RESPONSE")
+
+  printf '[Versuch %d/%d] matches=%s error=%s\n' "$i" "$MAX_POLLS" "$matches_with_external" "${error_field:-<none>}"
+
+  if [[ -z "$error_field" && "$matches_with_external" -gt 0 ]]; then
+    SUCCESS=1
+    FINAL_RESPONSE="$RESPONSE"
+    break
+  fi
+
+  sleep "$SLEEP_SECONDS"
+done
+
+if [[ "$SUCCESS" -ne 1 ]]; then
+  echo "[rag-demo] Fehler: Kein Treffer mit externer ID innerhalb des Zeitfensters gefunden." >&2
+  exit 1
+fi
+
+printf '%b[4/4] Hybrid-Suche erfolgreich%b\n' "$BOLD" "$RESET"
+printf '%bFinale Antwort:%b\n%s\n' "$BOLD" "$RESET" "$(jq . <<<"$FINAL_RESPONSE")"
+
+rm -f "$TMP_METADATA" "$TMP_PAYLOAD" "$TMP_SEARCH"
+exit 0


### PR DESCRIPTION
## Summary
- document an end-to-end plan to reset the environment, ingest hello.txt, and validate hybrid search parameters
- add a helper script to automate the upload, ingestion trigger, and hybrid search polling for the demo tenant

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddaa5deb0c832b86f005f9ecd5ccd7