### PR TITLE
Align test embedding dimension with schema

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,10 @@ def stub_embedding_client(monkeypatch):
 
     class _DummyEmbeddingClient:
         def __init__(self) -> None:
-            self._dim = 8
+            try:
+                self._dim = int(os.getenv("TEST_EMBEDDING_DIM", "1536"))
+            except (TypeError, ValueError):
+                self._dim = 1536
             self.batch_size = 64
 
         def embed(self, texts):


### PR DESCRIPTION
## Summary
- update the pytest embedding stub to use the production vector size expected by pgvector
- allow overriding the test embedding dimension via the TEST_EMBEDDING_DIM environment variable while keeping a safe fallback

## Testing
- pytest ai_core/tests/test_vector_client.py::TestPgVectorClient::test_format_vector_raises_on_dimension_mismatch -q


------
https://chatgpt.com/codex/tasks/task_e_68de7b08b4e0832bbf7ad22972581522