### PR TITLE
Restrict forwarding of scope kwargs for ScopedTask

### DIFF
--- a/ai_core/ingestion.py
+++ b/ai_core/ingestion.py
@@ -245,7 +245,13 @@ def partition_document_ids(
     return existing, missing
 
 
-@shared_task(base=ScopedTask, queue="ingestion", bind=True, max_retries=3)
+@shared_task(
+    base=ScopedTask,
+    queue="ingestion",
+    bind=True,
+    max_retries=3,
+    accepts_scope=True,
+)
 def process_document(
     self,
     tenant: str,
@@ -517,7 +523,7 @@ def process_document(
     }
 
 
-@shared_task(base=ScopedTask, queue="ingestion")
+@shared_task(base=ScopedTask, queue="ingestion", accepts_scope=True)
 def run_ingestion(
     tenant: str,
     case: str,
@@ -871,6 +877,7 @@ def _safe_dispatch_dead_letters(
     base=ScopedTask,
     queue="ingestion_dead_letter",
     name="ai_core.ingestion.dead_letter",
+    accepts_scope=True,
 )
 def record_dead_letter(payload: Dict[str, object]) -> None:
     log.error("Ingestion dead letter", extra=payload)

--- a/ai_core/rag/hard_delete.py
+++ b/ai_core/rag/hard_delete.py
@@ -288,7 +288,12 @@ def _emit_span(
     )
 
 
-@shared_task(base=ScopedTask, name="rag.hard_delete", queue="rag_delete")
+@shared_task(
+    base=ScopedTask,
+    name="rag.hard_delete",
+    queue="rag_delete",
+    accepts_scope=True,
+)
 def hard_delete(  # type: ignore[override]
     tenant_id: str,
     document_ids: Sequence[object],

--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -119,7 +119,7 @@ def log_ingestion_run_end(
         )
 
 
-@shared_task(base=ScopedTask)
+@shared_task(base=ScopedTask, accepts_scope=True)
 def ingest_raw(meta: Dict[str, str], name: str, data: bytes) -> Dict[str, str]:
     """Persist raw document bytes."""
     external_id = meta.get("external_id")
@@ -133,7 +133,7 @@ def ingest_raw(meta: Dict[str, str], name: str, data: bytes) -> Dict[str, str]:
     return {"path": path, "content_hash": content_hash}
 
 
-@shared_task(base=ScopedTask)
+@shared_task(base=ScopedTask, accepts_scope=True)
 def extract_text(meta: Dict[str, str], raw_path: str) -> Dict[str, str]:
     """Decode bytes to text and store."""
     full = object_store.BASE_PATH / raw_path
@@ -143,7 +143,7 @@ def extract_text(meta: Dict[str, str], raw_path: str) -> Dict[str, str]:
     return {"path": out_path}
 
 
-@shared_task(base=ScopedTask)
+@shared_task(base=ScopedTask, accepts_scope=True)
 def pii_mask(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
     """Mask PII in text."""
     full = object_store.BASE_PATH / text_path
@@ -156,7 +156,7 @@ def pii_mask(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
     return {"path": out_path}
 
 
-@shared_task(base=ScopedTask)
+@shared_task(base=ScopedTask, accepts_scope=True)
 def _split_sentences(text: str) -> List[str]:
     """Best-effort sentence segmentation that retains punctuation."""
 
@@ -433,7 +433,7 @@ def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
     return {"path": out_path}
 
 
-@shared_task(base=ScopedTask)
+@shared_task(base=ScopedTask, accepts_scope=True)
 def embed(meta: Dict[str, str], chunks_path: str) -> Dict[str, str]:
     """Generate embedding vectors for chunks via LiteLLM."""
 
@@ -519,7 +519,7 @@ def embed(meta: Dict[str, str], chunks_path: str) -> Dict[str, str]:
     return {"path": out_path}
 
 
-@shared_task(base=ScopedTask)
+@shared_task(base=ScopedTask, accepts_scope=True)
 def upsert(
     meta: Dict[str, str],
     embeddings_path: str,
@@ -585,7 +585,7 @@ def upsert(
     return written
 
 
-@shared_task(base=ScopedTask, queue="ingestion")
+@shared_task(base=ScopedTask, queue="ingestion", accepts_scope=True)
 def ingestion_run(
     tenant_id: str,
     case_id: str,


### PR DESCRIPTION
## Summary
- track the scope kwargs originally provided to `ScopedTask.__call__`
- forward scope-related kwargs and `session_scope` only when a task opts in via `accepts_scope`
- keep scope data for context configuration without surfacing unwanted kwargs downstream

## Testing
- pytest common/tests/test_celery_scope.py common/tests/test_pii_flags.py

------
https://chatgpt.com/codex/tasks/task_e_68e535448f84832b89ec056da62087bc