### PR TITLE
Refactor retrieval tool to new contract

### DIFF
--- a/ai_core/tool_contracts/__init__.py
+++ b/ai_core/tool_contracts/__init__.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ToolError(Exception):
+    """Base class for errors raised by tool implementations."""
+
+
+class InputError(ToolError):
+    """Raised when the provided tool input violates the contract."""
+
+    def __init__(self, message: str, *, field: str | None = None) -> None:
+        super().__init__(message)
+        self.field = field
+
+
+class ContextError(ToolError):
+    """Raised when the surrounding execution context is invalid."""
+
+    def __init__(self, message: str, *, field: str | None = None) -> None:
+        super().__init__(message)
+        self.field = field
+
+
+class ToolContext(BaseModel):
+    """Shared execution context provided to tool implementations."""
+
+    tenant_id: str
+    tenant_schema: str | None = None
+    case_id: str | None = None
+    trace_id: str | None = None
+    visibility_override_allowed: bool = False
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+
+__all__ = ["ContextError", "InputError", "ToolContext", "ToolError"]


### PR DESCRIPTION
## Summary
- add a tool_contracts module that defines ToolContext plus typed InputError/ContextError for tool execution
- refactor the retrieve node to use RetrieveInput/RetrieveOutput models, emit took_ms, and adopt the new ToolContext interface while updating the RAG graph adapter
- update retrieval unit and integration tests to cover the new contract and error handling semantics

## Testing
- pytest ai_core/tests/test_nodes.py tests/nodes/test_retrieve_integration.py ai_core/tests/test_graph_retrieval_augmented_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e615b85580832bb5463122171c53b1