### PR TITLE
Add tool contracts context model and error taxonomy

### DIFF
--- a/ai_core/__init__.py
+++ b/ai_core/__init__.py
@@ -1,0 +1,23 @@
+"""AI core package exports."""
+
+from .tool_contracts import (
+    InputError,
+    InternalToolError,
+    NotFoundError,
+    RateLimitedError,
+    TimeoutError,
+    ToolContext,
+    ToolError,
+    UpstreamServiceError,
+)
+
+__all__ = [
+    "ToolContext",
+    "ToolError",
+    "InputError",
+    "NotFoundError",
+    "RateLimitedError",
+    "TimeoutError",
+    "UpstreamServiceError",
+    "InternalToolError",
+]

--- a/ai_core/tests/test_tool_contracts.py
+++ b/ai_core/tests/test_tool_contracts.py
@@ -1,0 +1,49 @@
+"""Tests for tool contracts and error taxonomy."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ai_core.tool_contracts import (
+    InputError,
+    InternalToolError,
+    NotFoundError,
+    RateLimitedError,
+    TimeoutError,
+    ToolContext,
+    ToolError,
+    UpstreamServiceError,
+)
+
+
+class TestToolContext:
+    def test_valid_context_defaults(self) -> None:
+        context = ToolContext(tenant_id="tenant", case_id="case")
+
+        assert context.tenant_id == "tenant"
+        assert context.case_id == "case"
+        assert context.trace_id is None
+        assert context.idempotency_key is None
+
+    def test_missing_required_field_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolContext(tenant_id="tenant")  # type: ignore[call-arg]
+
+
+class TestToolErrorHierarchy:
+    @pytest.mark.parametrize(
+        "error_cls",
+        [
+            InputError,
+            NotFoundError,
+            RateLimitedError,
+            TimeoutError,
+            UpstreamServiceError,
+            InternalToolError,
+        ],
+    )
+    def test_specialized_errors_inherit_from_tool_error(self, error_cls: type[ToolError]) -> None:
+        assert issubclass(error_cls, ToolError)
+
+    def test_tool_error_inherits_from_exception(self) -> None:
+        assert issubclass(ToolError, Exception)

--- a/ai_core/tool_contracts.py
+++ b/ai_core/tool_contracts.py
@@ -1,0 +1,41 @@
+"""Contracts and error taxonomy for tool interactions."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ToolContext(BaseModel):
+    """Context metadata required for tool invocations."""
+
+    tenant_id: str
+    case_id: str
+    trace_id: str | None = None
+    idempotency_key: str | None = None
+
+
+class ToolError(Exception):
+    """Base error for tool related issues."""
+
+
+class InputError(ToolError):
+    """Raised when input data validation fails."""
+
+
+class NotFoundError(ToolError):
+    """Raised when a requested resource cannot be located."""
+
+
+class RateLimitedError(ToolError):
+    """Raised when rate limits are exceeded."""
+
+
+class TimeoutError(ToolError):
+    """Raised when an external call exceeds its timeout."""
+
+
+class UpstreamServiceError(ToolError):
+    """Raised when a dependent service returns an error."""
+
+
+class InternalToolError(ToolError):
+    """Raised when an unexpected error occurs within the tool itself."""


### PR DESCRIPTION
## Summary
- add a dedicated ToolContext pydantic model for tool call metadata
- define a standard ToolError hierarchy for consistent error handling
- expose the contracts via the ai_core package and cover them with unit tests

## Testing
- pytest ai_core/tests/test_tool_contracts.py

------
https://chatgpt.com/codex/tasks/task_e_68e6154d814c832b8869b89275bfc509