### PR TITLE
Clamp RAG candidate limits

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -494,8 +494,16 @@ class PgVectorClient:
         ).lower()
         if distance_score_mode not in {"inverse", "linear"}:
             distance_score_mode = "inverse"
-        vec_limit_value = max(top_k, int(vec_limit if vec_limit is not None else 50))
-        lex_limit_value = max(top_k, int(lex_limit if lex_limit is not None else 50))
+        max_candidates_setting = _get_setting("RAG_MAX_CANDIDATES", 200)
+        try:
+            max_candidates = int(max_candidates_setting)
+        except (TypeError, ValueError):
+            max_candidates = 200
+        max_candidates = max(1, max_candidates)
+        vec_limit_requested = int(vec_limit) if vec_limit is not None else 50
+        lex_limit_requested = int(lex_limit) if lex_limit is not None else 50
+        vec_limit_value = min(max_candidates, max(top_k, vec_limit_requested))
+        lex_limit_value = min(max_candidates, max(top_k, lex_limit_requested))
         query_norm = normalise_text(query)
         query_db_norm = normalise_text_db(query)
         raw_vec = self._embed_query(query_norm)

--- a/tests/rag/test_graph_rag_demo.py
+++ b/tests/rag/test_graph_rag_demo.py
@@ -1,0 +1,52 @@
+import pytest
+
+from ai_core.graphs import rag_demo
+from ai_core.rag.vector_client import HybridSearchResult
+
+
+class _DummyRouter:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.received_kwargs: dict | None = None
+
+    def hybrid_search(self, query: str, **kwargs):
+        self.calls += 1
+        self.received_kwargs = dict(kwargs)
+        top_k = int(kwargs.get("top_k", 0) or 0)
+        vec_limit = kwargs.get("vec_limit", top_k)
+        lex_limit = kwargs.get("lex_limit", top_k)
+        return HybridSearchResult(
+            chunks=[],
+            vector_candidates=0,
+            lexical_candidates=0,
+            fused_candidates=0,
+            duration_ms=0.0,
+            alpha=float(kwargs.get("alpha", 0.0) or 0.0),
+            min_sim=float(kwargs.get("min_sim", 0.0) or 0.0),
+            vec_limit=int(vec_limit),
+            lex_limit=int(lex_limit),
+        )
+
+
+@pytest.mark.django_db
+def test_run_clamps_limits_before_router_call(monkeypatch, settings):
+    settings.RAG_MAX_CANDIDATES = 25
+    router = _DummyRouter()
+    monkeypatch.setattr(rag_demo, "get_default_router", lambda: router)
+
+    state = {
+        "query": "Which limits?",
+        "vec_limit": 9999,
+        "lex_limit": 12345,
+        "top_k": 10,
+    }
+    meta = {"tenant_id": "tenant-123"}
+
+    new_state, result = rag_demo.run(state, meta)
+
+    assert router.calls == 1
+    assert router.received_kwargs is not None
+    assert router.received_kwargs["vec_limit"] == 25
+    assert router.received_kwargs["lex_limit"] == 25
+    assert new_state["rag_demo"]["top_k"] == 10
+    assert result["ok"] is True


### PR DESCRIPTION
## Summary
- clamp vector and lexical candidate limits in the pgvector client based on `RAG_MAX_CANDIDATES`
- ensure the RAG demo graph enforces the same cap before forwarding overrides to the router
- add regression tests covering the clamping behaviour in the client and graph

## Testing
- pytest tests/rag/test_vector_client.py::test_hybrid_search_clamps_candidate_limits tests/rag/test_graph_rag_demo.py::test_run_clamps_limits_before_router_call -q

------
https://chatgpt.com/codex/tasks/task_e_68de52ab9508832bb9e4db89bda35ef8