### PR TITLE
Propagate tenant schema to RAG routing

### DIFF
--- a/ai_core/nodes/retrieve.py
+++ b/ai_core/nodes/retrieve.py
@@ -49,6 +49,7 @@ def run(
     """
     query = state.get("query", "")
     tenant_id = meta.get("tenant") or meta.get("tenant_id")
+    tenant_schema = meta.get("tenant_schema")
     if not tenant_id:
         raise ValueError("tenant_id required")
     case_id = meta.get("case") or meta.get("case_id")
@@ -57,7 +58,10 @@ def run(
     filters: Dict[str, Optional[str]] | None = None
     for_tenant = getattr(router, "for_tenant", None)
     if callable(for_tenant):
-        tenant_client = for_tenant(tenant_id)
+        try:
+            tenant_client = for_tenant(tenant_id, tenant_schema)
+        except TypeError:
+            tenant_client = for_tenant(tenant_id)
         # Tenant-scoped clients already enforce the tenant context, so we only
         # inject the optional case filter here to avoid redundant constraints.
         filters = {"case": case_id} if case_id else None

--- a/ai_core/tests/test_ingestion_flow.py
+++ b/ai_core/tests/test_ingestion_flow.py
@@ -51,7 +51,7 @@ def test_upload_ingest_query_end2end(
     doc_id = body["document_id"]
 
     # Ingestion (direkt Task ausführen; alternativ run_ingestion.delay(...) und warten)
-    result = process_document(tenant, case, doc_id)
+    result = process_document(tenant, case, doc_id, tenant_schema=tenant)
     assert result["written"] >= 1
 
     # Query
@@ -143,6 +143,7 @@ def test_ingestion_run_reports_missing_documents(
     assert len(calls) == 1
     args, kwargs = calls[0]
     assert list(args[2]) == [doc_id]
+    assert kwargs["tenant_schema"] == tenant
 
 
 def test_fallback_external_id_consistency():

--- a/ai_core/tests/test_rag_ingestion_run.py
+++ b/ai_core/tests/test_rag_ingestion_run.py
@@ -26,6 +26,7 @@ def test_rag_ingestion_run_queues_task(client, monkeypatch, test_tenant_schema_n
         run_id,
         trace_id=None,
         idempotency_key=None,
+        tenant_schema=None,
     ):
         captured.update(
             {
@@ -35,6 +36,7 @@ def test_rag_ingestion_run_queues_task(client, monkeypatch, test_tenant_schema_n
                 "run_id": run_id,
                 "trace_id": trace_id,
                 "idempotency_key": idempotency_key,
+                "tenant_schema": tenant_schema,
             }
         )
 
@@ -71,6 +73,7 @@ def test_rag_ingestion_run_queues_task(client, monkeypatch, test_tenant_schema_n
         "trace_id": body["trace_id"],
         "run_id": body["ingestion_run_id"],
         "idempotency_key": None,
+        "tenant_schema": test_tenant_schema_name,
     }
 
 

--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -1020,6 +1020,7 @@ class RagIngestionRunView(APIView):
             meta["tenant"],
             meta["case"],
             to_dispatch,
+            tenant_schema=meta["tenant_schema"],
             run_id=ingestion_run_id,
             trace_id=meta["trace_id"],
             idempotency_key=request.headers.get(IDEMPOTENCY_KEY_HEADER),


### PR DESCRIPTION
## Summary
- forward the tenant schema through the retrieval node and ingestion endpoints so scoped routers receive it
- update ingestion and upsert tasks to accept schema-aware routing and call router.for_tenant with the schema
- extend vector router, node, task, and ingestion tests to cover schema scope handling

## Testing
- pytest ai_core/tests/test_vector_router.py ai_core/tests/test_nodes.py ai_core/tests/test_tasks.py ai_core/tests/test_ingestion_flow.py ai_core/tests/test_rag_ingestion_run.py

------
https://chatgpt.com/codex/tasks/task_e_68de52a4e394832ba97ec8e4a62aa347