### PR TITLE
Fix rebuild_rag_index isolation and schema initialization

### DIFF
--- a/ai_core/management/commands/rebuild_rag_index.py
+++ b/ai_core/management/commands/rebuild_rag_index.py
@@ -2,8 +2,8 @@ import re
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django.db import connection, transaction
 from psycopg2 import errors, sql
-from psycopg2.extensions import STATUS_IN_TRANSACTION
 
 from ai_core.rag import vector_client
 
@@ -20,114 +20,31 @@ class Command(BaseCommand):
         hnsw_ef = int(getattr(settings, "RAG_HNSW_EF_CONSTRUCTION", 200))
         ivf_lists = int(getattr(settings, "RAG_IVF_LISTS", 2048))
 
-        client = vector_client.get_default_client()
-        schema_name = getattr(client, "_schema", "rag")
+        schema_name = vector_client.get_default_schema()
         scope = f"{schema_name}.embeddings"
         hnsw_index_name = "embeddings_embedding_hnsw"
         ivfflat_index_name = "embeddings_embedding_ivfflat"
         expected_index = hnsw_index_name if index_kind == "HNSW" else ivfflat_index_name
-        row = None
-
-        with client.connection() as conn:
-            if (
-                not conn.closed and conn.get_transaction_status() == STATUS_IN_TRANSACTION
-            ):
-                conn.rollback()
-
-            original_autocommit = conn.autocommit
-            autocommit_changed = False
-            if original_autocommit:
-                conn.autocommit = False
-                autocommit_changed = True
-            try:
-                try:
-                    with conn.cursor() as cur:
-                        cur.execute(
-                            sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
-                                sql.Identifier(schema_name)
-                            )
-                        )
-                        cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
-                    conn.commit()
-                except errors.UndefinedFile as exc:
-                    conn.rollback()
-                    raise CommandError(
-                        "pgvector extension is not available; ensure it is installed in the database"
-                    ) from exc
-                except Exception:
-                    conn.rollback()
-                    raise
-
-                try:
-                    with conn.cursor() as cur:
-                        for index_name in (hnsw_index_name, ivfflat_index_name):
-                            cur.execute(
-                                sql.SQL("DROP INDEX IF EXISTS {}.{}").format(
-                                    sql.Identifier(schema_name),
-                                    sql.Identifier(index_name),
-                                )
-                            )
-                        if index_kind == "HNSW":
-                            cur.execute(
-                                sql.SQL(
-                                    """
-                                    CREATE INDEX {} ON {} USING hnsw (embedding vector_cosine_ops)
-                                    WITH (m = %s, ef_construction = %s)
-                                    """
-                                ).format(
-                                    sql.Identifier(hnsw_index_name),
-                                    sql.Identifier(schema_name, "embeddings"),
-                                ),
-                                (hnsw_m, hnsw_ef),
-                            )
-                        else:
-                            cur.execute(
-                                sql.SQL(
-                                    """
-                                    CREATE INDEX {} ON {} USING ivfflat (embedding vector_cosine_ops)
-                                    WITH (lists = %s)
-                                    """
-                                ).format(
-                                    sql.Identifier(ivfflat_index_name),
-                                    sql.Identifier(schema_name, "embeddings"),
-                                ),
-                                (ivf_lists,),
-                            )
-                        cur.execute(
-                            sql.SQL("ANALYZE {}").format(
-                                sql.Identifier(schema_name, "embeddings")
-                            )
-                        )
-                        cur.execute(
-                            """
-                            SELECT indexdef
-                            FROM pg_indexes
-                            WHERE schemaname = %s
-                              AND tablename = 'embeddings'
-                              AND indexname = %s
-                            """,
-                            (schema_name, expected_index),
-                        )
-                        row = cur.fetchone()
-                    conn.commit()
-                except errors.UndefinedTable as exc:
-                    conn.rollback()
-                    raise CommandError(
-                        "Vector table 'embeddings' not found; ensure the RAG schema is initialised"
-                    ) from exc
-                except Exception:
-                    conn.rollback()
-                    raise
-            finally:
-                try:
-                    if (
-                        not conn.closed
-                        and conn.get_transaction_status() == STATUS_IN_TRANSACTION
-                    ):
-                        conn.rollback()
-                finally:
-                    if autocommit_changed:
-                        conn.autocommit = original_autocommit
+        try:
+            with transaction.atomic():
+                row = self._rebuild_index(
+                    schema_name,
+                    index_kind,
+                    hnsw_m,
+                    hnsw_ef,
+                    ivf_lists,
+                    expected_index,
+                    hnsw_index_name,
+                    ivfflat_index_name,
+                )
+        except errors.UndefinedFile as exc:
+            raise CommandError(
+                f"Required database extension is not available: {exc}"
+            ) from exc
+        except errors.UndefinedTable as exc:
+            raise CommandError(
+                "Vector table 'embeddings' not found; ensure the RAG schema is initialised"
+            ) from exc
 
         if not row:
             raise CommandError(
@@ -146,4 +63,139 @@ class Command(BaseCommand):
             self.style.SUCCESS(
                 f"Rebuilt embeddings index using {index_kind} (scope: {scope}, {details})"
             )
+        )
+
+    def _rebuild_index(
+        self,
+        schema_name: str,
+        index_kind: str,
+        hnsw_m: int,
+        hnsw_ef: int,
+        ivf_lists: int,
+        expected_index: str,
+        hnsw_index_name: str,
+        ivfflat_index_name: str,
+    ) -> tuple[str] | None:
+        with connection.cursor() as cur:
+            self._ensure_schema(cur, schema_name)
+            self._ensure_tables(cur, schema_name)
+
+            for index_name in (hnsw_index_name, ivfflat_index_name):
+                cur.execute(
+                    sql.SQL("DROP INDEX IF EXISTS {}.{}").format(
+                        sql.Identifier(schema_name),
+                        sql.Identifier(index_name),
+                    )
+                )
+
+            if index_kind == "HNSW":
+                cur.execute(
+                    sql.SQL(
+                        """
+                        CREATE INDEX {} ON {} USING hnsw (embedding vector_cosine_ops)
+                        WITH (m = %s, ef_construction = %s)
+                        """
+                    ).format(
+                        sql.Identifier(hnsw_index_name),
+                        sql.Identifier(schema_name, "embeddings"),
+                    ),
+                    (hnsw_m, hnsw_ef),
+                )
+            else:
+                cur.execute(
+                    sql.SQL(
+                        """
+                        CREATE INDEX {} ON {} USING ivfflat (embedding vector_cosine_ops)
+                        WITH (lists = %s)
+                        """
+                    ).format(
+                        sql.Identifier(ivfflat_index_name),
+                        sql.Identifier(schema_name, "embeddings"),
+                    ),
+                    (ivf_lists,),
+                )
+
+            cur.execute(
+                sql.SQL("ANALYZE {}").format(
+                    sql.Identifier(schema_name, "embeddings")
+                )
+            )
+            cur.execute(
+                """
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE schemaname = %s
+                  AND tablename = 'embeddings'
+                  AND indexname = %s
+                """,
+                (schema_name, expected_index),
+            )
+            return cur.fetchone()
+
+    def _ensure_schema(self, cur, schema_name: str) -> None:
+        cur.execute(
+            sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                sql.Identifier(schema_name)
+            )
+        )
+        cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        cur.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    def _ensure_tables(self, cur, schema_name: str) -> None:
+        documents = sql.Identifier(schema_name, "documents")
+        chunks = sql.Identifier(schema_name, "chunks")
+        embeddings = sql.Identifier(schema_name, "embeddings")
+
+        cur.execute(
+            sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {documents} (
+                    id UUID PRIMARY KEY,
+                    tenant_id UUID NOT NULL,
+                    source TEXT NOT NULL,
+                    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                    hash TEXT NOT NULL,
+                    metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+                    deleted_at TIMESTAMP WITH TIME ZONE,
+                    external_id TEXT
+                )
+                """
+            ).format(documents=documents)
+        )
+
+        cur.execute(
+            sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {chunks} (
+                    id UUID PRIMARY KEY,
+                    document_id UUID NOT NULL REFERENCES {documents}(id) ON DELETE CASCADE,
+                    ord INTEGER NOT NULL,
+                    text TEXT NOT NULL,
+                    tokens INTEGER NOT NULL,
+                    metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+                    text_norm TEXT GENERATED ALWAYS AS (lower(regexp_replace(text, '\\s+', ' ', 'g'))) STORED
+                )
+                """
+            ).format(chunks=chunks, documents=documents)
+        )
+
+        cur.execute(
+            sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {embeddings} (
+                    id UUID PRIMARY KEY,
+                    chunk_id UUID NOT NULL REFERENCES {chunks}(id) ON DELETE CASCADE,
+                    embedding vector(1536) NOT NULL
+                )
+                """
+            ).format(embeddings=embeddings, chunks=chunks)
+        )
+
+        cur.execute(
+            sql.SQL(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS embeddings_chunk_idx
+                    ON {embeddings} (chunk_id)
+                """
+            ).format(embeddings=embeddings)
         )

--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -1854,6 +1854,12 @@ def _resolve_vector_schema() -> str:
     return "rag"
 
 
+def get_default_schema() -> str:
+    """Return the schema configured for the default :class:`PgVectorClient`."""
+
+    return _resolve_vector_schema()
+
+
 def get_default_client() -> PgVectorClient:
     global _DEFAULT_CLIENT
     if _DEFAULT_CLIENT is None:


### PR DESCRIPTION
## Summary
- execute the rebuild_rag_index command through Django's database connection so it shares the test transaction
- provision the required RAG tables and supporting extensions before recreating the vector indexes
- expose the configured default schema in the vector client and update the management command test to expect automatic table recreation

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py

------
https://chatgpt.com/codex/tasks/task_e_68e021d9c884832ba4dd9bae923ad8eb