### PR TITLE
Deduplicate candidate normalization in router inputs

### DIFF
--- a/ai_core/apps.py
+++ b/ai_core/apps.py
@@ -1,5 +1,9 @@
 from django.apps import AppConfig
 
+from .rag.embedding_config import validate_embedding_configuration
+from .rag.routing_rules import validate_routing_rules
+from .rag.vector_schema import validate_vector_schemas
+
 
 class AiCoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
@@ -9,6 +13,10 @@ class AiCoreConfig(AppConfig):
         """Perform application bootstrap when the app registry is ready."""
 
         super().ready()
+
+        validate_embedding_configuration()
+        validate_routing_rules()
+        validate_vector_schemas()
 
         from .graph.bootstrap import bootstrap
 

--- a/ai_core/management/commands/rag_routing_rules.py
+++ b/ai_core/management/commands/rag_routing_rules.py
@@ -1,0 +1,105 @@
+"""Inspect and dry-run embedding routing rules."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ai_core.rag.profile_resolver import (
+    ProfileResolverError,
+    resolve_embedding_profile,
+)
+from ai_core.rag.routing_rules import (
+    RoutingConfigurationError,
+    get_routing_table,
+    reset_routing_rules_cache,
+)
+from ai_core.rag.selector_utils import normalise_selector_value
+
+
+class Command(BaseCommand):
+    help = (
+        "Validate embedding routing rules and optionally resolve a selector "
+        "against the configured table."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--tenant",
+            help="Tenant identifier for dry-run profile resolution",
+        )
+        parser.add_argument(
+            "--process",
+            help="Process label for dry-run profile resolution",
+        )
+        parser.add_argument(
+            "--doc-class",
+            help="Document class label for dry-run profile resolution",
+        )
+        parser.add_argument(
+            "--refresh",
+            action="store_true",
+            help="Reload routing rules from disk before validation",
+        )
+
+    def handle(self, *args, **options):
+        if options.get("refresh"):
+            reset_routing_rules_cache()
+
+        try:
+            table = get_routing_table()
+        except RoutingConfigurationError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self.stdout.write("Default profile: %s" % table.default_profile)
+        if table.rules:
+            self.stdout.write("Overrides:")
+            for rule in table.rules:
+                tenant = rule.tenant or "*"
+                process = rule.process or "*"
+                doc_class = rule.doc_class or "*"
+                self.stdout.write(
+                    "  - tenant=%s, process=%s, doc_class=%s -> %s"
+                    % (tenant, process, doc_class, rule.profile)
+                )
+        else:
+            self.stdout.write("No override rules configured.")
+
+        tenant_option = options.get("tenant")
+        process_option = options.get("process")
+        doc_class_option = options.get("doc_class")
+
+        if tenant_option is None:
+            if process_option is not None or doc_class_option is not None:
+                raise CommandError(
+                    "--tenant is required when using --process or --doc-class"
+                )
+            return
+
+        tenant = str(tenant_option).strip()
+        if not tenant:
+            raise CommandError("--tenant must be a non-empty string")
+
+        sanitized_process = normalise_selector_value(process_option)
+        sanitized_doc_class = normalise_selector_value(doc_class_option)
+
+        try:
+            profile_id = resolve_embedding_profile(
+                tenant_id=tenant,
+                process=process_option,
+                doc_class=doc_class_option,
+            )
+        except ProfileResolverError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self.stdout.write("")
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Resolved selector tenant=%s, process=%s, doc_class=%s -> %s"
+                % (
+                    tenant,
+                    sanitized_process or "*",
+                    sanitized_doc_class or "*",
+                    profile_id,
+                )
+            )
+        )

--- a/ai_core/management/commands/rag_schema_smoke.py
+++ b/ai_core/management/commands/rag_schema_smoke.py
@@ -1,0 +1,48 @@
+"""Smoke-test helper for vector schema rendering."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ai_core.rag.embedding_config import get_embedding_configuration
+from ai_core.rag.vector_schema import render_schema_sql
+
+
+class Command(BaseCommand):
+    help = "Render the vector schema SQL for a configured space to validate templates."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--space",
+            required=True,
+            help="Embedding vector space identifier to render",
+        )
+        parser.add_argument(
+            "--show-sql",
+            action="store_true",
+            help="Print the rendered SQL instead of only reporting success",
+        )
+
+    def handle(self, *args, **options):
+        space_id = str(options["space"]).strip()
+        if not space_id:
+            raise CommandError("--space must be provided")
+
+        configuration = get_embedding_configuration()
+        try:
+            space = configuration.vector_spaces[space_id]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise CommandError(f"Vector space '{space_id}' is not configured") from exc
+
+        sql = render_schema_sql(space.schema, space.dimension)
+        if options.get("show_sql"):
+            self.stdout.write(sql)
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Rendered schema for space %s (schema=%s, dimension=%s)"
+                    % (space.id, space.schema, space.dimension)
+                )
+            )
+
+        return sql

--- a/ai_core/rag/__init__.py
+++ b/ai_core/rag/__init__.py
@@ -2,11 +2,44 @@
 
 from __future__ import annotations
 
+from .profile_resolver import (
+    ProfileResolverError,
+    ProfileResolverErrorCode,
+    resolve_embedding_profile,
+)
+from .limits import CandidatePoolPolicy, resolve_candidate_pool_policy
+from .router_validation import (
+    RouterInputError,
+    RouterInputErrorCode,
+    emit_router_validation_failure,
+    map_router_error_to_status,
+    validate_search_inputs,
+)
+from .ingestion_contracts import (
+    IngestionContractError,
+    IngestionContractErrorCode,
+    ensure_embedding_dimensions,
+    map_ingestion_error_to_status,
+    resolve_ingestion_profile,
+)
 from .vector_store import (
     TenantScopedVectorStore,
     VectorStore,
     VectorStoreRouter,
     get_default_router,
+)
+from .vector_space_resolver import (
+    VectorSpaceResolverError,
+    VectorSpaceResolverErrorCode,
+    resolve_vector_space_full,
+    resolve_vector_space,
+)
+from .vector_schema import (
+    VectorSchemaError,
+    VectorSchemaErrorCode,
+    build_vector_schema_plan,
+    render_schema_sql,
+    validate_vector_schemas,
 )
 from . import vector_client as vector_client
 
@@ -16,4 +49,28 @@ __all__ = [
     "TenantScopedVectorStore",
     "get_default_router",
     "vector_client",
+    "resolve_ingestion_profile",
+    "IngestionContractError",
+    "IngestionContractErrorCode",
+    "ensure_embedding_dimensions",
+    "map_ingestion_error_to_status",
+    "resolve_embedding_profile",
+    "ProfileResolverError",
+    "ProfileResolverErrorCode",
+    "CandidatePoolPolicy",
+    "resolve_vector_space_full",
+    "resolve_vector_space",
+    "VectorSpaceResolverError",
+    "VectorSpaceResolverErrorCode",
+    "build_vector_schema_plan",
+    "render_schema_sql",
+    "validate_vector_schemas",
+    "VectorSchemaError",
+    "VectorSchemaErrorCode",
+    "RouterInputError",
+    "RouterInputErrorCode",
+    "emit_router_validation_failure",
+    "map_router_error_to_status",
+    "validate_search_inputs",
+    "resolve_candidate_pool_policy",
 ]

