### PR TITLE
Refine query embeddings and logging

### DIFF
--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -385,15 +385,21 @@ def embed(meta: Dict[str, str], chunks_path: str) -> Dict[str, str]:
         batch_started = time.perf_counter()
         result: EmbeddingBatchResult = client.embed(inputs)
         duration_ms = (time.perf_counter() - batch_started) * 1000
-        logger.info(
-            "ingestion.embed.batch",
-            extra={
-                "batch": batches,
-                "chunks": len(batch),
-                "duration_ms": duration_ms,
-                "model": result.model,
-            },
-        )
+        extra = {
+            "batch": batches,
+            "chunks": len(batch),
+            "duration_ms": duration_ms,
+            "model": result.model,
+            "model_name": result.model,
+            "model_used": result.model_used,
+            "attempts": result.attempts,
+        }
+        if result.timeout_s is not None:
+            extra["timeout_s"] = result.timeout_s
+        key_alias = meta.get("key_alias")
+        if key_alias:
+            extra["key_alias"] = key_alias
+        logger.info("ingestion.embed.batch", extra=extra)
         batch_dim: Optional[int] = len(result.vectors[0]) if result.vectors else None
         current_dim = batch_dim
         try:

--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,13 @@ def stub_embedding_client(monkeypatch):
                 magnitude = float(len(normalized.split()) or 1)
                 tail = max(0, self._dim - 1)
                 vectors.append([magnitude] + [0.0] * tail)
-            return EmbeddingBatchResult(vectors=vectors, model="dummy-embed")
+            return EmbeddingBatchResult(
+                vectors=vectors,
+                model="dummy-embed",
+                model_used="primary",
+                attempts=1,
+                timeout_s=None,
+            )
 
         def dim(self) -> int:
             return self._dim


### PR DESCRIPTION
## Summary
- route query embedding requests through the shared EmbeddingClient and emit structured logs for model usage, timing, and key aliases
- harden the embedding client with timeout/HTTP fallback handling and surface model_used, attempts, and timeout metadata to callers
- enrich ingestion batch logging with alias/model fields and align the pytest embedding stub with the new result contract

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_embed_query_returns_non_zero_vector -q *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68de6fda7d44832bba8aff2e5f7b0e86