### PR TITLE
Guard rebuild RAG index commit under atomic

### DIFF
--- a/ai_core/management/commands/rebuild_rag_index.py
+++ b/ai_core/management/commands/rebuild_rag_index.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             conn.rollback()
             raise
         else:
-            if not conn.get_autocommit():
+            if not conn.get_autocommit() and not conn.in_atomic_block:
                 conn.commit()
 
         try:


### PR DESCRIPTION
## Summary
- avoid calling connection.commit during schema setup when already in an atomic block for rebuild_rag_index

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py

------
https://chatgpt.com/codex/tasks/task_e_68de64ee94c0832b8fea6768060c801e