### PR TITLE
Enable scope kwargs for rag hard delete task

### DIFF
--- a/ai_core/rag/hard_delete.py
+++ b/ai_core/rag/hard_delete.py
@@ -365,4 +365,7 @@ def hard_delete(  # type: ignore[override]
     }
 
 
+hard_delete.accepts_scope = True
+
+
 __all__ = ["hard_delete"]


### PR DESCRIPTION
## Summary
- opt the `rag.hard_delete` task into Celery scope kwargs so the trace identifier reaches the function body
- keep `_emit_span` emitting via `tracing.emit_span` with the received trace metadata

## Testing
- pytest ai_core/tests/test_hard_delete.py::test_hard_delete_service_key

------
https://chatgpt.com/codex/tasks/task_e_68e523a0593c832b92b99de8660c0c19