--- a/ai_core/rag/embedding_config.py
+++ b/ai_core/rag/embedding_config.py
@@ -1,0 +1,302 @@
+"""Configuration loader for embedding profiles and vector spaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Dict, Mapping, cast
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+class EmbeddingConfigurationError(ImproperlyConfigured):
+    """Raised when the embedding configuration is invalid."""
+
+
+class EmbeddingConfigErrorCode:
+    """Machine-readable error codes for embedding configuration issues."""
+
+    CONFIG_NOT_MAPPING = "EMB_CONFIG_TYPE"
+    VECTOR_SPACE_NOT_MAPPING = "EMB_SPACE_TYPE"
+    VECTOR_SPACE_BACKEND_REQUIRED = "EMB_SPACE_BACKEND_REQUIRED"
+    VECTOR_SPACE_SCHEMA_REQUIRED = "EMB_SPACE_SCHEMA_REQUIRED"
+    VECTOR_SPACE_DIMENSION_INVALID = "EMB_SPACE_DIM_INVALID"
+    VECTOR_SPACES_EMPTY = "EMB_NO_SPACES"
+    PROFILE_NOT_MAPPING = "EMB_PROFILE_TYPE"
+    PROFILE_MODEL_REQUIRED = "EMB_PROFILE_MODEL_REQUIRED"
+    PROFILE_DIMENSION_INVALID = "EMB_PROFILE_DIM_INVALID"
+    PROFILE_SPACE_REQUIRED = "EMB_PROFILE_SPACE_REQUIRED"
+    UNKNOWN_VECTOR_SPACE = "EMB_UNKNOWN_SPACE"
+    DIMENSION_MISMATCH = "EMB_DIM_MISMATCH"
+    PROFILES_EMPTY = "EMB_NO_PROFILES"
+    UNKNOWN_PROFILE = "EMB_UNKNOWN_PROFILE"
+
+
+_EMBEDDING_DOC_HINT = "See README.md (Fehlercodes Abschnitt) for remediation guidance."
+
+
+def _format_error(code: str, message: str) -> str:
+    return f"{code}: {message}. {_EMBEDDING_DOC_HINT}"
+
+
+@dataclass(frozen=True, slots=True)
+class VectorSpaceConfig:
+    """Describe a physical vector space for embeddings."""
+
+    id: str
+    backend: str
+    schema: str
+    dimension: int
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingProfileConfig:
+    """Logical embedding profile bound to a vector space."""
+
+    id: str
+    model: str
+    dimension: int
+    vector_space: str
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingConfiguration:
+    """Container holding validated vector spaces and embedding profiles."""
+
+    vector_spaces: Dict[str, VectorSpaceConfig]
+    embedding_profiles: Dict[str, EmbeddingProfileConfig]
+
+
+def _ensure_mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise EmbeddingConfigurationError(
+            _format_error(
+                EmbeddingConfigErrorCode.CONFIG_NOT_MAPPING,
+                f"{name} must be a mapping",
+            )
+        )
+    return cast(Mapping[str, Any], value)
+
+
+def _coerce_dimension(
+    raw: object, *, context: str, error_code: str
+) -> int:
+    try:
+        dimension = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise EmbeddingConfigurationError(
+            _format_error(
+                error_code,
+                f"{context} dimension must be an integer",
+            )
+        ) from exc
+    if dimension <= 0:
+        raise EmbeddingConfigurationError(
+            _format_error(
+                error_code,
+                f"{context} dimension must be positive",
+            )
+        )
+    return dimension
+
+
+def _parse_vector_spaces(
+    raw_spaces: Mapping[str, object],
+) -> Dict[str, VectorSpaceConfig]:
+    parsed: Dict[str, VectorSpaceConfig] = {}
+    for space_id, raw_config in raw_spaces.items():
+        if not isinstance(raw_config, Mapping):
+            raise EmbeddingConfigurationError(
+                _format_error(
+                    EmbeddingConfigErrorCode.VECTOR_SPACE_NOT_MAPPING,
+                    f"Vector space '{space_id}' must be a mapping",
+                )
+            )
+        backend = str(raw_config.get("backend", "")).strip()
+        if not backend:
+            raise EmbeddingConfigurationError(
+                _format_error(
+                    EmbeddingConfigErrorCode.VECTOR_SPACE_BACKEND_REQUIRED,
+                    f"Vector space '{space_id}' must define a backend",
+                )
+            )
+        schema = str(raw_config.get("schema", "")).strip()
+        if not schema:
+            raise EmbeddingConfigurationError(
+                _format_error(
+                    EmbeddingConfigErrorCode.VECTOR_SPACE_SCHEMA_REQUIRED,
+                    f"Vector space '{space_id}' must define a schema or namespace",
+                )
+            )
+        dimension = _coerce_dimension(
+            raw_config.get("dimension"),
+            context=f"Vector space '{space_id}'",
+            error_code=EmbeddingConfigErrorCode.VECTOR_SPACE_DIMENSION_INVALID,
+        )
+        parsed[space_id] = VectorSpaceConfig(
+            id=str(space_id),
+            backend=backend,
+            schema=schema,
+            dimension=dimension,
+        )
+    if not parsed:
+        raise EmbeddingConfigurationError(
+            _format_error(
+                EmbeddingConfigErrorCode.VECTOR_SPACES_EMPTY,
+                "No vector spaces configured",
+            )
+        )
+    return parsed
+
+
+def _parse_embedding_profiles(
+    raw_profiles: Mapping[str, object],
+    *,
+    vector_spaces: Mapping[str, VectorSpaceConfig],
+) -> Dict[str, EmbeddingProfileConfig]:
+    parsed: Dict[str, EmbeddingProfileConfig] = {}
+    for profile_id, raw_config in raw_profiles.items():
+        if not isinstance(raw_config, Mapping):
+            raise EmbeddingConfigurationError(
+                _format_error(
+                    EmbeddingConfigErrorCode.PROFILE_NOT_MAPPING,
+                    f"Embedding profile '{profile_id}' must be a mapping",
+                )
+            )
+        model = str(raw_config.get("model", "")).strip()
+        if not model:
+            raise EmbeddingConfigurationError(
+                _format_error(
+                    EmbeddingConfigErrorCode.PROFILE_MODEL_REQUIRED,
+                    f"Embedding profile '{profile_id}' must define a model alias",
+                )
+            )
+        dimension = _coerce_dimension(
+            raw_config.get("dimension"),
+            context=f"Embedding profile '{profile_id}'",
+            error_code=EmbeddingConfigErrorCode.PROFILE_DIMENSION_INVALID,
+        )
+        vector_space_id = str(raw_config.get("vector_space", "")).strip()
+        if not vector_space_id:
+            raise EmbeddingConfigurationError(
+                _format_error(
+                    EmbeddingConfigErrorCode.PROFILE_SPACE_REQUIRED,
+                    f"Embedding profile '{profile_id}' must reference a vector space",
+                )
+            )
+        if vector_space_id not in vector_spaces:
+            raise EmbeddingConfigurationError(
+                _format_error(
+                    EmbeddingConfigErrorCode.UNKNOWN_VECTOR_SPACE,
+                    (
+                        "Embedding profile "
+                        f"'{profile_id}' references unknown vector space "
+                        f"'{vector_space_id}'"
+                    ),
+                )
+            )
+        space = vector_spaces[vector_space_id]
+        if space.dimension != dimension:
+            raise EmbeddingConfigurationError(
+                _format_error(
+                    EmbeddingConfigErrorCode.DIMENSION_MISMATCH,
+                    (
+                        "Dimension mismatch between embedding profile "
+                        f"'{profile_id}' ({dimension}) and vector space "
+                        f"'{vector_space_id}' ({space.dimension})"
+                    ),
+                )
+            )
+        parsed[profile_id] = EmbeddingProfileConfig(
+            id=str(profile_id),
+            model=model,
+            dimension=dimension,
+            vector_space=vector_space_id,
+        )
+    if not parsed:
+        raise EmbeddingConfigurationError(
+            _format_error(
+                EmbeddingConfigErrorCode.PROFILES_EMPTY,
+                "No embedding profiles configured",
+            )
+        )
+    return parsed
+
+
+@lru_cache(maxsize=1)
+def get_embedding_configuration() -> EmbeddingConfiguration:
+    """Return the validated embedding configuration from Django settings."""
+
+    raw_spaces = _ensure_mapping(
+        getattr(settings, "RAG_VECTOR_STORES", {}), name="RAG_VECTOR_STORES"
+    )
+    raw_profiles = _ensure_mapping(
+        getattr(settings, "RAG_EMBEDDING_PROFILES", {}),
+        name="RAG_EMBEDDING_PROFILES",
+    )
+
+    vector_spaces = _parse_vector_spaces(raw_spaces)
+    embedding_profiles = _parse_embedding_profiles(
+        raw_profiles, vector_spaces=vector_spaces
+    )
+    return EmbeddingConfiguration(
+        vector_spaces=dict(vector_spaces),
+        embedding_profiles=dict(embedding_profiles),
+    )
+
+
+def validate_embedding_configuration() -> None:
+    """Validate the embedding configuration and raise on inconsistencies."""
+
+    get_embedding_configuration()
+
+
+def reset_embedding_configuration_cache() -> None:
+    """Clear cached configuration to honour runtime test overrides."""
+
+    get_embedding_configuration.cache_clear()  # type: ignore[attr-defined]
+
+
+def get_vector_space(space_id: str) -> VectorSpaceConfig:
+    """Return a configured vector space by identifier."""
+
+    config = get_embedding_configuration().vector_spaces
+    try:
+        return config[space_id]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise EmbeddingConfigurationError(
+            _format_error(
+                EmbeddingConfigErrorCode.UNKNOWN_VECTOR_SPACE,
+                f"Unknown vector space '{space_id}'",
+            )
+        ) from exc
+
+
+def get_embedding_profile(profile_id: str) -> EmbeddingProfileConfig:
+    """Return a configured embedding profile by identifier."""
+
+    config = get_embedding_configuration().embedding_profiles
+    try:
+        return config[profile_id]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise EmbeddingConfigurationError(
+            _format_error(
+                EmbeddingConfigErrorCode.UNKNOWN_PROFILE,
+                f"Unknown embedding profile '{profile_id}'",
+            )
+        ) from exc
+
+
+__all__ = [
+    "EmbeddingConfiguration",
+    "EmbeddingConfigurationError",
+    "EmbeddingProfileConfig",
+    "EmbeddingConfigErrorCode",
+    "VectorSpaceConfig",
+    "get_embedding_configuration",
+    "get_embedding_profile",
+    "get_vector_space",
+    "reset_embedding_configuration_cache",
+    "validate_embedding_configuration",
+]

--- a/ai_core/rag/ingestion_contracts.py
+++ b/ai_core/rag/ingestion_contracts.py
@@ -1,0 +1,183 @@
+"""Contracts and validation helpers for ingestion pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from common.logging import get_log_context, get_logger
+
+from ai_core.infra import tracing
+
+from .schemas import Chunk
+
+from .vector_space_resolver import (
+    VectorSpaceResolution,
+    VectorSpaceResolverError,
+    VectorSpaceResolverErrorCode,
+    resolve_vector_space_full,
+)
+
+_DOC_HINT = "See README.md (Fehlercodes Abschnitt) for remediation guidance."
+
+
+logger = get_logger(__name__)
+
+
+class IngestionContractError(ValueError):
+    """Raised when ingestion parameters violate the public contract."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        context: dict[str, object | None] | None = None,
+    ) -> None:
+        detail = f"{code}: {message}. {_DOC_HINT}"
+        super().__init__(detail)
+        self.code = code
+        self.message = message
+        self.context = dict(context or {})
+
+
+class IngestionContractErrorCode:
+    """Machine-readable ingestion contract error codes."""
+
+    PROFILE_REQUIRED = "INGEST_PROFILE_REQUIRED"
+    PROFILE_INVALID = "INGEST_PROFILE_INVALID"
+    PROFILE_UNKNOWN = "INGEST_PROFILE_UNKNOWN"
+    VECTOR_SPACE_UNKNOWN = "INGEST_VECTOR_SPACE_UNKNOWN"
+    VECTOR_DIMENSION_MISMATCH = "INGEST_VECTOR_DIMENSION_MISMATCH"
+
+
+def map_ingestion_error_to_status(code: str) -> int:
+    """Return HTTP status mapped to an ingestion contract error code."""
+
+    # All ingestion contract violations are client errors (bad request).
+    return 400
+
+
+@dataclass(frozen=True, slots=True)
+class IngestionProfileResolution:
+    """Describe the resolved embedding profile and vector space for ingestion."""
+
+    profile_id: str
+    resolution: VectorSpaceResolution
+
+
+def resolve_ingestion_profile(profile: object | None) -> IngestionProfileResolution:
+    """Validate and resolve the embedding profile for ingestion."""
+
+    raw_context = {"embedding_profile": profile}
+    if profile is None:
+        raise IngestionContractError(
+            IngestionContractErrorCode.PROFILE_REQUIRED,
+            "embedding_profile is required",
+            context=raw_context,
+        )
+
+    if not isinstance(profile, str):
+        raise IngestionContractError(
+            IngestionContractErrorCode.PROFILE_INVALID,
+            "embedding_profile must be a non-empty string",
+            context=raw_context,
+        )
+
+    profile_key = profile.strip()
+    if not profile_key:
+        raise IngestionContractError(
+            IngestionContractErrorCode.PROFILE_REQUIRED,
+            "embedding_profile must not be empty",
+            context=raw_context,
+        )
+
+    try:
+        resolution = resolve_vector_space_full(profile_key)
+    except VectorSpaceResolverError as exc:
+        mapping = {
+            VectorSpaceResolverErrorCode.PROFILE_REQUIRED: IngestionContractErrorCode.PROFILE_REQUIRED,
+            VectorSpaceResolverErrorCode.PROFILE_UNKNOWN: IngestionContractErrorCode.PROFILE_UNKNOWN,
+            VectorSpaceResolverErrorCode.VECTOR_SPACE_UNKNOWN: IngestionContractErrorCode.VECTOR_SPACE_UNKNOWN,
+        }
+        mapped_code = mapping.get(
+            exc.code, IngestionContractErrorCode.PROFILE_UNKNOWN
+        )
+        raise IngestionContractError(
+            mapped_code,
+            exc.message,
+            context={"embedding_profile": profile_key},
+        ) from exc
+
+    metadata = {
+        "embedding_profile": profile_key,
+        "vector_space_id": resolution.vector_space.id,
+        "vector_space_schema": resolution.vector_space.schema,
+        "vector_space_dimension": resolution.vector_space.dimension,
+    }
+    logger.debug("rag.ingestion.profile.resolve", extra=metadata)
+    log_context = get_log_context()
+    trace_id = log_context.get("trace_id")
+    if trace_id:
+        tracing.emit_span(
+            trace_id=trace_id,
+            node_name="rag.ingestion.profile.resolve",
+            metadata=metadata,
+        )
+
+    return IngestionProfileResolution(profile_id=profile_key, resolution=resolution)
+
+
+def ensure_embedding_dimensions(
+    chunks: Iterable[Chunk],
+    expected_dimension: int | None,
+    *,
+    tenant_id: str | None = None,
+    process: str | None = None,
+    doc_class: str | None = None,
+    embedding_profile: str | None = None,
+    vector_space_id: str | None = None,
+) -> None:
+    """Raise when embeddings do not match the configured vector space dimension."""
+
+    if expected_dimension is None:
+        return
+
+    for index, chunk in enumerate(chunks):
+        embedding = chunk.embedding
+        if embedding is None:
+            continue
+        observed = len(embedding)
+        if observed != expected_dimension:
+            context = {
+                "tenant": tenant_id,
+                "process": process,
+                "doc_class": doc_class,
+                "embedding_profile": embedding_profile,
+                "vector_space_id": vector_space_id,
+                "expected_dimension": expected_dimension,
+                "observed_dimension": observed,
+                "chunk_index": index,
+            }
+            external_id = chunk.meta.get("external_id") if chunk.meta else None
+            if external_id is not None:
+                context["external_id"] = external_id
+            raise IngestionContractError(
+                IngestionContractErrorCode.VECTOR_DIMENSION_MISMATCH,
+                (
+                    "embedding dimension mismatch detected before persistence: "
+                    f"expected {expected_dimension}, observed {observed}"
+                ),
+                context=context,
+            )
+
+
+__all__ = [
+    "IngestionContractError",
+    "IngestionContractErrorCode",
+    "map_ingestion_error_to_status",
+    "IngestionProfileResolution",
+    "resolve_ingestion_profile",
+    "ensure_embedding_dimensions",
+]
+

--- a/ai_core/rag/profile_resolver.py
+++ b/ai_core/rag/profile_resolver.py
@@ -1,0 +1,108 @@
+"""Pure embedding profile resolver for routing inputs."""
+
+from __future__ import annotations
+
+from common.logging import get_log_context, get_logger
+
+from ai_core.infra import tracing
+
+from .embedding_config import get_embedding_configuration
+from .routing_rules import get_routing_table
+from .selector_utils import normalise_selector_value
+
+
+logger = get_logger(__name__)
+
+
+class ProfileResolverError(Exception):
+    """Raised when embedding profile resolution cannot complete."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+class ProfileResolverErrorCode:
+    """Machine-readable error codes for profile resolver failures."""
+
+    TENANT_REQUIRED = "RESOLVE_TENANT_REQUIRED"
+    UNKNOWN_PROFILE = "RESOLVE_PROFILE_UNKNOWN"
+
+
+def _normalise_optional(value: str | None) -> str | None:
+    return normalise_selector_value(value)
+
+
+def resolve_embedding_profile(
+    *,
+    tenant_id: str,
+    process: str | None = None,
+    doc_class: str | None = None,
+) -> str:
+    """Return the embedding profile identifier for the provided context."""
+
+    tenant = tenant_id.strip()
+    if not tenant:
+        raise ProfileResolverError(
+            ProfileResolverErrorCode.TENANT_REQUIRED,
+            "tenant_id is required for embedding profile resolution",
+        )
+
+    sanitized_process = _normalise_optional(process)
+    sanitized_doc_class = _normalise_optional(doc_class)
+    profile_id = get_routing_table().resolve(
+        tenant=tenant,
+        process=sanitized_process,
+        doc_class=sanitized_doc_class,
+    )
+
+    configuration = get_embedding_configuration().embedding_profiles
+    if profile_id not in configuration:
+        raise ProfileResolverError(
+            ProfileResolverErrorCode.UNKNOWN_PROFILE,
+            f"Resolved profile '{profile_id}' is not configured",
+        )
+
+    _emit_profile_resolution(
+        tenant_id=tenant,
+        process=sanitized_process,
+        doc_class=sanitized_doc_class,
+        profile_id=profile_id,
+    )
+
+    return profile_id
+
+
+def _emit_profile_resolution(
+    *,
+    tenant_id: str,
+    process: str | None,
+    doc_class: str | None,
+    profile_id: str,
+) -> None:
+    """Emit trace metadata for successful profile resolution."""
+
+    metadata = {
+        "tenant": tenant_id,
+        "process": process,
+        "doc_class": doc_class,
+        "embedding_profile": profile_id,
+    }
+    logger.debug("rag.profile.resolve", extra=metadata)
+    log_context = get_log_context()
+    trace_id = log_context.get("trace_id")
+    if trace_id:
+        tracing.emit_span(
+            trace_id=trace_id,
+            node_name="rag.profile.resolve",
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "ProfileResolverError",
+    "ProfileResolverErrorCode",
+    "resolve_embedding_profile",
+]
+

