### PR TITLE
Handle case scope kwargs in rag hard delete

### DIFF
--- a/ai_core/rag/hard_delete.py
+++ b/ai_core/rag/hard_delete.py
@@ -302,6 +302,7 @@ def hard_delete(  # type: ignore[override]
     *,
     actor: Mapping[str, object] | None = None,
     tenant_schema: str | None = None,
+    case_id: str | None = None,
     trace_id: str | None = None,  # noqa: ARG001
     session_salt: str | None = None,
     session_scope: Sequence[str] | None = None,  # noqa: ARG001
@@ -345,6 +346,9 @@ def hard_delete(  # type: ignore[override]
         "vacuum": vacuum_performed,
         "reindex": reindex_performed,
     }
+
+    if case_id:
+        log_payload["case_id"] = str(case_id)
 
     if session_salt:
         log_payload["session_salt"] = session_salt


### PR DESCRIPTION
## Summary
- allow the `rag.hard_delete` task to receive scoped `case_id` kwargs from Celery
- include the case identifier in the audit payload emitted for spans and logging

## Testing
- pytest ai_core/tests/test_hard_delete.py::test_hard_delete_service_key_with_scoped_session -q

------
https://chatgpt.com/codex/tasks/task_e_68e55c52b230832baaafffcd1dad77d2