### PR TITLE
Remove unused hybrid search variables and fix lint warnings

### DIFF
--- a/ai_core/rag/vector_store.py
+++ b/ai_core/rag/vector_store.py
@@ -12,7 +12,6 @@ from ai_core.rag.limits import clamp_fraction, get_limit_setting
 from . import metrics
 from .router_validation import (
     RouterInputError,
-    RouterInputErrorCode,
     emit_router_validation_failure,
     validate_search_inputs,
 )
@@ -290,8 +289,6 @@ class VectorStoreRouter:
             _raise_router_error(exc)
 
         tenant = validation.tenant_id
-        sanitized_top_k = validation.top_k
-        sanitized_max = validation.max_candidates
         validation_context = validation.context
 
         normalized_top_k = validation.effective_top_k

--- a/tests/plugins/rag_db.py
+++ b/tests/plugins/rag_db.py
@@ -1,6 +1,4 @@
 import os
-import re
-from pathlib import Path
 from typing import Iterator
 
 import psycopg2


### PR DESCRIPTION
## Summary
- remove unused sanitised hybrid search values in the vector store router
- drop unused imports flagged by Ruff

## Testing
- python -m ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68e276931760832ba733b2fd50b7d763