--- a/ai_core/rag/router_validation.py
+++ b/ai_core/rag/router_validation.py
@@ -1,0 +1,319 @@
+"""Input validation utilities for vector store router calls."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from common.logging import get_log_context
+
+from ai_core.infra import tracing
+from ai_core.rag.limits import (
+    CandidatePoolPolicy,
+    get_limit_setting,
+    normalize_max_candidates,
+    normalize_top_k,
+    resolve_candidate_pool_policy,
+)
+from ai_core.rag.selector_utils import normalise_selector_value
+
+_ROUTER_DOC_HINT = "See README.md (Fehlercodes Abschnitt) for remediation guidance."
+
+
+logger = logging.getLogger(__name__)
+
+
+class RouterInputError(ValueError):
+    """Raised when router inputs are invalid."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        field: str | None = None,
+        context: Mapping[str, object | None] | None = None,
+    ) -> None:
+        detail = f"{code}: {message}. {_ROUTER_DOC_HINT}"
+        super().__init__(detail)
+        self.code = code
+        self.field = field
+        self.message = message
+        self.context = dict(context or {})
+
+
+class RouterInputErrorCode:
+    """Machine-readable router input error codes."""
+
+    TENANT_REQUIRED = "ROUTER_TENANT_REQUIRED"
+    TOP_K_INVALID = "ROUTER_TOP_K_INVALID"
+    MAX_CANDIDATES_INVALID = "ROUTER_MAX_CANDIDATES_INVALID"
+    MAX_CANDIDATES_LT_TOP_K = "ROUTER_MAX_CANDIDATES_LT_TOP_K"
+
+
+def map_router_error_to_status(code: str) -> int:
+    """Return the HTTP status code associated with a router validation error."""
+
+    client_error_codes = {
+        RouterInputErrorCode.TENANT_REQUIRED,
+        RouterInputErrorCode.TOP_K_INVALID,
+        RouterInputErrorCode.MAX_CANDIDATES_INVALID,
+        RouterInputErrorCode.MAX_CANDIDATES_LT_TOP_K,
+    }
+    if code in client_error_codes:
+        return 400
+    return 400
+
+
+@dataclass(frozen=True, slots=True)
+class SearchValidationResult:
+    """Sanitised router inputs and their effective limits."""
+
+    tenant_id: str
+    process: str | None
+    doc_class: str | None
+    top_k: int | None
+    max_candidates: int | None
+    effective_top_k: int
+    top_k_source: str
+    effective_max_candidates: int
+    max_candidates_source: str
+    context: dict[str, object | None]
+
+
+def _normalise_optional_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    return str(value).strip() or None
+
+
+def _coerce_positive_int(
+    value: Any,
+    *,
+    code: str,
+    field: str,
+    context: Mapping[str, object | None],
+) -> int:
+    if isinstance(value, bool):
+        candidate = int(value)
+    elif isinstance(value, int):
+        candidate = int(value)
+    elif isinstance(value, float):
+        if not value.is_integer():
+            raise RouterInputError(
+                code,
+                f"{field} must be a positive integer",
+                field=field,
+                context=context,
+            )
+        candidate = int(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise RouterInputError(
+                code,
+                f"{field} must be a positive integer",
+                field=field,
+                context=context,
+            )
+        try:
+            candidate = int(text)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise RouterInputError(
+                code,
+                f"{field} must be a positive integer",
+                field=field,
+                context=context,
+            ) from exc
+    else:
+        raise RouterInputError(
+            code,
+            f"{field} must be a positive integer",
+            field=field,
+            context=context,
+        )
+    if candidate <= 0:
+        raise RouterInputError(
+            code,
+            f"{field} must be a positive integer",
+            field=field,
+            context=context,
+        )
+    return candidate
+
+
+def validate_search_inputs(
+    *,
+    tenant_id: object | None,
+    process: str | None = None,
+    doc_class: str | None = None,
+    top_k: object | None = None,
+    max_candidates: object | None = None,
+) -> SearchValidationResult:
+    """Validate router inputs and return sanitised values."""
+
+    tenant = _normalise_optional_text(tenant_id)
+    sanitized_process = normalise_selector_value(process)
+    sanitized_doc_class = normalise_selector_value(doc_class)
+    context = {
+        "tenant_id": tenant,
+        "process": sanitized_process,
+        "doc_class": sanitized_doc_class,
+    }
+    policy = resolve_candidate_pool_policy()
+    context["candidate_policy"] = policy.value
+    if not tenant:
+        raise RouterInputError(
+            RouterInputErrorCode.TENANT_REQUIRED,
+            "tenant_id is required for retrieval requests",
+            field="tenant_id",
+            context=context,
+        )
+
+    sanitized_top_k: int | None
+    if top_k is None:
+        sanitized_top_k = None
+    elif isinstance(top_k, str) and not top_k.strip():
+        sanitized_top_k = None
+    else:
+        context["top_k"] = top_k
+        sanitized_top_k = _coerce_positive_int(
+            top_k,
+            code=RouterInputErrorCode.TOP_K_INVALID,
+            field="top_k",
+            context=context,
+        )
+        context["top_k"] = sanitized_top_k
+
+    sanitized_max: int | None
+    if max_candidates is None:
+        sanitized_max = None
+    elif isinstance(max_candidates, str) and not max_candidates.strip():
+        sanitized_max = None
+    else:
+        context["max_candidates"] = max_candidates
+        sanitized_max = _coerce_positive_int(
+            max_candidates,
+            code=RouterInputErrorCode.MAX_CANDIDATES_INVALID,
+            field="max_candidates",
+            context=context,
+        )
+        context["max_candidates"] = sanitized_max
+
+    normalized_top_k, top_k_source = normalize_top_k(
+        sanitized_top_k,
+        default=5,
+        minimum=1,
+        maximum=10,
+        return_source=True,
+    )
+    context["top_k_effective"] = normalized_top_k
+    context["top_k_source"] = top_k_source
+
+    max_candidates_cap = int(get_limit_setting("RAG_MAX_CANDIDATES", 200))
+    context["max_candidates_cap"] = max_candidates_cap
+
+    effective_max_candidates: int
+    max_candidates_source: str
+    if sanitized_max is None:
+        effective_max_candidates, max_candidates_source = normalize_max_candidates(
+            normalized_top_k,
+            None,
+            max_candidates_cap,
+            return_source=True,
+        )
+        context.setdefault("max_candidates", effective_max_candidates)
+    else:
+        effective_max_candidates = sanitized_max
+        max_candidates_source = "from_state"
+        if effective_max_candidates < normalized_top_k:
+            if policy is CandidatePoolPolicy.NORMALIZE:
+                requested = effective_max_candidates
+                effective_max_candidates = normalized_top_k
+                context["max_candidates"] = effective_max_candidates
+                context["candidate_policy_action"] = "normalized_to_top_k"
+                logger.warning(
+                    "rag.hybrid.candidate_pool.normalized",
+                    extra={
+                        "tenant": tenant,
+                        "routing_process": sanitized_process,
+                        "routing_doc_class": sanitized_doc_class,
+                        "requested": requested,
+                        "top_k": normalized_top_k,
+                    },
+                )
+            else:
+                detail_context = dict(context)
+                detail_context.update(
+                    {
+                        "top_k": normalized_top_k,
+                        "max_candidates": effective_max_candidates,
+                    }
+                )
+                raise RouterInputError(
+                    RouterInputErrorCode.MAX_CANDIDATES_LT_TOP_K,
+                    "max_candidates must be greater than or equal to top_k",
+                    field="max_candidates",
+                    context=detail_context,
+                )
+        if max_candidates_cap is not None and effective_max_candidates > max_candidates_cap:
+            effective_max_candidates = max_candidates_cap
+
+    context["max_candidates_effective"] = effective_max_candidates
+    context["max_candidates_source"] = max_candidates_source
+
+    normalized_max_for_result = (
+        effective_max_candidates if sanitized_max is not None else None
+    )
+
+    return SearchValidationResult(
+        tenant_id=tenant,
+        process=sanitized_process,
+        doc_class=sanitized_doc_class,
+        top_k=sanitized_top_k,
+        max_candidates=normalized_max_for_result,
+        effective_top_k=normalized_top_k,
+        top_k_source=top_k_source,
+        effective_max_candidates=effective_max_candidates,
+        max_candidates_source=max_candidates_source,
+        context=context,
+    )
+
+
+def emit_router_validation_failure(error: RouterInputError) -> None:
+    """Log and trace a router validation failure with mandatory tags."""
+
+    context = dict(error.context)
+    metadata = {
+        "tenant": context.get("tenant_id"),
+        "process": context.get("process"),
+        "doc_class": context.get("doc_class"),
+        "top_k": context.get("top_k"),
+        "max_candidates": context.get("max_candidates"),
+        "error_code": error.code,
+    }
+
+    log_context = get_log_context()
+    trace_id = log_context.get("trace_id")
+    if trace_id:
+        tracing.emit_span(
+            trace_id=trace_id,
+            node_name="rag.router.validation_failed",
+            metadata=metadata,
+        )
+
+
+
+__all__ = [
+    "RouterInputError",
+    "RouterInputErrorCode",
+    "SearchValidationResult",
+    "emit_router_validation_failure",
+    "map_router_error_to_status",
+    "validate_search_inputs",
+]
+

--- a/ai_core/rag/routing_rules.py
+++ b/ai_core/rag/routing_rules.py
@@ -1,0 +1,409 @@
+"""Routing rules for embedding profile selection."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+import logging
+from pathlib import Path
+
+import yaml
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from .embedding_config import get_embedding_configuration
+from .selector_utils import normalise_selector_value
+
+
+class RoutingConfigurationError(ImproperlyConfigured):
+    """Raised when the embedding routing rules are invalid."""
+
+
+class RoutingErrorCode:
+    """Machine-readable error codes for routing configuration issues."""
+
+    RULES_PATH_MISSING = "ROUTE_RULES_PATH_MISSING"
+    RULES_FILE_MISSING = "ROUTE_RULES_FILE_MISSING"
+    RULES_PARSE_FAILED = "ROUTE_RULES_PARSE_FAILED"
+    ROOT_NOT_MAPPING = "ROUTE_RULES_ROOT_TYPE"
+    FIELD_EMPTY = "ROUTE_FIELD_EMPTY"
+    RULE_NOT_MAPPING = "ROUTE_RULE_TYPE"
+    RULE_PROFILE_REQUIRED = "ROUTE_RULE_PROFILE_REQUIRED"
+    DEFAULT_PROFILE_MISSING = "ROUTE_DEFAULT_PROFILE_MISSING"
+    DEFAULT_PROFILE_EMPTY = "ROUTE_DEFAULT_PROFILE_EMPTY"
+    RULES_NOT_SEQUENCE = "ROUTE_RULES_TYPE"
+    UNKNOWN_PROFILE_DEFAULT = "ROUTE_UNKNOWN_PROFILE_DEFAULT"
+    UNKNOWN_PROFILE_RULE = "ROUTE_UNKNOWN_PROFILE_RULE"
+    DUPLICATE_SELECTOR = "ROUTE_DUP_SELECTOR"
+    DUPLICATE_SELECTOR_SAME_TARGET = "ROUTE_DUP_SAME_TARGET"
+    NO_MATCH = "ROUTE_NO_MATCH"
+    CONFLICT = "ROUTE_CONFLICT"
+    OVERLAP_SAME_SPECIFICITY = CONFLICT
+    AMBIGUOUS_MATCH = CONFLICT
+
+
+_ROUTING_DOC_HINT = (
+    "Check config/rag_routing_rules.yaml and README.md (Fehlercodes Abschnitt) for details."
+)
+
+
+def _format_error(code: str, message: str) -> str:
+    return f"{code}: {message}. {_ROUTING_DOC_HINT}"
+
+
+def _format_selector(rule: RoutingRule) -> str:
+    tenant = rule.tenant or "*"
+    process = rule.process or "*"
+    doc_class = rule.doc_class or "*"
+    return f"tenant={tenant}, process={process}, doc_class={doc_class}"
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingRule:
+    """A single routing rule describing an override for a profile."""
+
+    profile: str
+    tenant: str | None = None
+    process: str | None = None
+    doc_class: str | None = None
+
+    def matches(
+        self,
+        *,
+        tenant: str,
+        process: str | None,
+        doc_class: str | None,
+    ) -> bool:
+        if self.tenant is not None and tenant != self.tenant:
+            return False
+        if self.process is not None and process != self.process:
+            return False
+        if self.doc_class is not None and doc_class != self.doc_class:
+            return False
+        return True
+
+    @property
+    def specificity(self) -> int:
+        return sum(
+            value is not None for value in (self.tenant, self.process, self.doc_class)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingTable:
+    """Validated routing table for embedding profiles."""
+
+    default_profile: str
+    rules: tuple[RoutingRule, ...]
+
+    def resolve(
+        self,
+        *,
+        tenant: str,
+        process: str | None,
+        doc_class: str | None,
+    ) -> str:
+        best_rule: RoutingRule | None = None
+        highest_specificity = -1
+
+        for rule in self.rules:
+            if not rule.matches(tenant=tenant, process=process, doc_class=doc_class):
+                continue
+
+            if rule.specificity > highest_specificity:
+                best_rule = rule
+                highest_specificity = rule.specificity
+                continue
+
+            if rule.specificity == highest_specificity and best_rule is not None:
+                if rule.profile != best_rule.profile:
+                    raise RoutingConfigurationError(
+                        _format_error(
+                            RoutingErrorCode.CONFLICT,
+                            "Ambiguous routing rules match the same selector",
+                        )
+                    )
+
+        if best_rule is not None:
+            return best_rule.profile
+
+        if not self.default_profile:
+            raise RoutingConfigurationError(
+                _format_error(
+                    RoutingErrorCode.NO_MATCH,
+                    "No routing rule or default profile available for selector",
+                )
+            )
+
+        return self.default_profile
+
+
+def _routing_rules_path() -> Path:
+    raw_path = getattr(settings, "RAG_ROUTING_RULES_PATH", None)
+    if raw_path is None:
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.RULES_PATH_MISSING,
+                "RAG_ROUTING_RULES_PATH setting is missing",
+            )
+        )
+
+    if isinstance(raw_path, Path):
+        return raw_path
+
+    path = Path(str(raw_path))
+    return path
+
+
+def _read_yaml(file_path: Path) -> Mapping[str, object]:
+    if not file_path.exists():
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.RULES_FILE_MISSING,
+                f"Routing rules file '{file_path}' does not exist",
+            )
+        )
+
+    try:
+        with file_path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive parsing guard
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.RULES_PARSE_FAILED,
+                "Failed to parse routing rules YAML",
+            )
+        ) from exc
+
+    if not isinstance(data, Mapping):
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.ROOT_NOT_MAPPING,
+                "Routing rules file must be a mapping",
+            )
+        )
+
+    return data
+
+
+def _normalise_optional(value: object | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+
+    normalized = normalise_selector_value(value)
+    if normalized is None:
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.FIELD_EMPTY,
+                f"{field} cannot be empty when provided",
+            )
+        )
+    return normalized
+
+
+def _build_rules(raw_rules: Sequence[object]) -> tuple[RoutingRule, ...]:
+    rules: list[RoutingRule] = []
+    for index, raw in enumerate(raw_rules):
+        if not isinstance(raw, Mapping):
+            raise RoutingConfigurationError(
+                _format_error(
+                    RoutingErrorCode.RULE_NOT_MAPPING,
+                    f"Routing rule #{index + 1} must be a mapping",
+                )
+            )
+
+        profile = str(raw.get("profile", "")).strip()
+        if not profile:
+            raise RoutingConfigurationError(
+                _format_error(
+                    RoutingErrorCode.RULE_PROFILE_REQUIRED,
+                    f"Routing rule #{index + 1} must declare a profile",
+                )
+            )
+
+        rule = RoutingRule(
+            profile=profile,
+            tenant=_normalise_optional(raw.get("tenant"), field="tenant"),
+            process=_normalise_optional(raw.get("process"), field="process"),
+            doc_class=_normalise_optional(raw.get("doc_class"), field="doc_class"),
+        )
+
+        rules.append(rule)
+
+    return tuple(rules)
+
+
+def _ensure_profiles_exist(
+    *,
+    table: RoutingTable,
+    available_profiles: Iterable[str],
+) -> None:
+    profiles = set(available_profiles)
+    if table.default_profile not in profiles:
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.UNKNOWN_PROFILE_DEFAULT,
+                f"Default routing profile '{table.default_profile}' is not configured",
+            )
+        )
+
+    for rule in table.rules:
+        if rule.profile not in profiles:
+            raise RoutingConfigurationError(
+                _format_error(
+                    RoutingErrorCode.UNKNOWN_PROFILE_RULE,
+                    f"Routing rule references unknown profile '{rule.profile}'",
+                )
+            )
+
+
+def _validate_rule_uniqueness(rules: Sequence[RoutingRule]) -> None:
+    seen_selectors: dict[tuple[str | None, str | None, str | None], RoutingRule] = {}
+    duplicate_same_target: dict[tuple[str | None, str | None, str | None], RoutingRule] = {}
+    unique_rules: list[RoutingRule] = []
+
+    for rule in rules:
+        selector = (rule.tenant, rule.process, rule.doc_class)
+        if selector in seen_selectors:
+            previous_rule = seen_selectors[selector]
+            if previous_rule.profile != rule.profile:
+                raise RoutingConfigurationError(
+                    _format_error(
+                        RoutingErrorCode.DUPLICATE_SELECTOR,
+                        "Duplicate routing selector with different profile detected",
+                    )
+                )
+            duplicate_same_target.setdefault(selector, previous_rule)
+            continue
+
+        seen_selectors[selector] = rule
+        unique_rules.append(rule)
+
+    for primary_rule in duplicate_same_target.values():
+        LOGGER.warning(
+            "%s: Duplicate routing selector for %s keeps profile '%s'; subsequent entries share the same target",
+            RoutingErrorCode.DUPLICATE_SELECTOR_SAME_TARGET,
+            _format_selector(primary_rule),
+            primary_rule.profile,
+        )
+
+    for i, left in enumerate(unique_rules):
+        for right in unique_rules[i + 1 :]:
+            if left.specificity != right.specificity:
+                continue
+
+            if not _selectors_overlap(left, right):
+                continue
+
+            raise RoutingConfigurationError(
+                _format_error(
+                    RoutingErrorCode.CONFLICT,
+                    "Overlapping routing rules with same specificity detected",
+                )
+            )
+
+
+def _selectors_overlap(left: RoutingRule, right: RoutingRule) -> bool:
+    if left.tenant is not None and right.tenant is not None and left.tenant != right.tenant:
+        return False
+    if (
+        left.process is not None
+        and right.process is not None
+        and left.process != right.process
+    ):
+        return False
+    if (
+        left.doc_class is not None
+        and right.doc_class is not None
+        and left.doc_class != right.doc_class
+    ):
+        return False
+    return True
+
+
+@lru_cache(maxsize=1)
+def get_routing_table() -> RoutingTable:
+    """Load and validate the routing table from configuration."""
+
+    raw_config = _read_yaml(_routing_rules_path())
+
+    try:
+        default_profile = str(raw_config["default_profile"]).strip()
+    except KeyError as exc:
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.DEFAULT_PROFILE_MISSING,
+                "default_profile is required",
+            )
+        ) from exc
+
+    if not default_profile:
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.DEFAULT_PROFILE_EMPTY,
+                "default_profile cannot be empty",
+            )
+        )
+
+    raw_rules = raw_config.get("rules", [])
+    if not isinstance(raw_rules, Sequence):
+        raise RoutingConfigurationError(
+            _format_error(
+                RoutingErrorCode.RULES_NOT_SEQUENCE,
+                "rules must be a sequence of mappings",
+            )
+        )
+
+    rules = _build_rules(raw_rules)
+
+    table = RoutingTable(default_profile=default_profile, rules=rules)
+
+    config = get_embedding_configuration()
+
+    _ensure_profiles_exist(
+        table=table,
+        available_profiles=config.embedding_profiles.keys(),
+    )
+    _validate_rule_uniqueness(table.rules)
+
+    return table
+
+
+def resolve_embedding_profile_id(
+    *, tenant: str, process: str | None = None, doc_class: str | None = None
+) -> str:
+    from .profile_resolver import resolve_embedding_profile
+
+    return resolve_embedding_profile(
+        tenant_id=tenant,
+        process=process,
+        doc_class=doc_class,
+    )
+
+
+def validate_routing_rules() -> None:
+    """Validate routing rules at startup."""
+
+    get_routing_table()
+
+
+def reset_routing_rules_cache() -> None:
+    """Clear cached routing rules (used in tests)."""
+
+    get_routing_table.cache_clear()  # type: ignore[attr-defined]
+
+
+__all__ = [
+    "RoutingConfigurationError",
+    "RoutingRule",
+    "RoutingTable",
+    "RoutingErrorCode",
+    "get_routing_table",
+    "resolve_embedding_profile_id",
+    "reset_routing_rules_cache",
+    "validate_routing_rules",
+]

--- a/ai_core/rag/selector_utils.py
+++ b/ai_core/rag/selector_utils.py
@@ -1,0 +1,18 @@
+"""Utilities for normalising routing selector dimensions."""
+
+from __future__ import annotations
+
+__all__ = ["normalise_selector_value"]
+
+
+def normalise_selector_value(value: object | None) -> str | None:
+    """Return a lowercase, trimmed representation of routing dimensions."""
+
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    return text.lower()

--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -464,6 +464,13 @@ class PgVectorClient:
                 "chunk_count": chunk_count,
                 "duration_ms": duration,
             }
+            metadata = doc.get("metadata", {})
+            embedding_profile = metadata.get("embedding_profile")
+            if embedding_profile:
+                doc_payload["embedding_profile"] = embedding_profile
+            vector_space_id = metadata.get("vector_space_id")
+            if vector_space_id:
+                doc_payload["vector_space_id"] = vector_space_id
             documents_info.append(doc_payload)
             logger.info("ingestion.doc.result", extra=doc_payload)
             if action == "inserted":

--- a/ai_core/rag/vector_schema.py
+++ b/ai_core/rag/vector_schema.py
@@ -1,0 +1,178 @@
+"""DDL helpers for vector space schemas and dimension-specific tables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from django.core.exceptions import ImproperlyConfigured
+
+from .embedding_config import (
+    EmbeddingConfiguration,
+    VectorSpaceConfig,
+    get_embedding_configuration,
+)
+
+
+class VectorSchemaError(ImproperlyConfigured):
+    """Raised when vector schema DDL cannot be generated."""
+
+
+class VectorSchemaErrorCode:
+    """Machine-readable error codes for schema validation failures."""
+
+    TEMPLATE_NOT_FOUND = "SCHEMA_TEMPLATE_MISSING"
+    SCHEMA_DIMENSION_CONFLICT = "SCHEMA_DIM_CONFLICT"
+    DIMENSION_RENDER_FAILED = "SCHEMA_DIM_RENDER_FAILED"
+
+
+_DOC_HINT = "See README.md (Fehlercodes Abschnitt) for remediation guidance."
+
+_SCHEMA_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "rag" / "schema.sql"
+)
+
+_SCHEMA_PLACEHOLDER = "{{SCHEMA_NAME}}"
+_VECTOR_DIM_PLACEHOLDER = "{{VECTOR_DIM}}"
+
+
+def _format_error(code: str, message: str) -> str:
+    return f"{code}: {message}. {_DOC_HINT}"
+
+
+@dataclass(frozen=True, slots=True)
+class VectorSchemaDDL:
+    """Rendered DDL statements for a configured vector space."""
+
+    space_id: str
+    schema: str
+    dimension: int
+    sql: str
+
+
+def _load_schema_template() -> str:
+    try:
+        return _SCHEMA_TEMPLATE_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:  # pragma: no cover - defensive
+        raise VectorSchemaError(
+            _format_error(
+                VectorSchemaErrorCode.TEMPLATE_NOT_FOUND,
+                f"Vector schema template missing at {_SCHEMA_TEMPLATE_PATH}",
+            )
+        ) from exc
+
+
+def _render_schema_sql(schema: str, dimension: int, template: str) -> str:
+    if not schema:
+        raise VectorSchemaError(
+            _format_error(
+                VectorSchemaErrorCode.DIMENSION_RENDER_FAILED,
+                "Vector space schema must be provided",
+            )
+        )
+    if dimension <= 0:
+        raise VectorSchemaError(
+            _format_error(
+                VectorSchemaErrorCode.DIMENSION_RENDER_FAILED,
+                "Vector space dimension must be positive",
+            )
+        )
+
+    if _SCHEMA_PLACEHOLDER not in template:
+        raise VectorSchemaError(
+            _format_error(
+                VectorSchemaErrorCode.DIMENSION_RENDER_FAILED,
+                "Schema template does not contain the {{SCHEMA_NAME}} placeholder",
+            )
+        )
+
+    if _VECTOR_DIM_PLACEHOLDER not in template:
+        raise VectorSchemaError(
+            _format_error(
+                VectorSchemaErrorCode.DIMENSION_RENDER_FAILED,
+                "Schema template does not contain the {{VECTOR_DIM}} placeholder",
+            )
+        )
+
+    schema_sql = template.replace(_SCHEMA_PLACEHOLDER, schema)
+    rendered_sql = schema_sql.replace(_VECTOR_DIM_PLACEHOLDER, str(dimension))
+    if _VECTOR_DIM_PLACEHOLDER in rendered_sql:
+        raise VectorSchemaError(
+            _format_error(
+                VectorSchemaErrorCode.DIMENSION_RENDER_FAILED,
+                "Schema template replacement for {{VECTOR_DIM}} did not complete",
+            )
+        )
+    return rendered_sql
+
+
+def _ensure_schema_dimension_isolation(spaces: Iterable[VectorSpaceConfig]) -> None:
+    by_schema: Dict[str, int] = {}
+    for space in spaces:
+        schema = space.schema
+        dimension = space.dimension
+        if not schema:
+            continue
+        existing = by_schema.get(schema)
+        if existing is None:
+            by_schema[schema] = dimension
+            continue
+        if existing != dimension:
+            raise VectorSchemaError(
+                _format_error(
+                    VectorSchemaErrorCode.SCHEMA_DIMENSION_CONFLICT,
+                    (
+                        "Vector spaces with differing dimensions map to the same "
+                        f"schema '{schema}' ({existing} vs {dimension})"
+                    ),
+                )
+            )
+
+
+def build_vector_schema_plan(
+    config: EmbeddingConfiguration | None = None,
+) -> List[VectorSchemaDDL]:
+    """Return rendered DDL statements for all configured vector spaces."""
+
+    configuration = config or get_embedding_configuration()
+    spaces = list(configuration.vector_spaces.values())
+    _ensure_schema_dimension_isolation(spaces)
+    template = _load_schema_template()
+
+    plan: List[VectorSchemaDDL] = []
+    for space in spaces:
+        sql = _render_schema_sql(space.schema, space.dimension, template)
+        plan.append(
+            VectorSchemaDDL(
+                space_id=space.id,
+                schema=space.schema,
+                dimension=space.dimension,
+                sql=sql,
+            )
+        )
+    return plan
+
+
+def validate_vector_schemas() -> None:
+    """Validate vector-space schema assignments without rendering SQL."""
+
+    configuration = get_embedding_configuration()
+    _ensure_schema_dimension_isolation(configuration.vector_spaces.values())
+
+
+def render_schema_sql(schema: str, dimension: int) -> str:
+    """Render the schema template for a single vector space."""
+
+    template = _load_schema_template()
+    return _render_schema_sql(schema, dimension, template)
+
+
+__all__ = [
+    "VectorSchemaDDL",
+    "VectorSchemaError",
+    "VectorSchemaErrorCode",
+    "build_vector_schema_plan",
+    "render_schema_sql",
+    "validate_vector_schemas",
+]

