### PR TITLE
Handle ScopedTask session salt in rag hard delete

### DIFF
--- a/ai_core/rag/hard_delete.py
+++ b/ai_core/rag/hard_delete.py
@@ -303,6 +303,8 @@ def hard_delete(  # type: ignore[override]
     actor: Mapping[str, object] | None = None,
     tenant_schema: str | None = None,
     trace_id: str | None = None,  # noqa: ARG001
+    session_salt: str | None = None,
+    session_scope: Sequence[str] | None = None,  # noqa: ARG001
 ) -> Mapping[str, object]:
     """Physically delete documents and related rows from the vector store."""
 
@@ -343,6 +345,9 @@ def hard_delete(  # type: ignore[override]
         "vacuum": vacuum_performed,
         "reindex": reindex_performed,
     }
+
+    if session_salt:
+        log_payload["session_salt"] = session_salt
 
     logger.info("rag.hard_delete.audit", extra=log_payload)
 


### PR DESCRIPTION
## Summary
- allow `rag.hard_delete` to accept scoped session salt/session scope and include the salt in audit metadata
- cover the service-key execution path when ScopedTask injects session scope parameters

## Testing
- pytest ai_core/tests/test_hard_delete.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e54c0bf748832bbe82085799784bce