### PR TITLE
Fix pgvector index creation without schema-qualified names

### DIFF
--- a/ai_core/management/commands/rebuild_rag_index.py
+++ b/ai_core/management/commands/rebuild_rag_index.py
@@ -38,12 +38,12 @@ class Command(BaseCommand):
                     )
                     cur.execute(
                         sql.SQL("DROP INDEX IF EXISTS {}").format(
-                            sql.Identifier(schema_name, "embeddings_embedding_hnsw")
+                            sql.Identifier("embeddings_embedding_hnsw")
                         )
                     )
                     cur.execute(
                         sql.SQL("DROP INDEX IF EXISTS {}").format(
-                            sql.Identifier(schema_name, "embeddings_embedding_ivfflat")
+                            sql.Identifier("embeddings_embedding_ivfflat")
                         )
                     )
                     if index_kind == "HNSW":
@@ -54,9 +54,7 @@ class Command(BaseCommand):
                                 WITH (m = %s, ef_construction = %s)
                                 """
                             ).format(
-                                sql.Identifier(
-                                    schema_name, "embeddings_embedding_hnsw"
-                                ),
+                                sql.Identifier("embeddings_embedding_hnsw"),
                                 sql.Identifier(schema_name, "embeddings"),
                             ),
                             (hnsw_m, hnsw_ef),
@@ -69,9 +67,7 @@ class Command(BaseCommand):
                                 WITH (lists = %s)
                                 """
                             ).format(
-                                sql.Identifier(
-                                    schema_name, "embeddings_embedding_ivfflat"
-                                ),
+                                sql.Identifier("embeddings_embedding_ivfflat"),
                                 sql.Identifier(schema_name, "embeddings"),
                             ),
                             (ivf_lists,),


### PR DESCRIPTION
## Summary
- avoid schema-qualifying pgvector index names during rebuilds to satisfy PostgreSQL syntax

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py -k rebuild -q

------
https://chatgpt.com/codex/tasks/task_e_68de12a0a6ec832b888fdb4998064a9e