### PR TITLE
Add tests covering ingestion run success and failure paths

### DIFF
--- a/ai_core/tests/test_ingestion_task.py
+++ b/ai_core/tests/test_ingestion_task.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+import pytest
+from celery.exceptions import TimeoutError as CeleryTimeoutError
+
+from ai_core import ingestion
+
+
+class DummyProcessTask:
+    def __init__(self) -> None:
+        self.calls: List[tuple[Any, ...]] = []
+
+    def s(self, *args: Any) -> tuple[str, tuple[Any, ...]]:
+        self.calls.append(args)
+        return ("signature", args)
+
+
+class DummyChildResult:
+    def __init__(
+        self,
+        document_id: str,
+        *,
+        ready: bool,
+        partial: Optional[Dict[str, Any]] = None,
+        get_exception: Optional[BaseException] = None,
+    ) -> None:
+        self.document_id = document_id
+        self._ready = ready
+        self._partial = partial or {"document_id": document_id}
+        self._get_exception = get_exception
+        self.revoked: List[Dict[str, Any]] = []
+
+    def get(self, timeout: Optional[float] = None, propagate: bool = True):
+        if self._get_exception is not None:
+            raise self._get_exception
+        return self._partial
+
+    def ready(self) -> bool:
+        return self._ready
+
+    def revoke(self, terminate: bool = True) -> None:
+        self.revoked.append({"terminate": terminate})
+
+
+class DummyAsyncResult:
+    def __init__(self, results: Iterable[DummyChildResult]) -> None:
+        self.results = list(results)
+        self.get_calls: List[Dict[str, Any]] = []
+        self._results_payload: Optional[List[Dict[str, Any]]] = None
+        self.should_raise: Optional[BaseException] = None
+
+    def get(
+        self,
+        timeout: Optional[float] = None,
+        disable_sync_subtasks: Optional[bool] = None,
+    ) -> List[Dict[str, Any]]:
+        self.get_calls.append(
+            {"timeout": timeout, "disable_sync_subtasks": disable_sync_subtasks}
+        )
+        if self.should_raise is not None:
+            raise self.should_raise
+        assert self._results_payload is not None
+        return self._results_payload
+
+
+def _setup_common_monkeypatches(monkeypatch):
+    dummy_process = DummyProcessTask()
+    monkeypatch.setattr(ingestion, "process_document", dummy_process)
+
+    start_calls: List[Dict[str, Any]] = []
+    end_calls: List[Dict[str, Any]] = []
+    monkeypatch.setattr(
+        ingestion.pipe,
+        "log_ingestion_run_start",
+        lambda **kwargs: start_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        ingestion.pipe,
+        "log_ingestion_run_end",
+        lambda **kwargs: end_calls.append(kwargs),
+    )
+
+    apply_async_calls: List[Dict[str, Any]] = []
+
+    def fake_apply_async(*args: Any, **kwargs: Any) -> None:
+        apply_async_calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(ingestion.record_dead_letter, "apply_async", fake_apply_async)
+
+    return dummy_process, start_calls, end_calls, apply_async_calls
+
+
+def _patch_partition(monkeypatch, valid: List[str], invalid: List[str]) -> None:
+    monkeypatch.setattr(
+        ingestion,
+        "partition_document_ids",
+        lambda tenant, case, document_ids: (valid, invalid),
+    )
+
+
+def _patch_group(monkeypatch, async_result: DummyAsyncResult):
+    captured_signatures: List[List[Any]] = []
+
+    def fake_group(signatures_iterable: Iterable[Any]):
+        items = list(signatures_iterable)
+        captured_signatures.append(items)
+
+        class _Group:
+            def apply_async(self):
+                return async_result
+
+        return _Group()
+
+    monkeypatch.setattr(ingestion, "group", fake_group)
+    return captured_signatures
+
+
+def _patch_perf_counter(monkeypatch, start: float, end: float) -> None:
+    values = iter((start, end))
+
+    def fake_perf_counter() -> float:
+        try:
+            return next(values)
+        except StopIteration:
+            return end
+
+    monkeypatch.setattr(ingestion.time, "perf_counter", fake_perf_counter)
+
+
+def test_run_ingestion_success(monkeypatch):
+    dummy_process, start_calls, end_calls, apply_async_calls = _setup_common_monkeypatches(
+        monkeypatch
+    )
+    valid_ids = ["doc-1", "doc-2"]
+    invalid_ids = ["missing-1"]
+    _patch_partition(monkeypatch, valid_ids, invalid_ids)
+
+    async_result = DummyAsyncResult(results=[])
+    async_result._results_payload = [
+        {
+            "document_id": "doc-1",
+            "inserted": 2,
+            "replaced": 0,
+            "skipped": 0,
+            "chunk_count": 5,
+            "duration_ms": 100.0,
+        },
+        {
+            "document_id": "doc-2",
+            "inserted": 0,
+            "replaced": 1,
+            "skipped": 1,
+            "chunk_count": 3,
+            "duration_ms": 150.0,
+        },
+    ]
+
+    captured_signatures = _patch_group(monkeypatch, async_result)
+    _patch_perf_counter(monkeypatch, 10.0, 10.5)
+
+    response = ingestion.run_ingestion.run(
+        tenant="tenant-a",
+        case="case-b",
+        document_ids=list(valid_ids),
+        run_id="run-123",
+        trace_id="trace-xyz",
+        idempotency_key="idem-1",
+        timeout_seconds=5.0,
+    )
+
+    assert response["status"] == "dispatched"
+    assert response["count"] == len(valid_ids)
+    assert response["invalid_ids"] == invalid_ids
+    assert response["inserted"] == 2
+    assert response["replaced"] == 1
+    assert response["skipped"] == 1
+    assert response["total_chunks"] == 8
+    assert response["duration_ms"] == pytest.approx(500.0)
+
+    assert dummy_process.calls == [
+        ("tenant-a", "case-b", "doc-1", None),
+        ("tenant-a", "case-b", "doc-2", None),
+    ]
+    assert len(captured_signatures) == 1
+    assert len(captured_signatures[0]) == len(valid_ids)
+
+    assert start_calls == [
+        {
+            "tenant": "tenant-a",
+            "case": "case-b",
+            "run_id": "run-123",
+            "doc_count": len(valid_ids),
+            "trace_id": "trace-xyz",
+            "idempotency_key": "idem-1",
+        }
+    ]
+    assert len(end_calls) == 1
+    end_call = end_calls[0]
+    assert end_call["tenant"] == "tenant-a"
+    assert end_call["case"] == "case-b"
+    assert end_call["run_id"] == "run-123"
+    assert end_call["doc_count"] == len(valid_ids)
+    assert end_call["inserted"] == 2
+    assert end_call["replaced"] == 1
+    assert end_call["skipped"] == 1
+    assert end_call["total_chunks"] == 8
+    assert end_call["duration_ms"] == pytest.approx(500.0)
+    assert end_call["trace_id"] == "trace-xyz"
+    assert end_call["idempotency_key"] == "idem-1"
+    assert apply_async_calls == []
+
+
+def test_run_ingestion_timeout_dispatches_dead_letters(monkeypatch):
+    dummy_process, start_calls, end_calls, apply_async_calls = _setup_common_monkeypatches(
+        monkeypatch
+    )
+    valid_ids = ["doc-1", "doc-2"]
+    _patch_partition(monkeypatch, valid_ids, [])
+
+    child_success = DummyChildResult(
+        "doc-1",
+        ready=True,
+        partial={
+            "document_id": "doc-1",
+            "inserted": 1,
+            "replaced": 0,
+            "skipped": 0,
+            "chunk_count": 2,
+        },
+    )
+    child_pending = DummyChildResult(
+        "doc-2",
+        ready=False,
+        partial=None,
+        get_exception=CeleryTimeoutError("pending"),
+    )
+    async_result = DummyAsyncResult(results=[child_success, child_pending])
+    async_result.should_raise = CeleryTimeoutError("timed out")
+
+    captured_signatures = _patch_group(monkeypatch, async_result)
+    _patch_perf_counter(monkeypatch, 20.0, 20.4)
+
+    original_collect = ingestion._collect_partial_results
+    collect_calls: List[Any] = []
+
+    def fake_collect(async_result_param):
+        collect_calls.append(async_result_param)
+        return original_collect(async_result_param)
+
+    monkeypatch.setattr(ingestion, "_collect_partial_results", fake_collect)
+
+    response = ingestion.run_ingestion.run(
+        tenant="tenant-a",
+        case="case-b",
+        document_ids=list(valid_ids),
+        run_id="run-timeout",
+        trace_id="trace-timeout",
+        idempotency_key="timeout-id",
+        timeout_seconds=3.0,
+        dead_letter_queue="dlq-test",
+    )
+
+    assert response["status"] == "failed"
+    assert "timed out" in response["error"]
+    assert response["inserted"] == 1
+    assert response["replaced"] == 0
+    assert response["skipped"] == 0
+    assert response["total_chunks"] == 2
+    assert response["duration_ms"] == pytest.approx(400.0)
+
+    assert len(collect_calls) == 1
+    assert collect_calls[0] is async_result
+
+    assert len(apply_async_calls) == 1
+    dead_letter_payload = apply_async_calls[0]["kwargs"]["args"][0]
+    assert dead_letter_payload["document_id"] == "doc-2"
+    assert dead_letter_payload["run_id"] == "run-timeout"
+    assert dead_letter_payload["trace_id"] == "trace-timeout"
+
+    assert child_pending.revoked == [{"terminate": True}]
+    assert child_success.revoked == []
+
+    assert start_calls[0]["doc_count"] == len(valid_ids)
+    assert len(end_calls) == 1
+    assert end_calls[0]["inserted"] == 1
+    assert end_calls[0]["replaced"] == 0
+    assert end_calls[0]["skipped"] == 0
+    assert end_calls[0]["total_chunks"] == 2
+    assert end_calls[0]["duration_ms"] == pytest.approx(400.0)
+
+
+def test_run_ingestion_base_exception_dispatches_dead_letters(monkeypatch):
+    dummy_process, start_calls, end_calls, apply_async_calls = _setup_common_monkeypatches(
+        monkeypatch
+    )
+    valid_ids = ["doc-1", "doc-2"]
+    _patch_partition(monkeypatch, valid_ids, [])
+
+    child_success = DummyChildResult(
+        "doc-1",
+        ready=True,
+        partial={
+            "document_id": "doc-1",
+            "inserted": 1,
+            "replaced": 0,
+            "skipped": 0,
+            "chunk_count": 2,
+        },
+    )
+    child_pending = DummyChildResult(
+        "doc-2",
+        ready=False,
+        partial=None,
+        get_exception=CeleryTimeoutError("pending"),
+    )
+    async_result = DummyAsyncResult(results=[child_success, child_pending])
+    async_result.should_raise = CeleryTimeoutError("timed out")
+
+    _patch_group(monkeypatch, async_result)
+    _patch_perf_counter(monkeypatch, 30.0, 30.6)
+
+    original_determine = ingestion._determine_failed_documents
+    call_counter = {"count": 0}
+
+    def flaky_determine(document_ids: Iterable[str], results: Iterable[Dict[str, Any]]):
+        call_counter["count"] += 1
+        if call_counter["count"] == 1:
+            raise RuntimeError("aggregation failed")
+        return original_determine(document_ids, results)
+
+    monkeypatch.setattr(ingestion, "_determine_failed_documents", flaky_determine)
+
+    with pytest.raises(RuntimeError, match="aggregation failed"):
+        ingestion.run_ingestion.run(
+            tenant="tenant-a",
+            case="case-b",
+            document_ids=list(valid_ids),
+            run_id="run-exc",
+            trace_id="trace-exc",
+            idempotency_key="exc-id",
+            timeout_seconds=2.5,
+            dead_letter_queue="dlq-exc",
+        )
+
+    assert call_counter["count"] >= 2
+    assert len(apply_async_calls) == 1
+    dead_letter_payload = apply_async_calls[0]["kwargs"]["args"][0]
+    assert dead_letter_payload["document_id"] == "doc-2"
+    assert dead_letter_payload["run_id"] == "run-exc"
+    assert dead_letter_payload["trace_id"] == "trace-exc"
+
+    assert child_pending.revoked == [{"terminate": True}]
+    assert child_success.revoked == []
+
+    assert start_calls[0]["doc_count"] == len(valid_ids)
+    assert len(end_calls) == 1
+    assert end_calls[0]["duration_ms"] == pytest.approx(600.0)
+


### PR DESCRIPTION
## Summary
- add a dedicated ingestion task test module with reusable monkeypatch helpers
- cover successful run aggregation and logging plus timeout failure handling and dead-letter dispatch
- exercise the BaseException branch to ensure pending tasks are revoked and dead letters dispatched

## Testing
- pytest ai_core/tests/test_ingestion_task.py

------
https://chatgpt.com/codex/tasks/task_e_68e10c8b10b4832b8eed34795070cbfa