### PR TITLE
Propagate pgvector operator class to query execution

### DIFF
--- a/ai_core/management/commands/rebuild_rag_index.py
+++ b/ai_core/management/commands/rebuild_rag_index.py
@@ -100,7 +100,12 @@ class Command(BaseCommand):
                     )
                 )
 
-            operator_class = self._resolve_operator_class(cur, index_kind)
+            operator_class = vector_client.resolve_operator_class(cur, index_kind)
+            if operator_class is None:
+                raise CommandError(
+                    "No compatible operator class found for pgvector index creation. "
+                    "Ensure the pgvector extension is installed with cosine or L2 support."
+                )
             table_identifier = sql.Identifier(schema_name, "embeddings")
 
             if index_kind == "HNSW":
@@ -150,35 +155,6 @@ class Command(BaseCommand):
                 (schema_name, expected_index),
             )
             return cur.fetchone()
-
-    def _resolve_operator_class(self, cur, index_kind: str) -> str:
-        access_method = "hnsw" if index_kind == "HNSW" else "ivfflat"
-        preferred = "vector_cosine_ops"
-        if self._operator_class_exists(cur, preferred, access_method):
-            return preferred
-
-        for fallback in ("vector_l2_ops", "vector_ip_ops"):
-            if self._operator_class_exists(cur, fallback, access_method):
-                return fallback
-
-        raise CommandError(
-            "No compatible operator class found for pgvector index creation. "
-            "Ensure the pgvector extension is installed with cosine or L2 support."
-        )
-
-    def _operator_class_exists(
-        self, cur, operator_class: str, access_method: str
-    ) -> bool:
-        cur.execute(
-            """
-            SELECT 1
-            FROM pg_catalog.pg_opclass opc
-            JOIN pg_catalog.pg_am am ON am.oid = opc.opcmethod
-            WHERE opc.opcname = %s AND am.amname = %s
-            """,
-            (operator_class, access_method),
-        )
-        return cur.fetchone() is not None
 
     def _ensure_schema(self, cur, schema_name: str) -> None:
         cur.execute(

--- a/ai_core/tests/test_management_rebuild_rag_index.py
+++ b/ai_core/tests/test_management_rebuild_rag_index.py
@@ -175,14 +175,14 @@ def test_rebuild_rag_index_falls_back_when_cosine_ops_missing(
 
     settings.RAG_INDEX_KIND = "HNSW"
 
-    def fake_operator_class_exists(self, cur, operator_class: str, access_method: str) -> bool:
+    def fake_operator_class_exists(cur, operator_class: str, access_method: str) -> bool:
         if operator_class == "vector_cosine_ops":
             return False
         return operator_class == "vector_l2_ops"
 
     monkeypatch.setattr(
-        Command,
-        "_operator_class_exists",
+        vector_client,
+        "operator_class_exists",
         fake_operator_class_exists,
         raising=True,
     )


### PR DESCRIPTION
## Summary
- reuse the pgvector operator-class detection from the management command when rebuilding indexes
- cache and apply the detected distance operator in the vector client so hybrid search queries match index capabilities
- update the management command and vector client tests, adding coverage for the fallback operator path

## Testing
- pytest ai_core/tests/test_management_rebuild_rag_index.py::test_rebuild_rag_index_falls_back_when_cosine_ops_missing ai_core/tests/test_vector_client.py::TestPgVectorClient::test_hybrid_uses_fallback_distance_operator -q

------
https://chatgpt.com/codex/tasks/task_e_68e0490e4c24832bbd59d99347cf0b15