### PR TITLE
Validate embedding dimensions when formatting vectors

### DIFF
--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -1684,13 +1684,11 @@ class PgVectorClient:
         return max(1, len(content.split()))
 
     def _format_vector(self, values: Sequence[float]) -> str:
-        # Do not enforce a strict dimension check here.
-        #
-        # Rationale: Callers (and tests) may provide lightweight stub embeddings
-        # for query-time operations where we rely on the database/type system to
-        # validate dimensions. Ingestion paths still surface dimension problems
-        # at the database layer if the stored column uses a fixed vector size.
-        return "[" + ",".join(f"{float(v):.6f}" for v in values) + "]"
+        expected_dim = get_embedding_dim()
+        floats = [float(v) for v in values]
+        if len(floats) != expected_dim:
+            raise ValueError("Embedding dimension mismatch")
+        return "[" + ",".join(f"{value:.6f}" for value in floats) + "]"
 
     def _embed_query(self, query: str) -> List[float]:
         client = get_embedding_client()


### PR DESCRIPTION
## Summary
- ensure `PgVectorClient._format_vector` fetches the configured embedding dimensionality
- raise a clear error when the provided values do not match the expected dimension before rendering the vector

## Testing
- pytest -vv -rs ai_core/tests/test_vector_client.py::TestPgVectorClient::test_format_vector_raises_on_dimension_mismatch
- pytest -vv -rs tests/rag/test_vector_client.py::test_replace_chunks_normalises_embeddings


------
https://chatgpt.com/codex/tasks/task_e_68e2b4182050832bb8a7413dde8dd43d