### PR TITLE
Use Django-managed connection for RAG index rebuild command

### DIFF
--- a/ai_core/management/commands/rebuild_rag_index.py
+++ b/ai_core/management/commands/rebuild_rag_index.py
@@ -2,7 +2,7 @@ import re
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.db import DatabaseError, ProgrammingError
+from django.db import DatabaseError, ProgrammingError, connection
 from psycopg2 import errors, sql
 from psycopg2.extensions import STATUS_IN_TRANSACTION
 
@@ -29,119 +29,118 @@ class Command(BaseCommand):
         expected_index = hnsw_index_name if index_kind == "HNSW" else ivfflat_index_name
         row = None
 
-        with client.connection() as conn:
-            if (
-                not conn.closed
-                and conn.get_transaction_status() == STATUS_IN_TRANSACTION
-            ):
-                conn.rollback()
+        connection.ensure_connection()
+        conn = connection.connection
+        if conn is None:  # pragma: no cover - defensive
+            raise CommandError("Unable to obtain a database connection")
 
-            original_autocommit = conn.autocommit
-            autocommit_changed = False
-            if original_autocommit:
-                conn.autocommit = False
-                autocommit_changed = True
+        if (
+            not conn.closed and conn.get_transaction_status() == STATUS_IN_TRANSACTION
+        ):
+            conn.rollback()
+
+        original_autocommit = conn.autocommit
+        autocommit_changed = False
+        if original_autocommit:
+            conn.autocommit = False
+            autocommit_changed = True
+        try:
             try:
-                try:
-                    with conn.cursor() as cur:
-                        cur.execute(
-                            sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                                sql.Identifier(schema_name)
-                            )
+                with conn.cursor() as cur:
+                    cur.execute(
+                        sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                            sql.Identifier(schema_name)
                         )
-                        cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
-                    conn.commit()
-                except errors.UndefinedFile as exc:
-                    conn.rollback()
-                    raise CommandError(
-                        "pgvector extension is not available; ensure it is installed in the database"
-                    ) from exc
-                except Exception:
-                    conn.rollback()
-                    raise
+                    )
+                    cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+                conn.commit()
+            except errors.UndefinedFile as exc:
+                conn.rollback()
+                raise CommandError(
+                    "pgvector extension is not available; ensure it is installed in the database"
+                ) from exc
+            except Exception:
+                conn.rollback()
+                raise
 