--- a/ai_core/rag/vector_space_resolver.py
+++ b/ai_core/rag/vector_space_resolver.py
@@ -1,0 +1,121 @@
+"""Resolve vector space metadata for embedding profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from common.logging import get_log_context, get_logger
+
+from ai_core.infra import tracing
+
+from .embedding_config import (
+    EmbeddingConfiguration,
+    EmbeddingProfileConfig,
+    VectorSpaceConfig,
+    get_embedding_configuration,
+)
+
+_DOC_HINT = "See README.md (Fehlercodes Abschnitt) for remediation guidance."
+
+
+logger = get_logger(__name__)
+
+
+class VectorSpaceResolverError(Exception):
+    """Raised when vector space resolution fails."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}. {_DOC_HINT}")
+        self.code = code
+        self.message = message
+
+
+class VectorSpaceResolverErrorCode:
+    """Machine-readable error codes for vector space resolution."""
+
+    PROFILE_REQUIRED = "SPACE_PROFILE_REQUIRED"
+    PROFILE_UNKNOWN = "SPACE_PROFILE_UNKNOWN"
+    VECTOR_SPACE_UNKNOWN = "SPACE_UNDEFINED_FOR_PROFILE"
+
+
+@dataclass(frozen=True, slots=True)
+class VectorSpaceResolution:
+    """Return type describing the resolved vector space and embedding profile."""
+
+    profile: EmbeddingProfileConfig
+    vector_space: VectorSpaceConfig
+
+
+def resolve_vector_space_full(profile_id: str) -> VectorSpaceResolution:
+    """Return the embedding profile and configured vector space for ``profile_id``."""
+
+    profile_key = "" if profile_id is None else str(profile_id).strip()
+    if not profile_key:
+        raise VectorSpaceResolverError(
+            VectorSpaceResolverErrorCode.PROFILE_REQUIRED,
+            "embedding profile identifier is required",
+        )
+
+    configuration: EmbeddingConfiguration = get_embedding_configuration()
+    profile: EmbeddingProfileConfig | None = configuration.embedding_profiles.get(
+        profile_key
+    )
+    if profile is None:
+        raise VectorSpaceResolverError(
+            VectorSpaceResolverErrorCode.PROFILE_UNKNOWN,
+            f"embedding profile '{profile_key}' is not configured",
+        )
+
+    space: VectorSpaceConfig | None = configuration.vector_spaces.get(
+        profile.vector_space
+    )
+    if space is None:
+        message = (
+            "embedding profile "
+            f"'{profile_key}' references missing vector space "
+            f"'{profile.vector_space}'"
+        )
+        raise VectorSpaceResolverError(
+            VectorSpaceResolverErrorCode.VECTOR_SPACE_UNKNOWN,
+            message,
+        )
+
+    resolution = VectorSpaceResolution(profile=profile, vector_space=space)
+    _emit_vector_space_resolution(resolution)
+    return resolution
+
+
+def resolve_vector_space(profile_id: str) -> VectorSpaceConfig:
+    """Return the configured vector space for ``profile_id``."""
+
+    return resolve_vector_space_full(profile_id).vector_space
+
+
+def _emit_vector_space_resolution(resolution: VectorSpaceResolution) -> None:
+    """Emit trace metadata describing the resolved vector space."""
+
+    metadata = {
+        "embedding_profile": resolution.profile.id,
+        "vector_space_id": resolution.vector_space.id,
+        "vector_space_schema": resolution.vector_space.schema,
+        "vector_space_dimension": resolution.vector_space.dimension,
+    }
+    logger.debug("rag.vector_space.resolve", extra=metadata)
+    log_context = get_log_context()
+    trace_id = log_context.get("trace_id")
+    if trace_id:
+        tracing.emit_span(
+            trace_id=trace_id,
+            node_name="rag.vector_space.resolve",
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "VectorSpaceResolverError",
+    "VectorSpaceResolverErrorCode",
+    "VectorSpaceResolution",
+    "resolve_vector_space_full",
+    "resolve_vector_space",
+]
+

