### PR TITLE
Add tokenizer override and update chunkify tests

### DIFF
--- a/ai_core/tests/test_tasks.py
+++ b/ai_core/tests/test_tasks.py
@@ -38,12 +38,13 @@ def test_chunkify_applies_overlap_and_limits() -> None:
         "sieben acht neun",
     ]
 
-    chunks = tasks._chunkify(
-        sentences,
-        target_tokens=6,
-        overlap_tokens=2,
-        hard_limit=6,
-    )
+    with tasks.force_whitespace_tokenizer():
+        chunks = tasks._chunkify(
+            sentences,
+            target_tokens=6,
+            overlap_tokens=2,
+            hard_limit=6,
+        )
 
     assert chunks == [
         "eins zwei drei vier fünf sechs",
@@ -56,12 +57,13 @@ def test_chunkify_enforces_hard_limit_and_long_sentences() -> None:
     long_sentence = " ".join(f"wort{i}" for i in range(12))
     sentences = ["kurz eins", long_sentence]
 
-    chunks = tasks._chunkify(
-        sentences,
-        target_tokens=10,
-        overlap_tokens=0,
-        hard_limit=4,
-    )
+    with tasks.force_whitespace_tokenizer():
+        chunks = tasks._chunkify(
+            sentences,
+            target_tokens=10,
+            overlap_tokens=0,
+            hard_limit=4,
+        )
 
     expected_long_chunks = [
         " ".join(f"wort{i}" for i in range(start, min(start + 4, 12)))


### PR DESCRIPTION
## Summary
- add a whitespace-tokenizer override hook with optional environment flag for deterministic chunk sizing
- update chunkify unit tests to exercise the fallback tokenizer explicitly

## Testing
- pytest ai_core/tests/test_tasks.py -q
- AI_CORE_FORCE_WHITESPACE_TOKENIZER=1 pytest ai_core/tests/test_tasks.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dfbd665214832b9c90127e74ced3dd