### PR TITLE
Allow per-request overrides for hybrid search parameters

### DIFF
--- a/ai_core/tests/test_graph_rag_demo.py
+++ b/ai_core/tests/test_graph_rag_demo.py
@@ -203,10 +203,13 @@ def test_rag_demo_hybrid_search_uses_trimmed_query(
             min_sim: float,
             trgm_limit: float | None = None,
             trgm_threshold: float | None = None,
+            max_candidates: int | None = None,
         ) -> HybridSearchResult:
             assert filters is not None
             assert filters.get("tenant_id") == tenant_id
-            assert trgm_limit == 3.0
+            assert trgm_limit == 1.0
+            assert max_candidates is not None
+            assert max_candidates >= top_k
             self.received_query = query
             chunk = Chunk(
                 content="lexical match",
@@ -338,8 +341,22 @@ def test_rag_demo_no_hit_above_threshold_warning(
             filters: dict[str, object] | None = None,
             alpha: float | None = None,
             min_sim: float | None = None,
+            trgm_limit: float | None = None,
+            trgm_threshold: float | None = None,
+            max_candidates: int | None = None,
         ) -> HybridSearchResult:
-            del query, tenant_id, case_id, top_k, filters, alpha, min_sim
+            del (
+                query,
+                tenant_id,
+                case_id,
+                top_k,
+                filters,
+                alpha,
+                min_sim,
+                trgm_limit,
+                trgm_threshold,
+                max_candidates,
+            )
             return HybridSearchResult(
                 chunks=[],
                 vector_candidates=2,

--- a/ai_core/tests/test_vector_router.py
+++ b/ai_core/tests/test_vector_router.py
@@ -103,6 +103,7 @@ class HybridEnabledStore(VectorStore):
         vec_limit: int | None = None,
         lex_limit: int | None = None,
         trgm_limit: float | None = None,
+        max_candidates: int | None = None,
     ) -> HybridSearchResult:
         self.hybrid_calls.append(
             {
@@ -116,6 +117,7 @@ class HybridEnabledStore(VectorStore):
                 "vec_limit": vec_limit,
                 "lex_limit": lex_limit,
                 "trgm_limit": trgm_limit,
+                "max_candidates": max_candidates,
             }
         )
         return self._result
@@ -395,6 +397,7 @@ def test_router_hybrid_search_uses_scoped_store() -> None:
     assert call["top_k"] == 10  # capped
     assert call["filters"] == {"case": None}
     assert call["trgm_limit"] is None
+    assert call["max_candidates"] is None
     assert global_store.hybrid_calls == []
 
     fallback = router.hybrid_search("frage", tenant_id=tenant, scope="missing")

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -56,6 +56,7 @@ RAG_IVF_PROBES = env.int("RAG_IVF_PROBES", default=64)
 RAG_MIN_SIM = env.float("RAG_MIN_SIM", default=0.15)
 RAG_TRGM_LIMIT = env.float("RAG_TRGM_LIMIT", default=0.1)
 RAG_HYBRID_ALPHA = env.float("RAG_HYBRID_ALPHA", default=0.7)
+RAG_MAX_CANDIDATES = env.int("RAG_MAX_CANDIDATES", default=200)
 RAG_CHUNK_TARGET_TOKENS = env.int("RAG_CHUNK_TARGET_TOKENS", default=450)
 RAG_CHUNK_OVERLAP_TOKENS = env.int("RAG_CHUNK_OVERLAP_TOKENS", default=80)
 


### PR DESCRIPTION
## Summary
- add a RAG_MAX_CANDIDATES default alongside existing hybrid tuning settings
- normalise per-request hybrid parameters from state, including defensive clamping and max candidate handling
- extend vector client/router plumbing and tests to forward the sanitised overrides

## Testing
- pytest ai_core/tests/test_graph_rag_demo.py ai_core/tests/test_vector_router.py


------
https://chatgpt.com/codex/tasks/task_e_68de6564dfe4832bb10d558db7a2acb1