### PR TITLE
Use pgvector connection for RAG index rebuild

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -269,6 +269,13 @@ class PgVectorClient:
         finally:
             self._pool.putconn(conn)
 
+    @contextmanager
+    def connection(self):  # type: ignore[no-untyped-def]
+        """Yield a prepared connection from the pool."""
+
+        with self._connection() as conn:
+            yield conn
+
     def _prepare_connection(self, conn) -> None:  # type: ignore[no-untyped-def]
         with conn.cursor() as cur:
             cur.execute(


### PR DESCRIPTION
## Summary
- update the RAG index rebuild command to use a pgvector connection with explicit commit/rollback handling
- expose a reusable connection context manager on the pgvector client for management commands

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68de830b198c832b9863d4b0be431787