### PR TITLE
Add coverage for missing name in graph registry

### DIFF
--- a/ai_core/tests/test_graph_registry.py
+++ b/ai_core/tests/test_graph_registry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import types
 
+import pytest
+
 from ai_core.graph import registry
 
 
@@ -25,3 +27,11 @@ def test_register_overwrites_existing_runner(monkeypatch) -> None:
     registry.register("scope_check", second)
 
     assert registry.get("scope_check") is second
+
+
+def test_register_requires_name(monkeypatch) -> None:
+    monkeypatch.setattr(registry, "_REGISTRY", {})
+    runner = types.SimpleNamespace()
+
+    with pytest.raises(ValueError, match="graph name must be provided"):
+        registry.register("", runner)


### PR DESCRIPTION
## Summary
- add a regression test ensuring registry.register rejects empty graph names

## Testing
- pytest ai_core/tests/test_graph_registry.py::test_register_requires_name

------
https://chatgpt.com/codex/tasks/task_e_68e16c9eccbc832b8016c826d1a73e22