--- a/ai_core/tests/test_embedding_config.py
+++ b/ai_core/tests/test_embedding_config.py
@@ -1,0 +1,132 @@
+"""Tests for embedding profile and vector space configuration validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_core.rag.embedding_config import (
+    EmbeddingConfigurationError,
+    get_embedding_configuration,
+    get_embedding_profile,
+    get_vector_space,
+    reset_embedding_configuration_cache,
+    validate_embedding_configuration,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_embedding_config_cache() -> None:
+    reset_embedding_configuration_cache()
+    yield
+    reset_embedding_configuration_cache()
+
+
+def _base_vector_space() -> dict[str, object]:
+    return {
+        "backend": "pgvector",
+        "schema": "rag",
+        "dimension": 1536,
+    }
+
+
+def _base_profile() -> dict[str, object]:
+    return {
+        "model": "oai-embed-large",
+        "dimension": 1536,
+        "vector_space": "global",
+    }
+
+
+def test_get_embedding_configuration_returns_dataclasses(settings) -> None:
+    settings.RAG_VECTOR_STORES = {"global": _base_vector_space()}
+    settings.RAG_EMBEDDING_PROFILES = {"standard": _base_profile()}
+
+    config = get_embedding_configuration()
+
+    assert config.vector_spaces["global"].dimension == 1536
+    assert config.vector_spaces["global"].schema == "rag"
+    assert config.embedding_profiles["standard"].model == "oai-embed-large"
+    assert (
+        config.embedding_profiles["standard"].vector_space
+        == config.vector_spaces["global"].id
+    )
+
+
+def test_getters_return_single_entries(settings) -> None:
+    settings.RAG_VECTOR_STORES = {"global": _base_vector_space()}
+    settings.RAG_EMBEDDING_PROFILES = {"standard": _base_profile()}
+
+    vector_space = get_vector_space("global")
+    profile = get_embedding_profile("standard")
+
+    assert vector_space.schema == "rag"
+    assert profile.model == "oai-embed-large"
+    assert profile.vector_space == "global"
+
+
+def test_validate_configuration_raises_on_dimension_mismatch(settings) -> None:
+    settings.RAG_VECTOR_STORES = {"global": _base_vector_space()}
+    mismatched = _base_profile()
+    mismatched["dimension"] = 1024
+    settings.RAG_EMBEDDING_PROFILES = {"standard": mismatched}
+
+    with pytest.raises(EmbeddingConfigurationError) as excinfo:
+        validate_embedding_configuration()
+
+    message = str(excinfo.value)
+    assert "EMB_DIM_MISMATCH" in message
+    assert "Dimension mismatch" in message
+
+
+def test_validate_configuration_requires_known_vector_space(settings) -> None:
+    settings.RAG_VECTOR_STORES = {"global": _base_vector_space()}
+    profile = _base_profile()
+    profile["vector_space"] = "unknown"
+    settings.RAG_EMBEDDING_PROFILES = {"standard": profile}
+
+    with pytest.raises(EmbeddingConfigurationError) as excinfo:
+        get_embedding_configuration()
+
+    message = str(excinfo.value)
+    assert "EMB_UNKNOWN_SPACE" in message
+    assert "unknown vector space" in message
+
+
+def test_validate_configuration_requires_schema(settings) -> None:
+    settings.RAG_VECTOR_STORES = {
+        "global": {"backend": "pgvector", "dimension": 1536, "schema": ""}
+    }
+    settings.RAG_EMBEDDING_PROFILES = {"standard": _base_profile()}
+
+    with pytest.raises(EmbeddingConfigurationError) as excinfo:
+        get_embedding_configuration()
+
+    assert "must define a schema" in str(excinfo.value)
+
+
+def test_vector_space_dimension_must_be_positive(settings) -> None:
+    settings.RAG_VECTOR_STORES = {
+        "global": {"backend": "pgvector", "schema": "rag", "dimension": 0}
+    }
+    settings.RAG_EMBEDDING_PROFILES = {"standard": _base_profile()}
+
+    with pytest.raises(EmbeddingConfigurationError) as excinfo:
+        get_embedding_configuration()
+
+    message = str(excinfo.value)
+    assert "EMB_SPACE_DIM_INVALID" in message
+    assert "must be positive" in message
+
+
+def test_profile_dimension_must_be_positive_integer(settings) -> None:
+    settings.RAG_VECTOR_STORES = {"global": _base_vector_space()}
+    profile = _base_profile()
+    profile["dimension"] = "invalid"
+    settings.RAG_EMBEDDING_PROFILES = {"standard": profile}
+
+    with pytest.raises(EmbeddingConfigurationError) as excinfo:
+        get_embedding_configuration()
+
+    message = str(excinfo.value)
+    assert "EMB_PROFILE_DIM_INVALID" in message
+    assert "must be an integer" in message

--- a/ai_core/tests/test_ingestion_contracts.py
+++ b/ai_core/tests/test_ingestion_contracts.py
@@ -1,0 +1,126 @@
+import pytest
+
+from ai_core.rag.embedding_config import reset_embedding_configuration_cache
+from ai_core.rag.ingestion_contracts import (
+    IngestionContractError,
+    IngestionContractErrorCode,
+    ensure_embedding_dimensions,
+    resolve_ingestion_profile,
+)
+from ai_core.rag.vector_space_resolver import (
+    VectorSpaceResolverError,
+    VectorSpaceResolverErrorCode,
+)
+from ai_core.rag.schemas import Chunk
+
+
+@pytest.fixture(autouse=True)
+def _reset_embedding_cache() -> None:
+    reset_embedding_configuration_cache()
+    yield
+    reset_embedding_configuration_cache()
+
+
+def _configure_embeddings(settings) -> None:
+    settings.RAG_VECTOR_STORES = {
+        "global": {"backend": "pgvector", "schema": "rag", "dimension": 1536}
+    }
+    settings.RAG_EMBEDDING_PROFILES = {
+        "standard": {
+            "model": "oai-embed-large",
+            "dimension": 1536,
+            "vector_space": "global",
+        }
+    }
+
+
+def test_resolve_ingestion_profile_success(settings) -> None:
+    _configure_embeddings(settings)
+    result = resolve_ingestion_profile(" standard ")
+    assert result.profile_id == "standard"
+    assert result.resolution.vector_space.id == "global"
+
+
+def test_resolve_ingestion_profile_requires_value(settings) -> None:
+    _configure_embeddings(settings)
+    with pytest.raises(IngestionContractError) as excinfo:
+        resolve_ingestion_profile(None)
+    assert excinfo.value.code == IngestionContractErrorCode.PROFILE_REQUIRED
+
+
+def test_resolve_ingestion_profile_rejects_non_string(settings) -> None:
+    _configure_embeddings(settings)
+    with pytest.raises(IngestionContractError) as excinfo:
+        resolve_ingestion_profile(123)
+    assert excinfo.value.code == IngestionContractErrorCode.PROFILE_INVALID
+
+
+def test_resolve_ingestion_profile_unknown_id(settings) -> None:
+    _configure_embeddings(settings)
+    with pytest.raises(IngestionContractError) as excinfo:
+        resolve_ingestion_profile("unknown")
+    assert excinfo.value.code == IngestionContractErrorCode.PROFILE_UNKNOWN
+
+
+def test_resolve_ingestion_profile_missing_space(settings, monkeypatch) -> None:
+    _configure_embeddings(settings)
+
+    from ai_core.rag import ingestion_contracts as contracts_module
+
+    def _raise_missing_space(profile_id: str):
+        raise VectorSpaceResolverError(
+            VectorSpaceResolverErrorCode.VECTOR_SPACE_UNKNOWN,
+            "vector space missing",
+        )
+
+    monkeypatch.setattr(contracts_module, "resolve_vector_space_full", _raise_missing_space)
+
+    with pytest.raises(IngestionContractError) as excinfo:
+        resolve_ingestion_profile("standard")
+    assert excinfo.value.code == IngestionContractErrorCode.VECTOR_SPACE_UNKNOWN
+
+
+def test_ensure_embedding_dimensions_allows_matching_vectors() -> None:
+    chunks = [
+        Chunk(content="c", meta={"external_id": "doc-1"}, embedding=[0.1, 0.2])
+    ]
+
+    ensure_embedding_dimensions(
+        chunks,
+        2,
+        tenant_id="tenant-a",
+        process="review",
+        doc_class="manual",
+        embedding_profile="standard",
+        vector_space_id="global",
+    )
+
+
+def test_ensure_embedding_dimensions_raises_on_mismatch() -> None:
+    chunks = [
+        Chunk(content="c", meta={"external_id": "doc-1"}, embedding=[0.1])
+    ]
+
+    with pytest.raises(IngestionContractError) as excinfo:
+        ensure_embedding_dimensions(
+            chunks,
+            2,
+            tenant_id="tenant-a",
+            process="review",
+            doc_class="manual",
+            embedding_profile="standard",
+            vector_space_id="global",
+        )
+
+    error = excinfo.value
+    assert error.code == IngestionContractErrorCode.VECTOR_DIMENSION_MISMATCH
+    assert error.context["tenant"] == "tenant-a"
+    assert error.context["process"] == "review"
+    assert error.context["doc_class"] == "manual"
+    assert error.context["embedding_profile"] == "standard"
+    assert error.context["vector_space_id"] == "global"
+    assert error.context["expected_dimension"] == 2
+    assert error.context["observed_dimension"] == 1
+    assert error.context["chunk_index"] == 0
+    assert error.context["external_id"] == "doc-1"
+

--- a/ai_core/tests/test_ingestion_flow.py
+++ b/ai_core/tests/test_ingestion_flow.py
@@ -51,8 +51,16 @@ def test_upload_ingest_query_end2end(
     doc_id = body["document_id"]
 
     # Ingestion (direkt Task ausführen; alternativ run_ingestion.delay(...) und warten)
-    result = process_document(tenant, case, doc_id, tenant_schema=tenant)
+    result = process_document(
+        tenant,
+        case,
+        doc_id,
+        "standard",
+        tenant_schema=tenant,
+    )
     assert result["written"] >= 1
+    assert result["embedding_profile"] == "standard"
+    assert result["vector_space_id"] == "global"
 
     # Query
     resp = client.post(
@@ -123,6 +131,7 @@ def test_ingestion_run_reports_missing_documents(
     run_payload = {
         "document_ids": [doc_id, "missing-document"],
         "priority": "normal",
+        "embedding_profile": "standard",
     }
 
     resp = client.post(
@@ -143,6 +152,7 @@ def test_ingestion_run_reports_missing_documents(
     assert len(calls) == 1
     args, kwargs = calls[0]
     assert list(args[2]) == [doc_id]
+    assert args[3] == "standard"
     assert kwargs["tenant_schema"] == tenant
 
 

--- a/ai_core/tests/test_ingestion_idempotency.py
+++ b/ai_core/tests/test_ingestion_idempotency.py
@@ -52,7 +52,13 @@ def test_ingestion_idempotency_skips_unchanged_documents(
         return body["document_id"]
 
     first_doc = upload_document("Hello RAG ingestion!")
-    first_result = process_document(tenant, case, first_doc, tenant_schema=tenant)
+    first_result = process_document(
+        tenant,
+        case,
+        first_doc,
+        "standard",
+        tenant_schema=tenant,
+    )
 
     assert first_result["external_id"] == external_id
     assert first_result["inserted"] == 1
@@ -60,9 +66,16 @@ def test_ingestion_idempotency_skips_unchanged_documents(
     assert first_result["replaced"] == 0
     assert first_result["action"] == "inserted"
     assert first_result["written"] == 1
+    assert first_result["embedding_profile"] == "standard"
 
     second_doc = upload_document("Hello RAG ingestion!")
-    second_result = process_document(tenant, case, second_doc, tenant_schema=tenant)
+    second_result = process_document(
+        tenant,
+        case,
+        second_doc,
+        "standard",
+        tenant_schema=tenant,
+    )
 
     assert second_result["external_id"] == external_id
     assert second_result["inserted"] == 0
@@ -72,7 +85,13 @@ def test_ingestion_idempotency_skips_unchanged_documents(
     assert second_result["written"] == 0
 
     third_doc = upload_document("Hello RAG ingestion version two!")
-    third_result = process_document(tenant, case, third_doc, tenant_schema=tenant)
+    third_result = process_document(
+        tenant,
+        case,
+        third_doc,
+        "standard",
+        tenant_schema=tenant,
+    )
 
     assert third_result["external_id"] == external_id
     assert third_result["skipped"] == 0
@@ -125,10 +144,10 @@ def test_ingestion_concurrent_same_external_id_is_idempotent(
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         future_a = executor.submit(
-            process_document, tenant, case, doc_a, tenant_schema=tenant
+            process_document, tenant, case, doc_a, "standard", tenant_schema=tenant
         )
         future_b = executor.submit(
-            process_document, tenant, case, doc_b, tenant_schema=tenant
+            process_document, tenant, case, doc_b, "standard", tenant_schema=tenant
         )
         res_a = future_a.result()
         res_b = future_b.result()

--- a/ai_core/tests/test_management_rag_routing_rules.py
+++ b/ai_core/tests/test_management_rag_routing_rules.py
@@ -1,0 +1,99 @@
+"""Tests for the rag_routing_rules management command."""
+
+from __future__ import annotations
+
+import io
+import textwrap
+
+import pytest
+from django.core.management import CommandError, call_command
+
+from ai_core.rag.embedding_config import reset_embedding_configuration_cache
+from ai_core.rag.routing_rules import reset_routing_rules_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    reset_embedding_configuration_cache()
+    reset_routing_rules_cache()
+    yield
+    reset_embedding_configuration_cache()
+    reset_routing_rules_cache()
+
+
+@pytest.fixture
+def routing_config(tmp_path, settings):
+    rules = tmp_path / "routing.yaml"
+    rules.write_text(
+        textwrap.dedent(
+            """
+            default_profile: standard
+            rules:
+              - tenant: acme
+                process: Review
+                profile: premium
+            """
+        ).strip()
+    )
+    settings.RAG_ROUTING_RULES_PATH = str(rules)
+    settings.RAG_VECTOR_STORES = {
+        "global": {
+            "backend": "pgvector",
+            "schema": "rag",
+            "dimension": 1536,
+        }
+    }
+    settings.RAG_EMBEDDING_PROFILES = {
+        "standard": {
+            "model": "oai-embed-large",
+            "dimension": 1536,
+            "vector_space": "global",
+        },
+        "premium": {
+            "model": "vertex_ai/text-embedding-004",
+            "dimension": 1536,
+            "vector_space": "global",
+        },
+    }
+    return rules
+
+
+def test_command_lists_routing_rules(routing_config):
+    buffer = io.StringIO()
+
+    call_command("rag_routing_rules", stdout=buffer)
+
+    output = buffer.getvalue()
+    assert "Default profile: standard" in output
+    assert "tenant=acme, process=review, doc_class=* -> premium" in output
+
+
+def test_command_resolves_selector(routing_config):
+    buffer = io.StringIO()
+
+    call_command(
+        "rag_routing_rules",
+        tenant="acme",
+        process="REVIEW",
+        stdout=buffer,
+    )
+
+    output = buffer.getvalue()
+    assert (
+        "Resolved selector tenant=acme, process=review, doc_class=* -> premium"
+        in output
+    )
+
+
+def test_command_requires_tenant_for_resolution(routing_config):
+    with pytest.raises(CommandError) as exc:
+        call_command("rag_routing_rules", process="review")
+
+    assert "--tenant is required" in str(exc.value)
+
+
+def test_command_rejects_empty_tenant(routing_config):
+    with pytest.raises(CommandError) as exc:
+        call_command("rag_routing_rules", tenant="  ")
+
+    assert "non-empty" in str(exc.value)

--- a/ai_core/tests/test_management_rag_schema_smoke.py
+++ b/ai_core/tests/test_management_rag_schema_smoke.py
@@ -1,0 +1,45 @@
+"""Tests for the rag_schema_smoke management command."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings(settings) -> None:
+    settings.RAG_VECTOR_STORES = {
+        "global": {
+            "backend": "pgvector",
+            "schema": "rag",
+            "dimension": 1536,
+        }
+    }
+    settings.RAG_EMBEDDING_PROFILES = {
+        "standard": {
+            "model": "oai-embed-large",
+            "dimension": 1536,
+            "vector_space": "global",
+        }
+    }
+
+
+def test_rag_schema_smoke_reports_success(settings) -> None:
+    buffer = io.StringIO()
+    call_command("rag_schema_smoke", space="global", stdout=buffer)
+
+    output = buffer.getvalue()
+    assert "Rendered schema for space global" in output
+    assert "schema=rag" in output
+    assert "dimension=1536" in output
+
+
+def test_rag_schema_smoke_can_print_sql(settings) -> None:
+    buffer = io.StringIO()
+    call_command("rag_schema_smoke", space="global", show_sql=True, stdout=buffer)
+
+    output = buffer.getvalue()
+    assert "CREATE SCHEMA" in output
+    assert "vector(1536)" in output

