### PR TITLE
Polish RAG ingestion idempotency and index health tests

### DIFF
--- a/ai_core/tests/test_ingestion_idempotency.py
+++ b/ai_core/tests/test_ingestion_idempotency.py
@@ -1,0 +1,80 @@
+import json
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from ai_core.ingestion import process_document
+from ai_core.infra import object_store, rate_limit
+from common.constants import (
+    META_CASE_ID_KEY,
+    META_TENANT_ID_KEY,
+    META_TENANT_SCHEMA_KEY,
+)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("rag_database")
+def test_ingestion_idempotency_skips_unchanged_documents(
+    client,
+    monkeypatch,
+    tmp_path,
+    test_tenant_schema_name,
+):
+    tenant = test_tenant_schema_name
+    case = "case-idempotent"
+    external_id = "demo-hello-1759389009"
+
+    store_path = tmp_path / "object-store"
+    monkeypatch.setattr(object_store, "BASE_PATH", store_path)
+    monkeypatch.setattr(rate_limit, "check", lambda *_args, **_kwargs: True)
+
+    def upload_document(content: str) -> str:
+        upload = SimpleUploadedFile(
+            "hello.txt", content.encode("utf-8"), content_type="text/plain"
+        )
+        payload = {
+            "file": upload,
+            "metadata": json.dumps({"external_id": external_id}),
+        }
+        response = client.post(
+            "/ai/rag/documents/upload/",
+            data=payload,
+            **{
+                META_TENANT_SCHEMA_KEY: tenant,
+                META_TENANT_ID_KEY: tenant,
+                META_CASE_ID_KEY: case,
+            },
+        )
+        assert response.status_code == 202
+        body = response.json()
+        assert body["external_id"] == external_id
+        return body["document_id"]
+
+    first_doc = upload_document("Hello RAG ingestion!")
+    first_result = process_document(tenant, case, first_doc, tenant_schema=tenant)
+
+    assert first_result["external_id"] == external_id
+    assert first_result["inserted"] == 1
+    assert first_result["skipped"] == 0
+    assert first_result["replaced"] == 0
+    assert first_result["action"] == "inserted"
+    assert first_result["written"] == 1
+
+    second_doc = upload_document("Hello RAG ingestion!")
+    second_result = process_document(tenant, case, second_doc, tenant_schema=tenant)
+
+    assert second_result["external_id"] == external_id
+    assert second_result["inserted"] == 0
+    assert second_result["skipped"] == 1
+    assert second_result["replaced"] == 0
+    assert second_result["action"] == "skipped"
+    assert second_result["written"] == 0
+
+    third_doc = upload_document("Hello RAG ingestion version two!")
+    third_result = process_document(tenant, case, third_doc, tenant_schema=tenant)
+
+    assert third_result["external_id"] == external_id
+    assert third_result["skipped"] == 0
+    assert third_result["action"] in {"inserted", "replaced"}
+    assert third_result["inserted"] == 1 or third_result["replaced"] == 1
+    assert third_result["written"] == 1

--- a/ai_core/tests/test_management_rebuild_rag_index.py
+++ b/ai_core/tests/test_management_rebuild_rag_index.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
 import io
+import json
 import re
 
 import pytest
+from psycopg2 import sql
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db import connection
+from django.core.files.uploadedfile import SimpleUploadedFile
 
+from ai_core.ingestion import process_document
 from ai_core.rag import vector_client
+from ai_core.infra import object_store, rate_limit
 from tests.plugins.rag_db import SCHEMA_SQL
+from common.constants import (
+    META_CASE_ID_KEY,
+    META_TENANT_ID_KEY,
+    META_TENANT_SCHEMA_KEY,
+)
 
 
 @pytest.mark.django_db
@@ -127,3 +137,92 @@ def test_rebuild_rag_index_missing_embeddings_table() -> None:
         "Vector table 'embeddings' not found; ensure the RAG schema is initialised"
         == str(excinfo.value)
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("rag_database")
+def test_rebuild_rag_index_health_check(
+    client,
+    monkeypatch,
+    tmp_path,
+    settings,
+    test_tenant_schema_name,
+) -> None:
+    tenant = test_tenant_schema_name
+    case = "case-index-health"
+    store_path = tmp_path / "object-store"
+    monkeypatch.setattr(object_store, "BASE_PATH", store_path)
+    monkeypatch.setattr(rate_limit, "check", lambda *_args, **_kwargs: True)
+
+    def _upload(content: str, external_id: str) -> str:
+        upload = SimpleUploadedFile(
+            f"{external_id}.txt", content.encode("utf-8"), content_type="text/plain"
+        )
+        payload = {
+            "file": upload,
+            "metadata": json.dumps({"external_id": external_id}),
+        }
+        response = client.post(
+            "/ai/rag/documents/upload/",
+            data=payload,
+            **{
+                META_TENANT_SCHEMA_KEY: tenant,
+                META_TENANT_ID_KEY: tenant,
+                META_CASE_ID_KEY: case,
+            },
+        )
+        assert response.status_code == 202
+        body = response.json()
+        assert body["external_id"] == external_id
+        return body["document_id"]
+
+    doc_one = _upload("Vector index smoke check one", "index-health-one")
+    doc_two = _upload("Vector index smoke check two", "index-health-two")
+
+    first_result = process_document(tenant, case, doc_one, tenant_schema=tenant)
+    second_result = process_document(tenant, case, doc_two, tenant_schema=tenant)
+
+    assert first_result["inserted"] == 1
+    assert second_result["inserted"] == 1
+
+    call_command("rebuild_rag_index")
+
+    index_kind = str(getattr(settings, "RAG_INDEX_KIND", "HNSW")).upper()
+    expected_index = (
+        "embeddings_embedding_hnsw"
+        if index_kind == "HNSW"
+        else "embeddings_embedding_ivfflat"
+    )
+
+    client_handle = vector_client.get_default_client()
+    schema_name = getattr(client_handle, "_schema", "rag")
+
+    with connection.cursor() as cur:
+        cur.execute(
+            sql.SQL("SET search_path TO {}, public").format(
+                sql.Identifier(schema_name)
+            )
+        )
+        cur.execute(
+            """
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = current_schema()
+              AND tablename = 'embeddings'
+              AND indexname = %s
+            """,
+            (expected_index,),
+        )
+        row = cur.fetchone()
+    assert row is not None, f"expected index {expected_index} to be present"
+
+    results = client_handle.search(
+        "Vector index smoke check",
+        tenant_id=tenant,
+        top_k=2,
+        filters={"case": case},
+    )
+
+    assert len(results) == 2
+    ids = {chunk.meta.get("external_id") for chunk in results}
+    assert ids == {"index-health-one", "index-health-two"}


### PR DESCRIPTION
## Summary
- ensure the ingestion idempotency regression test validates written counters and avoids shadowing fixtures when bypassing rate limiting
- harden the rebuild_rag_index health check by safely setting the search path and asserting the queried chunks match the uploaded documents

## Testing
- pytest ai_core/tests/test_ingestion_idempotency.py ai_core/tests/test_management_rebuild_rag_index.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dfab7686d0832b8cf4b0700d8778fd