### PR TITLE
Ensure router forwards visibility flags

### DIFF
--- a/ai_core/rag/vector_store.py
+++ b/ai_core/rag/vector_store.py
@@ -570,6 +570,12 @@ class VectorStoreRouter:
                             inspect.Parameter.KEYWORD_ONLY,
                         )
                     }
+                    # visibility is handled via dedicated parameters on the client
+                    # even if older implementations haven't been updated yet. keep
+                    # these keys so PgVectorClient.hybrid_search can consume them.
+                    allowed_keywords.update(
+                        {"visibility", "visibility_override_allowed"}
+                    )
                     hybrid_kwargs = {
                         key: value
                         for key, value in hybrid_kwargs.items()


### PR DESCRIPTION
## Summary
- preserve visibility-specific keyword arguments when checking hybrid search signatures so the client receives them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ae83dcf8832ba527781b79a39364