### PR TITLE
Align rag_database fixture with Django test database

### DIFF
--- a/tests/plugins/rag_db.py
+++ b/tests/plugins/rag_db.py
@@ -6,7 +6,7 @@ from typing import Iterator
 import psycopg2
 import pytest
 from psycopg2 import OperationalError, errors, sql
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT, make_dsn, parse_dsn
 
 from ai_core.rag import vector_client as rag_vector_client
 from ai_core.rag.vector_store import reset_default_router
@@ -61,11 +61,28 @@ def reset_vector_schema(cur, schema_name: str = DEFAULT_SCHEMA_NAME) -> None:
 SCHEMA_SQL = render_schema_sql()
 
 
+def _extract_dbname(dsn: str) -> str | None:
+    if not dsn:
+        return None
+    try:
+        canonical = make_dsn(dsn=dsn)
+    except Exception:
+        canonical = dsn
+    try:
+        parsed = parse_dsn(canonical)
+    except Exception:
+        return None
+    name = parsed.get("dbname") or parsed.get("database")
+    return str(name) if name else None
+
+
 @pytest.fixture(scope="session")
 def rag_test_dsn() -> Iterator[str]:
-    dsn = os.environ.get(
-        "AI_CORE_TEST_DATABASE_URL",
-        "postgresql://postgres:postgres@localhost:5432/postgres",
+    dsn = (
+        os.environ.get("AI_CORE_TEST_DATABASE_URL")
+        or os.environ.get("RAG_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or "postgresql://postgres:postgres@localhost:5432/postgres"
     )
     try:
         conn = psycopg2.connect(dsn)
@@ -94,23 +111,58 @@ def rag_test_dsn() -> Iterator[str]:
 
 
 @pytest.fixture
-def rag_database(rag_test_dsn: str, monkeypatch) -> Iterator[str]:
-    conn = psycopg2.connect(rag_test_dsn)
+def rag_database(rag_test_dsn: str, monkeypatch, settings) -> Iterator[str]:
+    default_db_name = str(settings.DATABASES["default"].get("NAME") or "")
+
+    effective_dsn = rag_test_dsn
+    try:
+        canonical_dsn = make_dsn(dsn=rag_test_dsn)
+        parsed = parse_dsn(canonical_dsn)
+    except Exception:
+        parsed = {}
+    else:
+        current_name = parsed.get("dbname") or parsed.get("database")
+        if default_db_name and current_name and current_name != default_db_name:
+            parsed = {key: value for key, value in parsed.items() if value is not None}
+            parsed["dbname"] = default_db_name
+            effective_dsn = make_dsn(**parsed)
+
+    conn = psycopg2.connect(effective_dsn)
     conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-    with conn.cursor() as cur:
-        cur.execute(
-            sql.SQL("SET search_path TO {}, public").format(
-                sql.Identifier(DEFAULT_SCHEMA_NAME)
-            )
-        )
-        cur.execute("TRUNCATE TABLE embeddings, chunks, documents CASCADE")
-    conn.close()
-    monkeypatch.setenv("DATABASE_URL", rag_test_dsn)
-    monkeypatch.setenv("RAG_DATABASE_URL", rag_test_dsn)
+    schema_initialised = False
+    skip_reason: str | None = None
+    try:
+        with conn.cursor() as cur:
+            try:
+                cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            except errors.InsufficientPrivilege:
+                cur.execute(
+                    "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+                )
+                result = cur.fetchone()
+                if result is None:
+                    skip_reason = "pgvector extension is required for RAG tests"
+            if skip_reason is None:
+                reset_vector_schema(cur, DEFAULT_SCHEMA_NAME)
+                schema_initialised = True
+    finally:
+        conn.close()
+
+    if skip_reason is not None:
+        pytest.skip(skip_reason)
+
+    monkeypatch.setenv("DATABASE_URL", effective_dsn)
+    monkeypatch.setenv("RAG_DATABASE_URL", effective_dsn)
     rag_vector_client.reset_default_client()
     reset_default_router()
     try:
-        yield rag_test_dsn
+        yield effective_dsn
     finally:
         rag_vector_client.reset_default_client()
         reset_default_router()
+        if schema_initialised:
+            conn = psycopg2.connect(effective_dsn)
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            with conn.cursor() as cur:
+                reset_vector_schema(cur, DEFAULT_SCHEMA_NAME)
+            conn.close()


### PR DESCRIPTION
## Summary
- prefer existing DATABASE_URL-style environment variables when building the RAG test DSN
- rewrite the test DSN to target Django's active test database, bootstrap the pgvector schema, and gracefully skip when the extension is unavailable

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py -q *(skipped: pgvector extension is required for RAG tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe09d2ad0832b965afa825578f636