--- a/ai_core/tests/test_management_rebuild_rag_index.py
+++ b/ai_core/tests/test_management_rebuild_rag_index.py
@@ -123,10 +123,11 @@ def test_rebuild_rag_index_creates_expected_index(
 @pytest.mark.usefixtures("rag_database")
 def test_rebuild_rag_index_uses_scope_with_default_flag(settings) -> None:
     settings.RAG_VECTOR_STORES = {
-        "global": {"backend": "pgvector", "schema": "rag"},
+        "global": {"backend": "pgvector", "schema": "rag", "dimension": 1536},
         "enterprise": {
             "backend": "pgvector",
             "schema": "rag_enterprise",
+            "dimension": 1536,
             "default": True,
         },
     }
@@ -275,8 +276,20 @@ def test_rebuild_rag_index_health_check(
     doc_one = _upload("Vector index smoke check one", "index-health-one")
     doc_two = _upload("Vector index smoke check two", "index-health-two")
 
-    first_result = process_document(tenant, case, doc_one, tenant_schema=tenant)
-    second_result = process_document(tenant, case, doc_two, tenant_schema=tenant)
+    first_result = process_document(
+        tenant,
+        case,
+        doc_one,
+        "standard",
+        tenant_schema=tenant,
+    )
+    second_result = process_document(
+        tenant,
+        case,
+        doc_two,
+        "standard",
+        tenant_schema=tenant,
+    )
 
     assert first_result["inserted"] == 1
     assert second_result["inserted"] == 1

--- a/ai_core/tests/test_profile_resolver.py
+++ b/ai_core/tests/test_profile_resolver.py
@@ -1,0 +1,219 @@
+"""Tests for the embedding profile resolver."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ai_core.rag.embedding_config import (
+    EmbeddingConfiguration,
+    reset_embedding_configuration_cache,
+)
+from ai_core.rag.profile_resolver import (
+    ProfileResolverError,
+    ProfileResolverErrorCode,
+    resolve_embedding_profile,
+)
+from ai_core.rag.routing_rules import get_routing_table, reset_routing_rules_cache
+from common.logging import log_context
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    reset_embedding_configuration_cache()
+    reset_routing_rules_cache()
+    yield
+    reset_routing_rules_cache()
+    reset_embedding_configuration_cache()
+
+
+def _write_routing_rules(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def _configure_embeddings(settings) -> None:
+    settings.RAG_VECTOR_STORES = {
+        "global": {
+            "backend": "pgvector",
+            "schema": "rag",
+            "dimension": 1536,
+        },
+        "legacy": {
+            "backend": "pgvector",
+            "schema": "rag_legacy",
+            "dimension": 1024,
+        },
+    }
+    settings.RAG_EMBEDDING_PROFILES = {
+        "standard": {
+            "model": "oai-embed-large",
+            "dimension": 1536,
+            "vector_space": "global",
+        },
+        "legacy": {
+            "model": "oai-embed-small",
+            "dimension": 1024,
+            "vector_space": "legacy",
+        },
+    }
+
+
+def test_requires_tenant_id(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules: []
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    with pytest.raises(ProfileResolverError) as excinfo:
+        resolve_embedding_profile(tenant_id="  ")
+
+    assert excinfo.value.code == ProfileResolverErrorCode.TENANT_REQUIRED
+    assert "tenant_id is required" in str(excinfo.value)
+
+
+def test_resolves_profile_with_defaults(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: legacy
+            tenant: tenant-a
+            process: review
+            doc_class: manual
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    assert (
+        resolve_embedding_profile(
+            tenant_id="tenant-a", process="review", doc_class="manual"
+        )
+        == "legacy"
+    )
+    assert (
+        resolve_embedding_profile(
+            tenant_id="tenant-a", process="", doc_class="manual"
+        )
+        == "standard"
+    )
+    assert (
+        resolve_embedding_profile(
+            tenant_id="tenant-b", process=None, doc_class=None
+        )
+        == "standard"
+    )
+
+
+def test_resolver_is_case_insensitive(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: legacy
+            tenant: tenant-a
+            process: Review
+            doc_class: Manual
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    assert (
+        resolve_embedding_profile(
+            tenant_id="tenant-a", process="REVIEW", doc_class="manual"
+        )
+        == "legacy"
+    )
+
+
+def test_resolved_profile_must_exist(tmp_path, settings, monkeypatch) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules: []
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    # Materialise routing table before simulating configuration drift.
+    get_routing_table()
+
+    from ai_core.rag import embedding_config as embedding_config_module
+    from ai_core.rag import profile_resolver as profile_resolver_module
+
+    original_config = embedding_config_module.get_embedding_configuration()
+    broken_config = EmbeddingConfiguration(
+        vector_spaces=dict(original_config.vector_spaces),
+        embedding_profiles=dict(original_config.embedding_profiles),
+    )
+    broken_config.embedding_profiles.pop("standard")
+
+    monkeypatch.setattr(
+        profile_resolver_module,
+        "get_embedding_configuration",
+        lambda: broken_config,
+    )
+
+    with pytest.raises(ProfileResolverError) as excinfo:
+        resolve_embedding_profile(tenant_id="tenant-a")
+
+    assert excinfo.value.code == ProfileResolverErrorCode.UNKNOWN_PROFILE
+    assert "not configured" in str(excinfo.value)
+
+
+def test_profile_resolution_emits_trace_metadata(
+    tmp_path, settings, monkeypatch
+) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: legacy
+            tenant: tenant-a
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    spans: list[dict[str, object]] = []
+
+    from ai_core.rag import profile_resolver as resolver_module
+
+    monkeypatch.setattr(
+        resolver_module.tracing,
+        "emit_span",
+        lambda **kwargs: spans.append(kwargs),
+    )
+
+    with log_context(trace_id="trace-profile", tenant="tenant-a"):
+        assert (
+            resolve_embedding_profile(tenant_id="tenant-a", process=None, doc_class=None)
+            == "legacy"
+        )
+
+    assert spans, "expected resolver to emit a Langfuse span"
+    span = spans[0]
+    assert span["trace_id"] == "trace-profile"
+    assert span["node_name"] == "rag.profile.resolve"
+    metadata = span["metadata"]
+    assert metadata["embedding_profile"] == "legacy"
+    assert metadata["tenant"] == "tenant-a"
+

--- a/ai_core/tests/test_router_validation.py
+++ b/ai_core/tests/test_router_validation.py
@@ -1,0 +1,163 @@
+import pytest
+
+from ai_core.rag.limits import get_limit_setting, normalize_max_candidates
+from ai_core.rag.router_validation import (
+    RouterInputError,
+    RouterInputErrorCode,
+    emit_router_validation_failure,
+    map_router_error_to_status,
+    validate_search_inputs,
+)
+from common.logging import log_context
+
+
+def test_validate_requires_tenant() -> None:
+    with pytest.raises(RouterInputError) as excinfo:
+        validate_search_inputs(tenant_id="  ")
+
+    assert excinfo.value.code == RouterInputErrorCode.TENANT_REQUIRED
+    assert excinfo.value.field == "tenant_id"
+
+
+def test_validate_accepts_trimmed_values() -> None:
+    result = validate_search_inputs(
+        tenant_id="tenant-1 ",
+        top_k="7",
+        process=" draft ",
+        doc_class=" legal ",
+    )
+
+    assert result.tenant_id == "tenant-1"
+    assert result.process == "draft"
+    assert result.doc_class == "legal"
+    assert result.top_k == 7
+    assert result.max_candidates is None
+    assert result.effective_top_k == 7
+    assert result.top_k_source == "from_state"
+    expected_cap = int(get_limit_setting("RAG_MAX_CANDIDATES", 200))
+    assert result.effective_max_candidates == normalize_max_candidates(7, None, expected_cap)
+    assert result.max_candidates_source == "from_default"
+
+
+def test_validate_normalizes_selector_case() -> None:
+    result = validate_search_inputs(
+        tenant_id="tenant-1",
+        process="Review",
+        doc_class="Manual",
+    )
+
+    assert result.process == "review"
+    assert result.doc_class == "manual"
+
+
+def test_validate_treats_blank_top_k_as_default() -> None:
+    result = validate_search_inputs(tenant_id="tenant-1", top_k="  ")
+
+    assert result.top_k is None
+    assert result.process is None
+    assert result.doc_class is None
+    assert result.effective_top_k == 5
+    assert result.top_k_source == "from_default"
+    expected_cap = int(get_limit_setting("RAG_MAX_CANDIDATES", 200))
+    assert result.effective_max_candidates == normalize_max_candidates(5, None, expected_cap)
+    assert result.max_candidates_source == "from_default"
+
+
+def test_validate_context_includes_sanitized_limits() -> None:
+    result = validate_search_inputs(
+        tenant_id="tenant-1",
+        top_k="5",
+        max_candidates="15",
+    )
+
+    assert result.top_k == 5
+    assert result.max_candidates == 15
+    assert result.context["top_k"] == 5
+    assert result.context["max_candidates"] == 15
+    assert result.effective_top_k == 5
+    assert result.effective_max_candidates == 15
+
+
+@pytest.mark.parametrize("value", [0, -1, "not-a-number", 2.5])
+def test_validate_rejects_invalid_top_k(value) -> None:
+    with pytest.raises(RouterInputError) as excinfo:
+        validate_search_inputs(tenant_id="tenant", top_k=value)
+
+    assert excinfo.value.code == RouterInputErrorCode.TOP_K_INVALID
+
+
+@pytest.mark.parametrize("value", [0, -3, "invalid", 1.7])
+def test_validate_rejects_invalid_max_candidates(value) -> None:
+    with pytest.raises(RouterInputError) as excinfo:
+        validate_search_inputs(tenant_id="tenant", max_candidates=value)
+
+    assert excinfo.value.code == RouterInputErrorCode.MAX_CANDIDATES_INVALID
+
+
+def test_validate_guards_against_conflicting_limits(monkeypatch) -> None:
+    monkeypatch.setenv("RAG_CANDIDATE_POLICY", "error")
+    with pytest.raises(RouterInputError) as excinfo:
+        validate_search_inputs(tenant_id="tenant", top_k=10, max_candidates=5)
+
+    assert excinfo.value.code == RouterInputErrorCode.MAX_CANDIDATES_LT_TOP_K
+
+
+def test_validate_conflicting_limits_can_be_normalized(monkeypatch) -> None:
+    monkeypatch.setenv("RAG_CANDIDATE_POLICY", "normalize")
+
+    result = validate_search_inputs(
+        tenant_id="tenant", top_k=10, max_candidates=5
+    )
+
+    assert result.max_candidates == 10
+    assert result.context["candidate_policy_action"] == "normalized_to_top_k"
+    assert result.effective_top_k == 10
+    assert result.effective_max_candidates == 10
+    assert result.max_candidates_source == "from_state"
+
+
+def test_map_router_error_to_status_returns_client_error() -> None:
+    for code in (
+        RouterInputErrorCode.TENANT_REQUIRED,
+        RouterInputErrorCode.TOP_K_INVALID,
+        RouterInputErrorCode.MAX_CANDIDATES_INVALID,
+        RouterInputErrorCode.MAX_CANDIDATES_LT_TOP_K,
+        "ROUTER_FUTURE_CODE",
+    ):
+        assert map_router_error_to_status(code) == 400
+
+
+def test_emit_router_validation_failure_emits_span(monkeypatch) -> None:
+    error = RouterInputError(
+        RouterInputErrorCode.TOP_K_INVALID,
+        "invalid",
+        field="top_k",
+        context={
+            "tenant_id": "tenant-1",
+            "process": "draft",
+            "doc_class": "legal",
+            "top_k": 99,
+            "max_candidates": None,
+        },
+    )
+
+    spans: list[dict[str, object]] = []
+    from ai_core.rag import router_validation as router_validation_module
+
+    monkeypatch.setattr(
+        router_validation_module.tracing,
+        "emit_span",
+        lambda **kwargs: spans.append(kwargs),
+    )
+
+    with log_context(trace_id="trace-router"):
+        emit_router_validation_failure(error)
+
+    assert spans, "expected router validation failure to emit span"
+    span = spans[0]
+    assert span["trace_id"] == "trace-router"
+    assert span["node_name"] == "rag.router.validation_failed"
+    metadata = span["metadata"]
+    assert metadata["error_code"] == RouterInputErrorCode.TOP_K_INVALID
+    assert metadata["tenant"] == "tenant-1"
+    assert metadata["process"] == "draft"

--- a/ai_core/tests/test_routing_rules.py
+++ b/ai_core/tests/test_routing_rules.py
@@ -1,0 +1,332 @@
+"""Tests for embedding routing rules."""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ai_core.rag.embedding_config import reset_embedding_configuration_cache
+from ai_core.rag.routing_rules import (
+    RoutingConfigurationError,
+    RoutingErrorCode,
+    RoutingRule,
+    RoutingTable,
+    get_routing_table,
+    reset_routing_rules_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    reset_embedding_configuration_cache()
+    reset_routing_rules_cache()
+    yield
+    reset_routing_rules_cache()
+    reset_embedding_configuration_cache()
+
+
+def _write_routing_rules(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def _configure_embeddings(settings) -> None:
+    settings.RAG_VECTOR_STORES = {
+        "global": {
+            "backend": "pgvector",
+            "schema": "rag",
+            "dimension": 1536,
+        },
+        "legacy": {
+            "backend": "pgvector",
+            "schema": "rag_legacy",
+            "dimension": 1024,
+        },
+    }
+    settings.RAG_EMBEDDING_PROFILES = {
+        "standard": {
+            "model": "oai-embed-large",
+            "dimension": 1536,
+            "vector_space": "global",
+        },
+        "legacy": {
+            "model": "oai-embed-small",
+            "dimension": 1024,
+            "vector_space": "legacy",
+        },
+    }
+
+
+def test_resolve_prefers_more_specific_rule(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: legacy
+            tenant: tenant-a
+          - profile: standard
+            tenant: tenant-a
+            doc_class: legal
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    table = get_routing_table()
+
+    assert (
+        table.resolve(tenant="tenant-a", process="review", doc_class="legal")
+        == "standard"
+    )
+    assert (
+        table.resolve(tenant="tenant-a", process="review", doc_class="manual")
+        == "legacy"
+    )
+    assert (
+        table.resolve(tenant="tenant-b", process="review", doc_class="legal")
+        == "standard"
+    )
+
+
+def test_rules_are_case_insensitive(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: legacy
+            tenant: tenant-a
+            process: Review
+            doc_class: Manual
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    table = get_routing_table()
+
+    assert (
+        table.resolve(tenant="tenant-a", process="review", doc_class="manual")
+        == "legacy"
+    )
+
+
+@pytest.mark.parametrize(
+    "process,doc_class,expected",
+    [
+        ("review", "legal", "enterprise"),
+        ("review", "manual", "premium"),
+        ("draft", "legal", "legacy"),
+        ("draft", None, "legacy"),
+        ("review", None, "premium"),
+    ],
+)
+def test_specificity_precedence(tmp_path, settings, process, doc_class, expected) -> None:
+    _configure_embeddings(settings)
+    settings.RAG_EMBEDDING_PROFILES.update(
+        {
+            "premium": {
+                "model": "oai-embed-large",
+                "dimension": 1536,
+                "vector_space": "global",
+            },
+            "enterprise": {
+                "model": "oai-embed-large",
+                "dimension": 1536,
+                "vector_space": "global",
+            },
+        }
+    )
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: legacy
+            tenant: tenant-a
+          - profile: premium
+            tenant: tenant-a
+            process: review
+          - profile: enterprise
+            tenant: tenant-a
+            process: review
+            doc_class: legal
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    table = get_routing_table()
+
+    assert (
+        table.resolve(tenant="tenant-a", process=process, doc_class=doc_class)
+        == expected
+    )
+
+
+def test_unknown_profile_raises(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: unknown
+        rules: []
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    with pytest.raises(RoutingConfigurationError) as excinfo:
+        get_routing_table()
+
+    message = str(excinfo.value)
+    assert "ROUTE_UNKNOWN_PROFILE_DEFAULT" in message
+    assert "Default routing profile" in message
+
+
+def test_overlapping_rules_with_same_specificity_fail(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: standard
+            tenant: tenant-a
+            process: review
+          - profile: legacy
+            tenant: tenant-a
+            doc_class: legal
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    with pytest.raises(RoutingConfigurationError) as excinfo:
+        get_routing_table()
+
+    message = str(excinfo.value)
+    assert "ROUTE_CONFLICT" in message
+    assert "Overlapping routing rules" in message
+
+
+def test_duplicate_rule_same_target_is_tolerated(tmp_path, settings, caplog) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: legacy
+            tenant: tenant-a
+            process: review
+          - profile: legacy
+            tenant: tenant-a
+            process: review
+          - profile: legacy
+            tenant: tenant-a
+            process: review
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    with caplog.at_level(logging.WARNING):
+        table = get_routing_table()
+
+    dup_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and "ROUTE_DUP_SAME_TARGET" in record.getMessage()
+    ]
+
+    assert len(dup_warnings) == 1
+
+    assert (
+        table.resolve(tenant="tenant-a", process="review", doc_class="manual")
+        == "legacy"
+    )
+
+
+def test_duplicate_rule_conflicting_targets_raises(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: standard
+            tenant: tenant-a
+            process: review
+          - profile: legacy
+            tenant: tenant-a
+            process: review
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    with pytest.raises(RoutingConfigurationError) as excinfo:
+        get_routing_table()
+
+    message = str(excinfo.value)
+    assert "ROUTE_DUP_SELECTOR" in message
+    assert "Duplicate routing selector" in message
+
+
+def test_resolve_raises_on_ambiguous_runtime_match() -> None:
+    table = RoutingTable(
+        default_profile="standard",
+        rules=(
+            RoutingRule(profile="legacy", tenant="tenant-a", process=None, doc_class=None),
+            RoutingRule(profile="premium", tenant="tenant-a", process=None, doc_class=None),
+        ),
+    )
+
+    with pytest.raises(RoutingConfigurationError) as excinfo:
+        table.resolve(tenant="tenant-a", process="draft", doc_class="manual")
+
+    message = str(excinfo.value)
+    assert RoutingErrorCode.CONFLICT in message
+    assert "Ambiguous routing rules" in message
+
+
+def test_same_specificity_same_profile_still_conflicts(tmp_path, settings) -> None:
+    _configure_embeddings(settings)
+    rules_file = tmp_path / "routing.yaml"
+    _write_routing_rules(
+        rules_file,
+        """
+        default_profile: standard
+        rules:
+          - profile: standard
+            tenant: tenant-a
+            process: review
+          - profile: standard
+            tenant: tenant-a
+            doc_class: legal
+        """,
+    )
+    settings.RAG_ROUTING_RULES_PATH = rules_file
+
+    with pytest.raises(RoutingConfigurationError) as excinfo:
+        get_routing_table()
+
+    message = str(excinfo.value)
+    assert "ROUTE_CONFLICT" in message
+    assert "Overlapping routing rules" in message
+
+
+def test_routing_table_without_default_raises() -> None:
+    table = RoutingTable(default_profile="", rules=())
+
+    with pytest.raises(RoutingConfigurationError) as excinfo:
+        table.resolve(tenant="tenant-a", process=None, doc_class=None)
+
+    assert RoutingErrorCode.NO_MATCH in str(excinfo.value)

--- a/ai_core/tests/test_vector_schema.py
+++ b/ai_core/tests/test_vector_schema.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import uuid
+
+import psycopg2
+import pytest
+from django.db import connection
+
+from ai_core.rag.embedding_config import reset_embedding_configuration_cache
+from ai_core.rag.vector_schema import (
+    VectorSchemaError,
+    VectorSchemaErrorCode,
+    build_vector_schema_plan,
+    render_schema_sql,
+    validate_vector_schemas,
+)
+
+
+def _configure_vector_spaces(settings, spaces):
+    settings.RAG_VECTOR_STORES = spaces
+    settings.RAG_EMBEDDING_PROFILES = {
+        "default": {
+            "model": "test-model",
+            "dimension": next(iter(spaces.values()))["dimension"],
+            "vector_space": next(iter(spaces.keys())),
+        }
+    }
+    reset_embedding_configuration_cache()
+
+
+def test_build_vector_schema_plan_renders_per_space(settings) -> None:
+    spaces = {
+        "global": {"backend": "pgvector", "schema": "rag_alpha", "dimension": 6},
+        "archive": {"backend": "pgvector", "schema": "rag_archive", "dimension": 8},
+    }
+    _configure_vector_spaces(settings, spaces)
+
+    plan = build_vector_schema_plan()
+
+    assert {ddl.space_id for ddl in plan} == {"global", "archive"}
+    assert all(f"SET search_path TO {spaces[ddl.space_id]['schema']}" in ddl.sql for ddl in plan)
+    assert any("vector(6)" in ddl.sql for ddl in plan)
+    assert any("vector(8)" in ddl.sql for ddl in plan)
+
+    reset_embedding_configuration_cache()
+
+
+def test_validate_vector_schemas_detects_dimension_conflict(settings) -> None:
+    spaces = {
+        "primary": {"backend": "pgvector", "schema": "rag_conflict", "dimension": 3},
+        "secondary": {"backend": "pgvector", "schema": "rag_conflict", "dimension": 7},
+    }
+    settings.RAG_VECTOR_STORES = spaces
+    settings.RAG_EMBEDDING_PROFILES = {
+        "p": {"model": "m", "dimension": 3, "vector_space": "primary"}
+    }
+    reset_embedding_configuration_cache()
+
+    with pytest.raises(VectorSchemaError) as excinfo:
+        validate_vector_schemas()
+    assert VectorSchemaErrorCode.SCHEMA_DIMENSION_CONFLICT in str(excinfo.value)
+
+    reset_embedding_configuration_cache()
+
+
+@pytest.mark.django_db
+def test_rendered_schema_sql_enforces_dimension_guard(settings) -> None:
+    schema_name = "rag_smoke"
+    dimension = 4
+    sql = render_schema_sql(schema_name, dimension)
+
+    params = connection.get_connection_params()
+    ddl_conn = psycopg2.connect(**params)
+    skip_exc: Exception | None = None
+    try:
+        ddl_conn.set_session(autocommit=True)
+        with ddl_conn.cursor() as cur:
+            cur.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            try:
+                cur.execute(sql)
+            except psycopg2.errors.InsufficientPrivilege as exc:
+                ddl_conn.rollback()
+                skip_exc = exc
+
+        if skip_exc is None:
+            with ddl_conn.cursor() as cur:
+                cur.execute(f"SET search_path TO {schema_name}, public")
+                doc_id = uuid.uuid4()
+                chunk_id = uuid.uuid4()
+                tenant_id = uuid.uuid4()
+                cur.execute(
+                    "INSERT INTO documents (id, tenant_id, source, hash, metadata)"
+                    " VALUES (%s, %s, %s, %s, '{}'::jsonb)",
+                    (doc_id, str(tenant_id), "test", "hash"),
+                )
+                cur.execute(
+                    "INSERT INTO chunks (id, document_id, ord, text, tokens, metadata)"
+                    " VALUES (%s, %s, %s, %s, %s, '{}'::jsonb)",
+                    (chunk_id, doc_id, 0, "chunk", 5),
+                )
+                vector_literal = "[" + ",".join("0" for _ in range(dimension)) + "]"
+                cur.execute(
+                    "INSERT INTO embeddings (id, chunk_id, embedding)"
+                    " VALUES (%s, %s, %s::vector)",
+                    (uuid.uuid4(), chunk_id, vector_literal),
+                )
+
+                wrong_literal = "[" + ",".join("0" for _ in range(dimension + 1)) + "]"
+                with pytest.raises(psycopg2.errors.DataException):
+                    cur.execute(
+                        "INSERT INTO embeddings (id, chunk_id, embedding)"
+                        " VALUES (%s, %s, %s::vector)",
+                        (uuid.uuid4(), chunk_id, wrong_literal),
+                    )
+    finally:
+        try:
+            ddl_conn.rollback()
+        except Exception:
+            pass
+        if skip_exc is None:
+            with ddl_conn.cursor() as cur:
+                cur.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+        ddl_conn.close()
+
+    if skip_exc is not None:
+        pytest.skip(f"requires extension privileges: {skip_exc}")
+
+    reset_embedding_configuration_cache()

--- a/ai_core/tests/test_vector_space_resolver.py
+++ b/ai_core/tests/test_vector_space_resolver.py
@@ -1,0 +1,141 @@
+import pytest
+
+from ai_core.rag.embedding_config import (
+    EmbeddingConfiguration,
+    reset_embedding_configuration_cache,
+)
+from ai_core.rag.vector_space_resolver import (
+    VectorSpaceResolverError,
+    VectorSpaceResolverErrorCode,
+    resolve_vector_space_full,
+    resolve_vector_space,
+)
+from common.logging import log_context
+
+
+@pytest.fixture(autouse=True)
+def _reset_embedding_cache() -> None:
+    reset_embedding_configuration_cache()
+    yield
+    reset_embedding_configuration_cache()
+
+
+def _configure_embeddings(settings) -> None:
+    settings.RAG_VECTOR_STORES = {
+        "global": {
+            "backend": "pgvector",
+            "schema": "rag",
+            "dimension": 1536,
+        },
+        "legacy": {
+            "backend": "pgvector",
+            "schema": "rag_legacy",
+            "dimension": 1024,
+        },
+    }
+    settings.RAG_EMBEDDING_PROFILES = {
+        "standard": {
+            "model": "oai-embed-large",
+            "dimension": 1536,
+            "vector_space": "global",
+        },
+        "legacy": {
+            "model": "oai-embed-small",
+            "dimension": 1024,
+            "vector_space": "legacy",
+        },
+    }
+
+
+def test_resolve_vector_space_returns_config(settings) -> None:
+    _configure_embeddings(settings)
+
+    resolved = resolve_vector_space("standard")
+
+    assert resolved.id == "global"
+    assert resolved.dimension == 1536
+    assert resolved.backend == "pgvector"
+    assert resolved.schema == "rag"
+
+
+def test_resolve_vector_space_full_returns_profile_and_space(settings) -> None:
+    _configure_embeddings(settings)
+
+    resolution = resolve_vector_space_full("legacy")
+
+    assert resolution.profile.id == "legacy"
+    assert resolution.profile.vector_space == "legacy"
+    assert resolution.vector_space.id == "legacy"
+    assert resolution.vector_space.dimension == 1024
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_requires_profile_identifier(settings, value) -> None:
+    _configure_embeddings(settings)
+
+    with pytest.raises(VectorSpaceResolverError) as excinfo:
+        resolve_vector_space(value)
+
+    assert excinfo.value.code == VectorSpaceResolverErrorCode.PROFILE_REQUIRED
+
+
+def test_unknown_profile_raises(settings) -> None:
+    _configure_embeddings(settings)
+
+    with pytest.raises(VectorSpaceResolverError) as excinfo:
+        resolve_vector_space("missing")
+
+    assert excinfo.value.code == VectorSpaceResolverErrorCode.PROFILE_UNKNOWN
+    assert "missing" in excinfo.value.message
+
+
+def test_missing_vector_space_is_guarded(settings, monkeypatch) -> None:
+    _configure_embeddings(settings)
+    from ai_core.rag import vector_space_resolver as resolver_module
+
+    original = resolver_module.get_embedding_configuration()
+    broken = EmbeddingConfiguration(
+        vector_spaces=dict(original.vector_spaces),
+        embedding_profiles=dict(original.embedding_profiles),
+    )
+    broken.vector_spaces.pop("global")
+
+    monkeypatch.setattr(
+        resolver_module,
+        "get_embedding_configuration",
+        lambda: broken,
+    )
+
+    with pytest.raises(VectorSpaceResolverError) as excinfo:
+        resolve_vector_space("standard")
+
+    assert excinfo.value.code == VectorSpaceResolverErrorCode.VECTOR_SPACE_UNKNOWN
+    assert "global" in excinfo.value.message
+
+
+def test_vector_space_resolution_emits_trace_metadata(
+    settings, monkeypatch
+) -> None:
+    _configure_embeddings(settings)
+
+    spans: list[dict[str, object]] = []
+    from ai_core.rag import vector_space_resolver as resolver_module
+
+    monkeypatch.setattr(
+        resolver_module.tracing,
+        "emit_span",
+        lambda **kwargs: spans.append(kwargs),
+    )
+
+    with log_context(trace_id="trace-space", tenant="tenant-a"):
+        resolution = resolve_vector_space_full("standard")
+
+    assert resolution.vector_space.id == "global"
+    assert spans, "expected vector space resolver to emit a Langfuse span"
+    span = spans[0]
+    assert span["trace_id"] == "trace-space"
+    assert span["node_name"] == "rag.vector_space.resolve"
+    metadata = span["metadata"]
+    assert metadata["vector_space_id"] == "global"
+    assert metadata["embedding_profile"] == "standard"
+

--- a/config/rag_routing_rules.yaml
+++ b/config/rag_routing_rules.yaml
@@ -1,0 +1,15 @@
+# Routing table for embedding profiles used by the RAG vector store.
+#
+# The router selects a profile deterministically based on tenant, process
+# context and document class. The default profile must always be defined and
+# every override must reference an existing embedding profile identifier.
+#
+# Duplicate selectors that point to the same profile are tolerated and will
+# emit a `ROUTE_DUP_SAME_TARGET` warning to highlight redundant entries.
+# Selectors are normalised to lowercase during validation and routing so
+# `review`, `Review` and `REVIEW` are treated identically.
+#
+# Operators can override this file via the RAG_ROUTING_RULES_PATH setting.
+
+default_profile: standard
+rules: []

--- a/load/locust/locustfile.py
+++ b/load/locust/locustfile.py
@@ -142,6 +142,9 @@ class IngestionRunUser(TenantHttpUser):
         {
             "document_ids": document_ids,
             "priority": os.getenv("LOCUST_INGESTION_PRIORITY", "normal"),
+            "embedding_profile": os.getenv(
+                "LOCUST_INGESTION_PROFILE", "standard"
+            ),
         },
     )
 

--- a/noesis2/settings/base.py
+++ b/noesis2/settings/base.py
@@ -29,6 +29,8 @@ if "RAG_VECTOR_STORES" not in globals():
     RAG_VECTOR_STORES = {
         "global": {
             "backend": "pgvector",
+            "schema": "rag",
+            "dimension": 1536,
             # "dsn_env": "RAG_DATABASE_URL",
         }
     }
@@ -57,8 +59,23 @@ RAG_MIN_SIM = env.float("RAG_MIN_SIM", default=0.15)
 RAG_TRGM_LIMIT = env.float("RAG_TRGM_LIMIT", default=0.1)
 RAG_HYBRID_ALPHA = env.float("RAG_HYBRID_ALPHA", default=0.7)
 RAG_MAX_CANDIDATES = env.int("RAG_MAX_CANDIDATES", default=200)
+RAG_CANDIDATE_POLICY = env("RAG_CANDIDATE_POLICY", default="error")
 RAG_CHUNK_TARGET_TOKENS = env.int("RAG_CHUNK_TARGET_TOKENS", default=450)
 RAG_CHUNK_OVERLAP_TOKENS = env.int("RAG_CHUNK_OVERLAP_TOKENS", default=80)
+
+if "RAG_EMBEDDING_PROFILES" not in globals():
+    RAG_EMBEDDING_PROFILES = {
+        "standard": {
+            "model": env("EMBEDDINGS_MODEL_PRIMARY", default="oai-embed-large"),
+            "dimension": 1536,
+            "vector_space": "global",
+        }
+    }
+
+_default_routing_rules_path = BASE_DIR / "config" / "rag_routing_rules.yaml"
+RAG_ROUTING_RULES_PATH = Path(
+    env("RAG_ROUTING_RULES_PATH", default=str(_default_routing_rules_path))
+)
 
 EMBEDDINGS_PROVIDER = env("EMBEDDINGS_PROVIDER", default="litellm")
 EMBEDDINGS_MODEL_PRIMARY = env("EMBEDDINGS_MODEL_PRIMARY", default="oai-embed-large")

--- a/tests/rag/test_limits.py
+++ b/tests/rag/test_limits.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from ai_core.rag.limits import clamp_fraction, normalize_max_candidates, normalize_top_k
+from ai_core.rag.limits import (
+    CandidatePoolPolicy,
+    clamp_fraction,
+    normalize_max_candidates,
+    normalize_top_k,
+    resolve_candidate_pool_policy,
+)
 from ai_core.rag.vector_client import PgVectorClient
 
 
@@ -99,3 +105,21 @@ def test_estimated_tokens_feed_into_candidate_cap(
 
     normalized_candidates = normalize_max_candidates(top_k, estimated_tokens, cap)
     assert normalized_candidates == expected_candidates
+
+
+def test_resolve_candidate_pool_policy_defaults_to_error(monkeypatch) -> None:
+    monkeypatch.delenv("RAG_CANDIDATE_POLICY", raising=False)
+
+    assert resolve_candidate_pool_policy() == CandidatePoolPolicy.ERROR
+
+
+def test_resolve_candidate_pool_policy_reads_env(monkeypatch) -> None:
+    monkeypatch.setenv("RAG_CANDIDATE_POLICY", "normalize")
+
+    assert resolve_candidate_pool_policy() == CandidatePoolPolicy.NORMALIZE
+
+
+def test_resolve_candidate_pool_policy_rejects_unknown(monkeypatch) -> None:
+    monkeypatch.setenv("RAG_CANDIDATE_POLICY", "unsupported")
+
+    assert resolve_candidate_pool_policy() == CandidatePoolPolicy.ERROR


### PR DESCRIPTION
## Summary
- extend router validation to compute effective top_k and max_candidates once, logging policy actions with normalized metadata
- update vector store routing to trust the validator output instead of reapplying candidate normalization
- expand router validation tests to cover the new effective limit fields and preserved warning semantics

## Testing
- pytest ai_core/tests/test_router_validation.py ai_core/tests/test_vector_router.py tests/rag/test_limits.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e21aa8a210832bb896c3a987d1b21e