### PR TITLE
refactor: use tool input error for ingestion contracts

### DIFF
--- a/ai_core/ingestion.py
+++ b/ai_core/ingestion.py
@@ -13,10 +13,9 @@ from common.logging import get_logger
 from . import tasks as pipe
 from .infra import object_store
 from .ingestion_utils import make_fallback_external_id
-from .rag.ingestion_contracts import (
-    IngestionContractError,
-    resolve_ingestion_profile,
-)
+from ai_core.tools import InputError
+
+from .rag.ingestion_contracts import resolve_ingestion_profile
 from .rag.selector_utils import normalise_selector_value
 
 log = get_logger(__name__)
@@ -417,7 +416,7 @@ def process_document(
         state["last_error"] = None
         state["completed_at"] = time.time()
         _write_pipeline_state(tenant, case, document_id, state)
-    except IngestionContractError as exc:
+    except InputError as exc:
         state["last_error"] = {
             "step": current_step,
             "message": str(exc),
@@ -541,7 +540,7 @@ def run_ingestion(
     doc_count = len(valid_ids)
     try:
         binding = resolve_ingestion_profile(embedding_profile)
-    except IngestionContractError as exc:
+    except InputError as exc:
         log.error(
             "Failed to resolve ingestion profile",
             extra={

--- a/ai_core/rag/__init__.py
+++ b/ai_core/rag/__init__.py
@@ -16,7 +16,6 @@ from .router_validation import (
     validate_search_inputs,
 )
 from .ingestion_contracts import (
-    IngestionContractError,
     IngestionContractErrorCode,
     ensure_embedding_dimensions,
     map_ingestion_error_to_status,
@@ -56,7 +55,6 @@ __all__ = [
     "get_default_router",
     "vector_client",
     "resolve_ingestion_profile",
-    "IngestionContractError",
     "IngestionContractErrorCode",
     "ensure_embedding_dimensions",
     "map_ingestion_error_to_status",

--- a/ai_core/tests/test_ingestion_contracts.py
+++ b/ai_core/tests/test_ingestion_contracts.py
@@ -2,11 +2,11 @@ import pytest
 
 from ai_core.rag.embedding_config import reset_embedding_configuration_cache
 from ai_core.rag.ingestion_contracts import (
-    IngestionContractError,
     IngestionContractErrorCode,
     ensure_embedding_dimensions,
     resolve_ingestion_profile,
 )
+from ai_core.tools import InputError
 from ai_core.rag.vector_space_resolver import (
     VectorSpaceResolverError,
     VectorSpaceResolverErrorCode,
@@ -43,21 +43,21 @@ def test_resolve_ingestion_profile_success(settings) -> None:
 
 def test_resolve_ingestion_profile_requires_value(settings) -> None:
     _configure_embeddings(settings)
-    with pytest.raises(IngestionContractError) as excinfo:
+    with pytest.raises(InputError) as excinfo:
         resolve_ingestion_profile(None)
     assert excinfo.value.code == IngestionContractErrorCode.PROFILE_REQUIRED
 
 
 def test_resolve_ingestion_profile_rejects_non_string(settings) -> None:
     _configure_embeddings(settings)
-    with pytest.raises(IngestionContractError) as excinfo:
+    with pytest.raises(InputError) as excinfo:
         resolve_ingestion_profile(123)
     assert excinfo.value.code == IngestionContractErrorCode.PROFILE_INVALID
 
 
 def test_resolve_ingestion_profile_unknown_id(settings) -> None:
     _configure_embeddings(settings)
-    with pytest.raises(IngestionContractError) as excinfo:
+    with pytest.raises(InputError) as excinfo:
         resolve_ingestion_profile("unknown")
     assert excinfo.value.code == IngestionContractErrorCode.PROFILE_UNKNOWN
 
@@ -77,7 +77,7 @@ def test_resolve_ingestion_profile_missing_space(settings, monkeypatch) -> None:
         contracts_module, "resolve_vector_space_full", _raise_missing_space
     )
 
-    with pytest.raises(IngestionContractError) as excinfo:
+    with pytest.raises(InputError) as excinfo:
         resolve_ingestion_profile("standard")
     assert excinfo.value.code == IngestionContractErrorCode.VECTOR_SPACE_UNKNOWN
 
@@ -99,7 +99,7 @@ def test_ensure_embedding_dimensions_allows_matching_vectors() -> None:
 def test_ensure_embedding_dimensions_raises_on_mismatch() -> None:
     chunks = [Chunk(content="c", meta={"external_id": "doc-1"}, embedding=[0.1])]
 
-    with pytest.raises(IngestionContractError) as excinfo:
+    with pytest.raises(InputError) as excinfo:
         ensure_embedding_dimensions(
             chunks,
             2,

--- a/ai_core/tests/test_ingestion_task.py
+++ b/ai_core/tests/test_ingestion_task.py
@@ -7,6 +7,7 @@ from celery.exceptions import TimeoutError as CeleryTimeoutError
 
 from ai_core import ingestion
 from ai_core.rag.ingestion_contracts import IngestionContractErrorCode
+from ai_core.tools import InputError
 
 
 class DummyProcessTask:
@@ -397,7 +398,7 @@ def test_run_ingestion_contract_error_includes_context(monkeypatch):
     _patch_partition(monkeypatch, valid_ids, [])
 
     async_result = DummyAsyncResult(results=[])
-    async_result.should_raise = ingestion.IngestionContractError(
+    async_result.should_raise = InputError(
         IngestionContractErrorCode.VECTOR_DIMENSION_MISMATCH,
         "dimension mismatch",
         context={

--- a/ai_core/tests/test_tasks.py
+++ b/ai_core/tests/test_tasks.py
@@ -7,10 +7,8 @@ from structlog.testing import capture_logs
 from ai_core import tasks
 from ai_core.infra import object_store
 from ai_core.rag import metrics, vector_client
-from ai_core.rag.ingestion_contracts import (
-    IngestionContractError,
-    IngestionContractErrorCode,
-)
+from ai_core.rag.ingestion_contracts import IngestionContractErrorCode
+from ai_core.tools import InputError
 from common import logging as common_logging
 from common.celery import ContextTask
 
@@ -183,7 +181,7 @@ def test_upsert_raises_on_dimension_mismatch(monkeypatch):
 
     monkeypatch.setattr(tasks, "get_default_router", lambda: _Router())
 
-    with pytest.raises(IngestionContractError) as excinfo:
+    with pytest.raises(InputError) as excinfo:
         tasks.upsert(meta, "embeddings.json")
 
     error = excinfo.value

--- a/ai_core/tools/__init__.py
+++ b/ai_core/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Tooling helpers and error types for AI Core."""
+
+from .errors import InputError, ToolError
+
+__all__ = ["ToolError", "InputError"]

--- a/ai_core/tools/errors.py
+++ b/ai_core/tools/errors.py
@@ -1,0 +1,35 @@
+"""Common error types for AI tool contracts."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+_DOC_HINT = "See README.md (Fehlercodes Abschnitt) for remediation guidance."
+
+
+class ToolError(ValueError):
+    """Base class for tool errors with structured metadata."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        context: Mapping[str, Any] | None = None,
+        doc_hint: str | None = _DOC_HINT,
+    ) -> None:
+        detail = f"{code}: {message}"
+        if doc_hint:
+            detail = f"{detail}. {doc_hint}"
+        super().__init__(detail)
+        self.code = code
+        self.message = message
+        self.context = dict(context or {})
+        self.doc_hint = doc_hint
+
+
+class InputError(ToolError):
+    """Raised when tool input validation fails."""
+
+
+__all__ = ["ToolError", "InputError"]

--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -83,8 +83,9 @@ from .infra import object_store, rate_limit
 from .ingestion import partition_document_ids, run_ingestion
 from .ingestion_utils import make_fallback_external_id
 from .rag.hard_delete import hard_delete
+from ai_core.tools import InputError
+
 from .rag.ingestion_contracts import (
-    IngestionContractError,
     map_ingestion_error_to_status,
     resolve_ingestion_profile,
 )
@@ -1201,7 +1202,7 @@ class RagIngestionRunView(APIView):
             profile_binding = resolve_ingestion_profile(
                 payload.get("embedding_profile")
             )
-        except IngestionContractError as exc:
+        except InputError as exc:
             return _error_response(
                 exc.message,
                 exc.code,


### PR DESCRIPTION
## Summary
- add shared `ToolError`/`InputError` types for tool contract violations
- raise `InputError` from ingestion contract validation and propagate handling in ingestion tasks and views
- update ingestion unit tests to expect the new error class

## Testing
- pytest ai_core/tests/test_ingestion_contracts.py ai_core/tests/test_tasks.py ai_core/tests/test_ingestion_task.py

------
https://chatgpt.com/codex/tasks/task_e_68e616945ee8832b95c32f40bf6165cd