### PR TITLE
docs: clarify vector spaces and router guardrails

### DIFF
--- a/docs/rag/overview.md
+++ b/docs/rag/overview.md
@@ -31,6 +31,60 @@ Standardweg: Embeddings und Metadaten liegen in einem gemeinsamen Schema, `tenan
 | Schema pro Mandant | Eigenes Schema `tenant_<slug>` für Tabellen `documents`, `chunks`, `embeddings` | Skalierungspfad für Großkunden oder erhöhte Isolation |
 | Hybrid | Kern-Tabellen pro Schema, Embeddings global mit `tenant_id` | Wenn LiteLLM und Django gemeinsame Daten teilen müssen |
 
+## Mehrdimensionale Profile
+Wir unterscheiden künftig drei orthogonale Dimensionen, die Einfluss auf den Vektor-Speicher haben: (1) **Tenant** bzw. gebuchtes Service-Level, (2) **Prozesskontext** (z. B. Draft, Review, Final) und (3) **Dokumentklasse** (z. B. juristische Dokumente, technische Handbücher). Das aktuelle Setup unterstützt zwar Tenants über `tenant_id`, koppelt aber alle weiteren Dimensionen an ein einziges Embedding-Profil (`vector(1536)` + `oai-embed-large`).
+
+> **Begriff Vector Space:** Ein Vector Space ist die kleinste persistente Einheit des RAG-Stores mit fester `embedding_dim`, eindeutigem Backend (z. B. pgvector, Faiss) und eigener Tabelle bzw. eigenem Schema. Jeder Vector Space korrespondiert mit einem Eintrag in `RAG_VECTOR_STORES` und den Staging-/Prod-Datenpfaden aus der [Architekturübersicht](../architektur/overview.md#datenpfade-und-tenancy). Damit verankern wir „Dimension ist physische Eigenschaft des Stores“ als Schnittstellenvertrag; Details zum Ingestionspfad stehen im [RAG-Store-Kapitel](ingestion.md).
+
+Für ein skalierbares Zielbild dokumentieren wir folgende Anpassungen:
+
+1. **Embedding-Profile definieren:** Führe eine Konfigurationsstruktur (z. B. `EMBEDDING_PROFILES`) ein, die pro Profil den LiteLLM-Alias, die erwartete Dimension und den Ziel-Vector-Space beschreibt. Beispiel:
+   ```python
+   EMBEDDING_PROFILES = {
+       "standard": {"model": "oai-embed-large", "dimension": 1536, "vector_space": "global"},
+       "premium": {"model": "vertex_ai/text-embedding-004", "dimension": 3072, "vector_space": "premium"},
+       "fast": {"model": "oai-embed-small", "dimension": 1536, "vector_space": "fast"},
+   }
+   ```
+   Jeder Vector Space verweist auf ein dediziertes Schema oder Backend mit passender `vector(n)`-Spalte.
+
+2. **Routing pro Dimension:** Ergänze den `VectorStoreRouter` um Regeln, die aus Tenant-Metadaten, Prozessschritt und Dokumentklasse ein Profil ermitteln. Tenants buchen Upgrades, indem sie im Admin-Backend einem anderen Profil zugeordnet werden; Prozessschritte und Dokumentklassen werden als Ingestion-Parameter übergeben und entscheiden, in welchen Vector Space geschrieben/gelesen wird.
+
+3. **Pipelines anreichern:** Der Ingestion-Task erhält einen verpflichtenden `embedding_profile`-Parameter. Vor dem Schreiben prüft er die Dimension (`ChunkEmbedding.dim()`), erzwingt Konsistenz mit dem Zielprofil und führt bei Abweichungen einen Hard-Fail aus. Retrieval-Aufrufe (LangGraph, Reports) müssen denselben Profilschlüssel an den Router durchreichen, damit Query und Speicherung auf denselben Vector Space zeigen. Verstöße (z. B. fehlendes Profil oder Dimensionsabweichung) werden als Dead-Letter markiert und gemäß [Ingestion-Runbook](ingestion.md#fehlertoleranz-und-deduplizierung) abgearbeitet.
+
+4. **Fallback-Politik:** Fallback ist ausschließlich zu Anbietern oder Endpunkten mit identischer Ausgabelänge zulässig; Dimensionswechsel bedeuten Migration. Die Admin-GUI dokumentiert dieses „Do & Don’t“, damit Betriebs-Teams nicht spontan auf Modelle anderer Dimension umschalten.
+
+5. **Observability:** Ergänze `embedding_profile` und `vector_space_id` als Pflicht-Tags in Langfuse-Traces (z. B. `retrieval_results`, `embedding_rate_limit`), um Nulltreffer oder Kostenpeaks eindeutig zu einer Pipeline und einem Profil zurückzuführen.
+
+6. **Migration planen:** Profile mit abweichender Dimension (z. B. `premium` mit 3072) erfordern dedizierte Tabellen/Schemata sowie ein Re-Embedding der betroffenen Dokumente. Wechsel zwischen Profilen werden als Migration behandelt (Datenexport → Re-Embedding → Import in neues Schema) und nicht durch automatischen Fallback realisiert.
+
+Mit dieser Schichtung bleibt LiteLLM weiterhin die abstrakte Schnittstelle zu den Modell-Anbietern, während Persistenz und Kostensteuerung pro Dimension kontrolliert werden können. Standard-Tenants nutzen weiterhin das globale Profil; Großkunden oder hochwertige Prozessschritte lassen sich gezielt auf erweiterte Vector Spaces routen, ohne Dimensionen zu mischen.
+
+### Persistenz & Schema-Guards
+Neben den Validierungen in Worker und Router muss auch das Datenbankschema Guardrails enthalten. `docs/rag/schema.sql` erhält je Vector Space einen expliziten Block – bevorzugt separate Tabellen oder Schemata. Beispiel für ein Premium-Profil:
+
+```sql
+CREATE TABLE rag_premium_embeddings (
+  id uuid PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  doc_id uuid NOT NULL,
+  chunk_id uuid NOT NULL,
+  embedding vector(3072) NOT NULL,
+  metadata jsonb NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+```
+
+Falls eine gemeinsame Tabelle unvermeidlich ist, erzwingt mindestens ein `CHECK` auf einer Meta-Spalte die erlaubte Dimension und der Upsert-Pfad prüft `len(embedding)` zur Laufzeit – erst nach erfolgreichem Guard wird geschrieben. Diese Guardrails sind Bestandteil der Migrations-Runbooks und Staging-Smoke-Tests.
+
+### Betriebs- & Migrationspfad
+Profilwechsel folgen einem festen Ablauf (Runbooks unter [docs/runbooks](../runbooks) beschreiben Details):
+
+1. **Vector Space provisionieren:** Neues Schema/Backend samt Tabellen, Indexen und Guardrails erstellen.
+2. **Backfill vorbereiten:** Re-Embedding via Queue-Ingestion, Batch-Limits und Backoff gemäß [Scaling-Leitfaden](../operations/scaling.md) konfigurieren.
+3. **Dual-Read Smoke:** In Staging beide Vector Spaces abfragen, Ergebnisdifferenzen in Langfuse markieren und mit Trace-Tags versehen.
+4. **Router-Switch:** Konfiguration/Feature-Flag umschalten, Monitoring beobachten und erst bei stabilen Zahlen den Altbestand dekommissionieren.
+
 ## VectorStore Router
 Der VectorStore Router kapselt die Auswahl des Backends und erzwingt, dass jede Suche mit einer gültigen `tenant_id` ausgeführt wird. Er normalisiert Filter, deckelt `top_k` hart auf zehn Ergebnisse und schützt damit Agenten vor übermäßigen Resultatmengen. Silos pro Tenant lassen sich später über zusätzliche Router-Scopes konfigurieren, während der Standard weiterhin auf den globalen Store zeigt. Weil der Router immer aktiv ist, entfällt das frühere Feature-Flagging für RAG. Tests können dank Fake-Stores ohne PostgreSQL durchgeführt werden, während optionale Integrationsläufe weiterhin gegen pgvector laufen. Die Delegation sorgt zugleich dafür, dass PII-Redaktionen und Hash-Prüfungen im bestehenden `PgVectorClient` unverändert greifen.
 
@@ -38,8 +92,32 @@ Der VectorStore Router kapselt die Auswahl des Backends und erzwingt, dass jede 
 from ai_core.rag import get_default_router
 
 router = get_default_router()
-results = router.search("fallback instructions", tenant_id="tenant-uuid", top_k=5)
+profile = router.resolve_profile(
+    tenant_id="tenant-uuid",
+    process="review",
+    doc_class="legal",
+)
+vector_space = router.resolve_vector_space(profile)
+embedding = embedder(
+    text,
+    model=EMBEDDING_PROFILES[profile]["model"],
+)
+assert len(embedding) == vector_space["dim"], "dim mismatch"
+pg.upsert(
+    schema=vector_space["schema"],
+    embedding=embedding,
+    metadata=meta,
+)
+results = router.search(
+    "fallback instructions",
+    tenant_id="tenant-uuid",
+    process="review",
+    doc_class="legal",
+    top_k=5,
+)
 ```
+
+Der Router deckelt `top_k` weiterhin auf zehn Ergebnisse. Achte darauf, dass der konfigurierbare Kandidatenpool (`max_candidates`, `normalize_max_candidates`) nie kleiner als `top_k` ist; andernfalls muss der Router frühzeitig einen Fehler werfen, um Recall-Regressionen zu vermeiden.
 
 ## Löschkonzept
 - Dokumente erhalten Hashes (siehe [Schema](schema.sql)) und `metadata` mit Herkunft.


### PR DESCRIPTION
## Summary
- introduce the "Vector Space" contract in the multi-dimensional profile overview and connect it to existing RAG store and environment docs
- document schema guardrails, migration runbook steps, and operational policies such as fallback limits, required ingestion parameters, and observability tags
- extend the VectorStore router example to demonstrate consistent profile resolution and highlight candidate-pool guardrails

## Testing
- no tests were run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68ded2688f08832b8d07c3baa3485a18