-                try:
-                    with conn.cursor() as cur:
+            try:
+                with conn.cursor() as cur:
+                    for index_name in (hnsw_index_name, ivfflat_index_name):
                         cur.execute(
-                            sql.SQL("SET LOCAL search_path TO {}, public").format(
-                                sql.Identifier(schema_name)
+                            sql.SQL("DROP INDEX IF EXISTS {}.{}").format(
+                                sql.Identifier(schema_name),
+                                sql.Identifier(index_name),
                             )
                         )
-                        for index_name in (hnsw_index_name, ivfflat_index_name):
-                            cur.execute(
-                                sql.SQL("DROP INDEX IF EXISTS {}").format(
-                                    sql.Identifier(index_name)
-                                )
-                            )
-                        if index_kind == "HNSW":
-                            cur.execute(
-                                sql.SQL(
-                                    """
-                                    CREATE INDEX {} ON {} USING hnsw (embedding vector_cosine_ops)
-                                    WITH (m = %s, ef_construction = %s)
-                                    """
-                                ).format(
-                                    sql.Identifier(hnsw_index_name),
-                                    sql.Identifier(schema_name, "embeddings"),
-                                ),
-                                (hnsw_m, hnsw_ef),
-                            )
-                        else:
-                            cur.execute(
-                                sql.SQL(
-                                    """
-                                    CREATE INDEX {} ON {} USING ivfflat (embedding vector_cosine_ops)
-                                    WITH (lists = %s)
-                                    """
-                                ).format(
-                                    sql.Identifier(ivfflat_index_name),
-                                    sql.Identifier(schema_name, "embeddings"),
-                                ),
-                                (ivf_lists,),
-                            )
+                    if index_kind == "HNSW":
                         cur.execute(
-                            sql.SQL("ANALYZE {}").format(
-                                sql.Identifier(schema_name, "embeddings")
-                            )
+                            sql.SQL(
+                                """
+                                CREATE INDEX {} ON {} USING hnsw (embedding vector_cosine_ops)
+                                WITH (m = %s, ef_construction = %s)
+                                """
+                            ).format(
+                                sql.Identifier(hnsw_index_name),
+                                sql.Identifier(schema_name, "embeddings"),
+                            ),
+                            (hnsw_m, hnsw_ef),
                         )
+                    else:
                         cur.execute(
-                            """
-                            SELECT indexdef
-                            FROM pg_indexes
-                            WHERE schemaname = %s
-                              AND tablename = 'embeddings'
-                              AND indexname = %s
-                            """,
-                            (schema_name, expected_index),
+                            sql.SQL(
+                                """
+                                CREATE INDEX {} ON {} USING ivfflat (embedding vector_cosine_ops)
+                                WITH (lists = %s)
+                                """
+                            ).format(
+                                sql.Identifier(ivfflat_index_name),
+                                sql.Identifier(schema_name, "embeddings"),
+                            ),
+                            (ivf_lists,),
                         )
-                        row = cur.fetchone()
-                    conn.commit()
-                except errors.UndefinedTable as exc:
-                    conn.rollback()
+                    cur.execute(
+                        sql.SQL("ANALYZE {}").format(
+                            sql.Identifier(schema_name, "embeddings")
+                        )
+                    )
+                    cur.execute(
+                        """
+                        SELECT indexdef
+                        FROM pg_indexes
+                        WHERE schemaname = %s
+                          AND tablename = 'embeddings'
+                          AND indexname = %s
+                        """,
+                        (schema_name, expected_index),
+                    )
+                    row = cur.fetchone()
+                conn.commit()
+            except errors.UndefinedTable as exc:
+                conn.rollback()
+                raise CommandError(
+                    "Vector table 'embeddings' not found; ensure the RAG schema is initialised"
+                ) from exc
+            except (DatabaseError, ProgrammingError) as exc:
+                conn.rollback()
+                cause = getattr(exc, "__cause__", None)
+                if isinstance(cause, errors.UndefinedTable):
                     raise CommandError(
                         "Vector table 'embeddings' not found; ensure the RAG schema is initialised"
-                    ) from exc
-                except (DatabaseError, ProgrammingError) as exc:
+                    ) from cause
+                raise
+            except Exception:
+                conn.rollback()
+                raise
+        finally:
+            try:
+                if (
+                    not conn.closed
+                    and conn.get_transaction_status() == STATUS_IN_TRANSACTION
+                ):
                     conn.rollback()
-                    cause = getattr(exc, "__cause__", None)
-                    if isinstance(cause, errors.UndefinedTable):
-                        raise CommandError(
-                            "Vector table 'embeddings' not found; ensure the RAG schema is initialised"
-                        ) from cause
-                    raise
-                except Exception:
-                    conn.rollback()
-                    raise
             finally:
-                try:
-                    if (
-                        not conn.closed
-                        and conn.get_transaction_status() == STATUS_IN_TRANSACTION
-                    ):
-                        conn.rollback()
-                finally:
-                    if autocommit_changed:
-                        conn.autocommit = original_autocommit
+                if autocommit_changed:
+                    conn.autocommit = original_autocommit
 
         if not row:
             raise CommandError(


### PR DESCRIPTION
## Summary
- ensure the `rebuild_rag_index` management command operates via Django's database connection so it honours cloned test databases
- rebuild indexes using schema-qualified statements while preserving error handling for missing extensions or tables

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py *(skipped: PostgreSQL with pgvector not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e00d572bd8832b94fa386d68f4013f