### PR TITLE
Fix tenant filter to use UUID index in hybrid search

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -533,8 +533,8 @@ class PgVectorClient:
             filter_debug,
         )
 
-        where_clauses = ["d.tenant_id::text = %s"]
-        where_params: List[object] = [tenant]
+        where_clauses = ["d.tenant_id = %s"]
+        where_params: List[object] = [tenant_uuid]
         for key, value in metadata_filters:
             kind = SUPPORTED_METADATA_FILTERS[key]
             normalised = self._normalise_filter_value(value)


### PR DESCRIPTION
## Summary
- stop casting tenant_id to text when building hybrid search filters
- pass the tenant UUID directly so PostgreSQL can leverage the tenant_id index

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de471e0bac832b9a63f3cfe4c8bbdc