### PR TITLE
Refactor metadata keys to tenant_id/case_id

### DIFF
--- a/ai_core/graphs/info_intake.py
+++ b/ai_core/graphs/info_intake.py
@@ -11,7 +11,7 @@ def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
     state:
         Mutable workflow state.
     meta:
-        Context containing ``tenant``, ``case`` and ``trace_id``.
+        Context containing ``tenant_id``, ``case_id`` and ``trace_id``.
 
     Returns
     -------
@@ -23,7 +23,7 @@ def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
     new_state.setdefault("meta", meta)
     result = {
         "received": True,
-        "tenant": meta.get("tenant"),
-        "case": meta.get("case"),
+        "tenant_id": meta.get("tenant_id"),
+        "case_id": meta.get("case_id"),
     }
     return new_state, result

--- a/ai_core/graphs/retrieval_augmented_generation.py
+++ b/ai_core/graphs/retrieval_augmented_generation.py
@@ -48,7 +48,7 @@ def _ensure_mutable_meta(
 
 
 def _ensure_tenant_id(meta: MutableMapping[str, Any]) -> str:
-    tenant_id = meta.get("tenant_id") or meta.get("tenant")
+    tenant_id = meta.get("tenant_id")
     if tenant_id is None:
         raise ValueError("tenant_id is required for retrieval graphs")
     tenant_id = str(tenant_id)

--- a/ai_core/infra/resp.py
+++ b/ai_core/infra/resp.py
@@ -28,8 +28,8 @@ def apply_std_headers(response: HttpResponse, meta: Meta) -> HttpResponse:
 
     header_map = {
         X_TRACE_ID_HEADER: meta.get("trace_id"),
-        X_CASE_ID_HEADER: meta.get("case"),
-        X_TENANT_ID_HEADER: meta.get("tenant"),
+        X_CASE_ID_HEADER: meta.get("case_id"),
+        X_TENANT_ID_HEADER: meta.get("tenant_id"),
         X_KEY_ALIAS_HEADER: meta.get("key_alias"),
         "traceparent": meta.get("traceparent"),
     }

--- a/ai_core/middleware/context.py
+++ b/ai_core/middleware/context.py
@@ -70,9 +70,9 @@ class RequestContextMiddleware:
         if span_id:
             response_meta["span_id"] = span_id
         if tenant_id:
-            response_meta["tenant"] = tenant_id
+            response_meta["tenant_id"] = tenant_id
         if case_id:
-            response_meta["case"] = case_id
+            response_meta["case_id"] = case_id
         if key_alias:
             response_meta["key_alias"] = key_alias
         if traceparent:

--- a/ai_core/nodes/retrieve.py
+++ b/ai_core/nodes/retrieve.py
@@ -154,13 +154,13 @@ def run(
     doc_class = state.get("doc_class")
     requested_visibility = state.get("visibility")
 
-    tenant_id = meta.get("tenant_id") or meta.get("tenant")
+    tenant_id = meta.get("tenant_id")
     if not tenant_id:
         raise ValueError("tenant_id required")
     tenant_id = str(tenant_id)
 
     tenant_schema = meta.get("tenant_schema")
-    case_id = meta.get("case_id") or meta.get("case")
+    case_id = meta.get("case_id")
 
     hybrid_config = parse_hybrid_parameters(state, override_top_k=top_k)
 

--- a/ai_core/rag/filters.py
+++ b/ai_core/rag/filters.py
@@ -9,8 +9,8 @@ def strict_match(
     - When `tenant` is None, do not filter by tenant.
     - When `case` is None, do not filter by case.
     """
-    if tenant is not None and meta.get("tenant") != tenant:
+    if tenant is not None and meta.get("tenant_id") != tenant:
         return False
-    if case is not None and meta.get("case") != case:
+    if case is not None and meta.get("case_id") != case:
         return False
     return True

--- a/ai_core/rag/vector_client.py
+++ b/ai_core/rag/vector_client.py
@@ -50,7 +50,7 @@ logger = get_logger(__name__)
 # - "document_hash": Spalte d.hash
 # - "document_id":  Spalte d.id::text
 SUPPORTED_METADATA_FILTERS = {
-    "case": "chunk_meta",
+    "case_id": "chunk_meta",
     "source": "chunk_meta",
     "doctype": "chunk_meta",
     "published": "chunk_meta",
@@ -580,24 +580,24 @@ class PgVectorClient:
         if case_id not in {None, ""}:
             case_value = case_id
         else:
-            case_value = normalized_filters.get("case")
+            case_value = normalized_filters.get("case_id")
         if case_value is not None:
             case_value = str(case_value)
-        normalized_filters["tenant"] = tenant
-        normalized_filters["case"] = case_value
+        normalized_filters["tenant_id"] = tenant
+        normalized_filters["case_id"] = case_value
         metadata_filters = [
             (key, value)
             for key, value in normalized_filters.items()
-            if key not in {"tenant"}
+            if key not in {"tenant_id"}
             and value is not None
             and key in SUPPORTED_METADATA_FILTERS
         ]
         filter_debug: Dict[str, object | None] = {
-            "tenant": "<set>",
+            "tenant_id": "<set>",
             "visibility": visibility_mode.value,
         }
         for key, value in normalized_filters.items():
-            if key in {"tenant"}:
+            if key in {"tenant_id"}:
                 continue
             filter_debug[key] = (
                 "<set>"
@@ -687,7 +687,7 @@ class PgVectorClient:
                 "rag.hybrid.null_embedding",
                 alpha=alpha_value,
                 tenant=tenant,
-                case=case_value,
+                case_id=case_value,
             )
         index_kind = str(_get_setting("RAG_INDEX_KIND", "HNSW")).upper()
         ef_search = int(_get_setting("RAG_HNSW_EF_SEARCH", 80))
@@ -818,7 +818,7 @@ class PgVectorClient:
                         "rag.hybrid.vector_query_failed",
                         extra={
                             "tenant": tenant,
-                            "case": case_value,
+                            "case_id": case_value,
                             "error": str(vector_format_error),
                         },
                     )
@@ -876,7 +876,7 @@ class PgVectorClient:
                             "rag.hybrid.vector_query_failed",
                             extra={
                                 "tenant": tenant,
-                                "case": case_value,
+                                "case_id": case_value,
                                 "error": str(exc),
                             },
                         )
@@ -1035,7 +1035,7 @@ class PgVectorClient:
                                         "rag.hybrid.lexical_primary_failed",
                                         extra={
                                             "tenant": tenant,
-                                            "case": case_value,
+                                            "case_id": case_value,
                                             "error": str(exc),
                                         },
                                     )
@@ -1076,7 +1076,7 @@ class PgVectorClient:
                                     "rag.hybrid.trgm_no_match",
                                     extra={
                                         "tenant": tenant,
-                                        "case": case_value,
+                                        "case_id": case_value,
                                         "trgm_limit": trgm_limit_value,
                                         "applied_trgm_limit": applied_trgm_limit,
                                         "fallback": True,
@@ -1216,7 +1216,7 @@ class PgVectorClient:
                                 logger.info(
                                     "rag.hybrid.trgm_fallback_applied",
                                     tenant=tenant,
-                                    case=case_value,
+                                    case_id=case_value,
                                     tried_limits=list(fallback_tried_limits),
                                     picked_limit=picked_limit,
                                     count=len(lexical_rows_local),
@@ -1240,7 +1240,7 @@ class PgVectorClient:
                         "rag.hybrid.lexical_query_failed",
                         extra={
                             "tenant": tenant,
-                            "case": case_value,
+                            "case_id": case_value,
                             "error": str(exc),
                         },
                     )
@@ -1343,7 +1343,7 @@ class PgVectorClient:
                     logger.warning(
                         "rag.hybrid.deleted_visibility_count_failed",
                         tenant=tenant,
-                        case=case_value,
+                        case_id=case_value,
                         error=str(exc),
                     )
                     total_without_filter_local = None
@@ -1358,7 +1358,7 @@ class PgVectorClient:
         logger.info(
             "rag.hybrid.sql_counts",
             tenant=tenant,
-            case=case_value,
+            case_id=case_value,
             vec_rows=len(vector_rows),
             lex_rows=len(lexical_rows),
             alpha=alpha_value,
@@ -1468,7 +1468,7 @@ class PgVectorClient:
             "rag.hybrid.debug.fusion",
             extra={
                 "tenant": tenant,
-                "case": case_value,
+                "case_id": case_value,
                 "candidates": fused_candidates,
                 "has_vec": bool(vector_rows),
                 "has_lex": bool(lexical_rows),
@@ -1490,8 +1490,8 @@ class PgVectorClient:
             if doc_id is not None and "id" not in meta:
                 meta["id"] = str(doc_id)
             if not strict_match(meta, tenant, case_value):
-                candidate_tenant = meta.get("tenant")
-                candidate_case = meta.get("case")
+                candidate_tenant = meta.get("tenant_id")
+                candidate_case = meta.get("case_id")
                 reasons: List[str] = []
                 if tenant is not None:
                     if candidate_tenant is None:
@@ -1506,7 +1506,7 @@ class PgVectorClient:
                 logger.info(
                     "rag.strict.reject",
                     tenant=tenant,
-                    case=case_value,
+                    case_id=case_value,
                     candidate_tenant=candidate_tenant,
                     candidate_case=candidate_case,
                     doc_hash=doc_hash,
@@ -1574,7 +1574,7 @@ class PgVectorClient:
                     "rag.hybrid.cutoff_fallback",
                     extra={
                         "tenant": tenant,
-                        "case": case_value,
+                        "case_id": case_value,
                         "requested_min_sim": min_sim_value,
                         "returned": len(limited_results),
                         "below_cutoff": below_cutoff,
@@ -1606,7 +1606,7 @@ class PgVectorClient:
             "rag.hybrid.debug.after_cutoff",
             extra={
                 "tenant": tenant,
-                "case": case_value,
+                "case_id": case_value,
                 "returned": len(limited_results),
                 "top_fused": top_fused,
                 "top_vscore": top_v,
@@ -1626,7 +1626,7 @@ class PgVectorClient:
             )
 
         logger.info(
-            "RAG hybrid search executed: tenant=%s case=%s vector_candidates=%d lexical_candidates=%d fused_candidates=%d returned=%d deleted_blocked=%d duration_ms=%.2f",
+            "RAG hybrid search executed: tenant=%s case_id=%s vector_candidates=%d lexical_candidates=%d fused_candidates=%d returned=%d deleted_blocked=%d duration_ms=%.2f",
             tenant,
             case_value,
             len(vector_rows),
@@ -1671,12 +1671,12 @@ class PgVectorClient:
     def _group_by_document(self, chunks: Sequence[Chunk]) -> GroupedDocuments:
         grouped: GroupedDocuments = {}
         for chunk in chunks:
-            tenant_value = chunk.meta.get("tenant")
+            tenant_value = chunk.meta.get("tenant_id")
             doc_hash = str(chunk.meta.get("hash"))
             source = chunk.meta.get("source", "")
             external_id = chunk.meta.get("external_id")
             if tenant_value in {None, "", "None"}:
-                raise ValueError("Chunk metadata must include tenant")
+                raise ValueError("Chunk metadata must include tenant_id")
             if not doc_hash or doc_hash == "None":
                 raise ValueError("Chunk metadata must include hash")
             if external_id in {None, "", "None"}:
@@ -1700,12 +1700,12 @@ class PgVectorClient:
                     "metadata": {
                         k: v
                         for k, v in chunk.meta.items()
-                        if k not in {"tenant", "hash", "source"}
+                        if k not in {"tenant_id", "hash", "source"}
                     },
                     "chunks": [],
                 }
             chunk_meta = dict(chunk.meta)
-            chunk_meta["tenant"] = tenant
+            chunk_meta["tenant_id"] = tenant
             chunk_meta["external_id"] = external_id_str
             grouped[key]["chunks"].append(
                 Chunk(content=chunk.content, meta=chunk_meta, embedding=chunk.embedding)

--- a/ai_core/rag/vector_store.py
+++ b/ai_core/rag/vector_store.py
@@ -663,9 +663,9 @@ class VectorStoreRouter:
         chunk_list = list(chunks)
         expected_tenant = str(tenant_id).strip() if tenant_id is not None else None
         for chunk in chunk_list:
-            tenant_meta = str(chunk.meta.get("tenant") or "").strip()
+            tenant_meta = str(chunk.meta.get("tenant_id") or "").strip()
             if not tenant_meta:
-                raise ValueError("chunk metadata must include tenant")
+                raise ValueError("chunk metadata must include tenant_id")
             if expected_tenant is not None and tenant_meta != expected_tenant:
                 raise ValueError(
                     "Chunk tenant '%s' does not match expected tenant '%s'"
@@ -807,7 +807,7 @@ class _TenantScopedClient:
         coerced: list[Chunk] = []
         for chunk in chunk_list:
             meta = dict(chunk.meta)
-            tenant_meta_raw = meta.get("tenant")
+            tenant_meta_raw = meta.get("tenant_id")
             tenant_meta = str(tenant_meta_raw).strip() if tenant_meta_raw else ""
             if tenant_meta and tenant_meta != self._tenant_id:
                 msg = "Chunk tenant '%s' does not match scoped tenant '%s'" % (
@@ -815,7 +815,7 @@ class _TenantScopedClient:
                     self._tenant_id,
                 )
                 raise ValueError(msg)
-            meta["tenant"] = self._tenant_id
+            meta["tenant_id"] = self._tenant_id
             coerced.append(
                 Chunk(content=chunk.content, meta=meta, embedding=chunk.embedding)
             )

--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -35,8 +35,8 @@ logger = get_logger(__name__)
 
 
 def _build_path(meta: Dict[str, str], *parts: str) -> str:
-    tenant = object_store.sanitize_identifier(meta["tenant"])
-    case = object_store.sanitize_identifier(meta["case"])
+    tenant = object_store.sanitize_identifier(meta["tenant_id"])
+    case = object_store.sanitize_identifier(meta["case_id"])
     return "/".join([tenant, case, *parts])
 
 
@@ -379,8 +379,8 @@ def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
             chunk_text = f"{prefix}\n\n{body}" if body else prefix
         normalised = normalise_text(chunk_text)
         chunk_meta = {
-            "tenant": meta["tenant"],
-            "case": meta.get("case"),
+            "tenant_id": meta["tenant_id"],
+            "case_id": meta.get("case_id"),
             "source": text_path,
             "hash": content_hash,
             "external_id": external_id,
@@ -405,8 +405,8 @@ def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
     if not chunks:
         normalised = normalise_text(text)
         chunk_meta = {
-            "tenant": meta["tenant"],
-            "case": meta.get("case"),
+            "tenant_id": meta["tenant_id"],
+            "case_id": meta.get("case_id"),
             "source": text_path,
             "hash": content_hash,
             "external_id": external_id,
@@ -535,13 +535,13 @@ def upsert(
             Chunk(content=ch["content"], meta=ch["meta"], embedding=embedding)
         )
 
-    tenant_id: Optional[str] = meta.get("tenant") if meta else None
+    tenant_id: Optional[str] = meta.get("tenant_id") if meta else None
     if not tenant_id:
         tenant_id = next(
             (
-                str(chunk.meta.get("tenant"))
+                str(chunk.meta.get("tenant_id"))
                 for chunk in chunk_objs
-                if chunk.meta and chunk.meta.get("tenant")
+                if chunk.meta and chunk.meta.get("tenant_id")
             ),
             None,
         )
@@ -549,7 +549,7 @@ def upsert(
         raise ValueError("tenant_id required for upsert")
 
     for chunk in chunk_objs:
-        chunk_tenant = chunk.meta.get("tenant") if chunk.meta else None
+        chunk_tenant = chunk.meta.get("tenant_id") if chunk.meta else None
         if chunk_tenant and str(chunk_tenant) != tenant_id:
             raise ValueError("chunk tenant mismatch")
 

--- a/ai_core/tests/test_graph_retrieval_augmented_generation.py
+++ b/ai_core/tests/test_graph_retrieval_augmented_generation.py
@@ -76,7 +76,7 @@ def test_graph_normalises_tenant_alias() -> None:
         compose_node=_fake_compose,
     )
 
-    meta = {"tenant": "tenant-alias"}
+    meta = {"tenant_id": "tenant-alias"}
     state, result = graph.run({}, meta)
 
     assert meta["tenant_id"] == "tenant-alias"

--- a/ai_core/tests/test_graphs.py
+++ b/ai_core/tests/test_graphs.py
@@ -5,13 +5,13 @@ from ai_core.graphs import (
     system_description,
 )
 
-META = {"tenant": "t1", "case": "c1", "trace_id": "tr"}
+META = {"tenant_id": "t1", "case_id": "c1", "trace_id": "tr"}
 
 
 def test_info_intake_adds_meta():
     state, result = info_intake.run({}, META)
     assert state["meta"] == META
-    assert result["tenant"] == META["tenant"]
+    assert result["tenant_id"] == META["tenant_id"]
 
 
 def test_scope_check_never_creates_draft():

--- a/ai_core/tests/test_infra.py
+++ b/ai_core/tests/test_infra.py
@@ -38,8 +38,8 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
     resp = HttpResponse("ok", status=200)
     meta = {
         "trace_id": "abc123",
-        "case": "case-1",
-        "tenant": "tenant-1",
+        "case_id": "case-1",
+        "tenant_id": "tenant-1",
         "key_alias": "alias-1",
         "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     }
@@ -55,7 +55,7 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
 
 def test_apply_std_headers_skips_missing_optional_headers():
     resp = HttpResponse("ok", status=200)
-    meta = {"trace_id": "abc123", "case": "case-1", "tenant": "tenant-1"}
+    meta = {"trace_id": "abc123", "case_id": "case-1", "tenant_id": "tenant-1"}
 
     result = apply_std_headers(resp, meta)
 
@@ -67,8 +67,8 @@ def test_apply_std_headers_skips_missing_optional_headers():
 def test_apply_std_headers_ignores_non_success_responses():
     meta = {
         "trace_id": "abc123",
-        "case": "case-1",
-        "tenant": "tenant-1",
+        "case_id": "case-1",
+        "tenant_id": "tenant-1",
         "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     }
 

--- a/ai_core/tests/test_rag_filters.py
+++ b/ai_core/tests/test_rag_filters.py
@@ -2,15 +2,15 @@ from ai_core.rag.filters import strict_match
 
 
 def test_strict_match_positive():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t1", "c1") is True
 
 
 def test_strict_match_negative():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t1", "c2") is False
 
 
 def test_strict_match_negative_tenant():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t2", "c1") is False

--- a/ai_core/tests/test_tasks.py
+++ b/ai_core/tests/test_tasks.py
@@ -92,9 +92,9 @@ def test_build_chunk_prefix_combines_breadcrumbs_and_title() -> None:
 @pytest.mark.usefixtures("rag_database")
 def test_upsert_persists_chunks(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    tenant = str(uuid.uuid4())
-    case = str(uuid.uuid4())
-    meta = {"tenant": tenant, "case": case, "external_id": "doc-1"}
+    tenant_id = str(uuid.uuid4())
+    case_id = str(uuid.uuid4())
+    meta = {"tenant_id": tenant_id, "case_id": case_id, "external_id": "doc-1"}
     vector_client.reset_default_client()
 
     raw = tasks.ingest_raw(meta, "doc.txt", b"User 123")
@@ -107,7 +107,7 @@ def test_upsert_persists_chunks(tmp_path, monkeypatch):
     assert count == 1
 
     client = vector_client.get_default_client()
-    results = client.search("User", tenant_id=tenant, case_id=case, top_k=5)
+    results = client.search("User", tenant_id=tenant_id, case_id=case_id, top_k=5)
     assert len(results) == 1
     assert results[0].content == "User XXX"
     assert results[0].meta.get("hash")
@@ -119,7 +119,7 @@ def test_upsert_persists_chunks(tmp_path, monkeypatch):
 
 def test_upsert_forwards_tenant_schema(monkeypatch):
     meta = {
-        "tenant": "tenant-42",
+        "tenant_id": "tenant-42",
         "tenant_schema": "schema-tenant-42",
     }
 
@@ -127,7 +127,7 @@ def test_upsert_forwards_tenant_schema(monkeypatch):
         {
             "content": "payload",
             "embedding": [0.0],
-            "meta": {"tenant": "tenant-42"},
+            "meta": {"tenant_id": "tenant-42"},
         }
     ]
 
@@ -155,7 +155,7 @@ def test_upsert_forwards_tenant_schema(monkeypatch):
 
 def test_upsert_raises_on_dimension_mismatch(monkeypatch):
     meta = {
-        "tenant": "tenant-42",
+        "tenant_id": "tenant-42",
         "embedding_profile": "standard",
         "vector_space_id": "global",
         "vector_space_dimension": 2,
@@ -167,7 +167,7 @@ def test_upsert_raises_on_dimension_mismatch(monkeypatch):
             "content": "payload",
             "embedding": [0.0],
             "meta": {
-                "tenant": "tenant-42",
+                "tenant_id": "tenant-42",
                 "embedding_profile": "standard",
                 "vector_space_id": "global",
                 "external_id": "doc-1",
@@ -234,8 +234,8 @@ def test_task_logging_context_includes_metadata(monkeypatch, tmp_path, settings)
     with capture_logs() as logs:
         tasks.ingest_raw(
             {
-                "tenant": "tenant-123",
-                "case": "case-456",
+                "tenant_id": "tenant-123",
+                "case_id": "case-456",
                 "trace_id": "trace-7890",
                 "key_alias": "alias-1234",
                 "external_id": "doc-logging",
@@ -258,12 +258,16 @@ def test_task_logging_context_includes_metadata(monkeypatch, tmp_path, settings)
 
 def test_ingest_raw_sanitizes_meta(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    meta = {"tenant": "Tenant Name", "case": "Case*ID", "external_id": "doc-1"}
+    meta = {
+        "tenant_id": "Tenant Name",
+        "case_id": "Case*ID",
+        "external_id": "doc-1",
+    }
 
     result = tasks.ingest_raw(meta, "doc.txt", b"payload")
 
-    safe_tenant = object_store.sanitize_identifier(meta["tenant"])
-    safe_case = object_store.sanitize_identifier(meta["case"])
+    safe_tenant = object_store.sanitize_identifier(meta["tenant_id"])
+    safe_case = object_store.sanitize_identifier(meta["case_id"])
     assert result["path"] == f"{safe_tenant}/{safe_case}/raw/doc.txt"
 
     stored = tmp_path / ".ai_core_store" / safe_tenant / safe_case / "raw" / "doc.txt"
@@ -272,7 +276,11 @@ def test_ingest_raw_sanitizes_meta(tmp_path, monkeypatch):
 
 def test_ingest_raw_rejects_unsafe_meta(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    meta = {"tenant": "tenant/../", "case": "case", "external_id": "doc-unsafe"}
+    meta = {
+        "tenant_id": "tenant/../",
+        "case_id": "case",
+        "external_id": "doc-unsafe",
+    }
 
     original_request = getattr(tasks.ingest_raw, "request", None)
     tasks.ingest_raw.request = SimpleNamespace(headers=None, kwargs=None)

--- a/ai_core/tests/test_vector_client.py
+++ b/ai_core/tests/test_vector_client.py
@@ -141,7 +141,7 @@ class TestPgVectorClient:
         client = vector_client.get_default_client()
         chunk = Chunk(
             content="text",
-            meta={"tenant": str(uuid.uuid4()), "external_id": "ext-1"},
+            meta={"tenant_id": str(uuid.uuid4()), "external_id": "ext-1"},
             embedding=[0.0] * vector_client.get_embedding_dim(),
         )
         with pytest.raises(ValueError):
@@ -154,9 +154,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="missing external id",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
-                "case": "case-fallback",
+                "case_id": "case-fallback",
                 "source": "example",
             },
             embedding=[0.25] + [0.0] * (vector_client.get_embedding_dim() - 1),
@@ -168,7 +168,7 @@ class TestPgVectorClient:
         results = client.search(
             "missing external id",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=1,
         )
 
@@ -208,9 +208,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="legacy",
             meta={
-                "tenant": "tenant-1",
+                "tenant_id": "tenant-1",
                 "hash": doc_hash,
-                "case": "c",
+                "case_id": "c",
                 "source": "s",
                 "external_id": "legacy-doc",
             },
@@ -226,13 +226,13 @@ class TestPgVectorClient:
 
         results = client.search(
             "legacy",
-            tenant_id=chunk.meta["tenant"],
-            filters={"case": None},
+            tenant_id=chunk.meta["tenant_id"],
+            filters={"case_id": None},
             top_k=1,
         )
         assert len(results) == 1
         assert histogram.samples
-        assert uuid.UUID(results[0].meta["tenant"])  # tenant ids are normalised
+        assert uuid.UUID(results[0].meta["tenant_id"])  # tenant ids are normalised
         assert 0.0 <= results[0].meta["score"] <= 1.0
         assert results[0].meta.get("hash") == chunk.meta["hash"]
         assert results[0].meta.get("external_id") == "legacy-doc"
@@ -261,7 +261,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="chunk-1",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
                 "source": "s",
                 "external_id": external_id,
@@ -311,7 +311,7 @@ class TestPgVectorClient:
             return Chunk(
                 content=content,
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "hash": doc_hash,
                     "source": "s",
                     "external_id": external_id,
@@ -368,7 +368,7 @@ class TestPgVectorClient:
             return Chunk(
                 content=content,
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "external_id": external_id,
                     "hash": doc_hash,
                     "source": "unit",
@@ -383,7 +383,7 @@ class TestPgVectorClient:
         initial_results = client.search(
             "original",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
         assert len(initial_results) == 1
@@ -397,7 +397,7 @@ class TestPgVectorClient:
         duplicate_results = client.search(
             "original",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
         assert len(duplicate_results) == 1
@@ -411,7 +411,7 @@ class TestPgVectorClient:
         updated_results = client.search(
             "updated",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
         assert len(updated_results) == 1
@@ -460,7 +460,7 @@ class TestPgVectorClient:
             Chunk(
                 content="Filtered",
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "hash": hashlib.sha256(b"doc-a").hexdigest(),
                     "source": "alpha",
                     "doctype": "contract",
@@ -471,7 +471,7 @@ class TestPgVectorClient:
             Chunk(
                 content="Filtered",
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "hash": hashlib.sha256(b"doc-b").hexdigest(),
                     "source": "beta",
                     "doctype": "contract",
@@ -508,7 +508,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Boolean",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": hashlib.sha256(b"doc-bool").hexdigest(),
                 "source": "gamma",
                 "published": True,
@@ -541,7 +541,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Filter tolerant",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": "doc-filter-tolerant",
                 "source": "alpha",
             },
@@ -609,7 +609,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Lexical fallback example",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
                 "source": "lexical",
                 "external_id": "doc-lex",
@@ -642,7 +642,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "Lexical fallback example",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 top_k=3,
                 alpha=0.0,
             )
@@ -676,9 +676,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="ZEBRAGURKE",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
-                "case": "lexical-case",
+                "case_id": "lexical-case",
                 "source": "lexical",
                 "external_id": "lex-1",
             },
@@ -694,7 +694,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "ZEBRAGURKE",
             tenant_id=tenant,
-            filters={"case": "lexical-case"},
+            filters={"case_id": "lexical-case"},
             alpha=0.0,
             top_k=1,
         )
@@ -712,7 +712,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Cutoff candidate example",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
                 "source": "cutoff",
                 "external_id": "doc-cutoff",
@@ -739,7 +739,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "candidate cutoff",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
             alpha=0.8,
             min_sim=0.95,
@@ -761,7 +761,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Dies ist ein völlig anderer Inhalt",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
                 "source": "lexical",
                 "external_id": "doc-trigram",
@@ -774,7 +774,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "zzzzzzzz",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 top_k=1,
                 alpha=0.0,
             )
@@ -1272,7 +1272,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "shape mismatch",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 top_k=3,
             )
 
@@ -1318,7 +1318,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "vector meta",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=1,
         )
 
@@ -1418,7 +1418,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "lexical only",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=2,
         )
 
@@ -1600,7 +1600,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "min sim cutoff",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=1,
             min_sim=0.8,
         )
@@ -1636,10 +1636,10 @@ class TestPgVectorClient:
         active_chunk = Chunk(
             content="Vector candidate still active",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": active_hash,
                 "external_id": "active-doc",
-                "case": case,
+                "case_id": case,
                 "source": "example",
             },
             embedding=list(base_vector),
@@ -1647,10 +1647,10 @@ class TestPgVectorClient:
         deleted_chunk = Chunk(
             content="Vector candidate soft deleted",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": deleted_hash,
                 "external_id": "deleted-doc",
-                "case": case,
+                "case_id": case,
                 "source": "example",
                 "deleted_at": "2024-01-01T00:00:00Z",
             },
@@ -1663,7 +1663,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "   ",
             tenant_id=tenant,
-            filters={"case": case},
+            filters={"case_id": case},
             top_k=5,
             alpha=1.0,
             min_sim=0.0,
@@ -1765,9 +1765,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Trigram limit example",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
-                "case": "case-a",
+                "case_id": "case-a",
                 "source": "example",
             },
             embedding=[0.12] + [0.0] * (vector_client.get_embedding_dim() - 1),
@@ -1778,7 +1778,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "Trigram limit example",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 trgm_limit=0.42,
                 top_k=3,
             )
@@ -1798,9 +1798,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Lexical fallback candidate",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
-                "case": "case-b",
+                "case_id": "case-b",
                 "source": "example",
             },
             embedding=[0.4] + [0.0] * (vector_client.get_embedding_dim() - 1),
@@ -1811,7 +1811,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "Completely different query",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 alpha=0.0,
                 trgm_limit=1.0,
                 top_k=2,
@@ -2027,7 +2027,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "Linear score",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=1,
             alpha=1.0,
         )

--- a/ai_core/tests/test_vector_pg_integration.py
+++ b/ai_core/tests/test_vector_pg_integration.py
@@ -65,7 +65,7 @@ def test_router_roundtrip_with_pgvector_backend(monkeypatch) -> None:
         )
         assert len(results) == len(tenant_chunks)
         assert len(results) <= 10
-        assert {chunk.meta.get("tenant") for chunk in results} == {tenant_id}
+        assert {chunk.meta.get("tenant_id") for chunk in results} == {tenant_id}
         assert all("hash" in chunk.meta for chunk in results)
         assert all(0.0 <= chunk.meta.get("score", 0.0) <= 1.0 for chunk in results)
 
@@ -75,7 +75,7 @@ def test_router_roundtrip_with_pgvector_backend(monkeypatch) -> None:
             top_k=25,
         )
         assert len(isolated_results) == len(other_chunks)
-        assert {chunk.meta.get("tenant") for chunk in isolated_results} == {
+        assert {chunk.meta.get("tenant_id") for chunk in isolated_results} == {
             other_tenant_id
         }
 

--- a/ai_core/tests/test_vector_router.py
+++ b/ai_core/tests/test_vector_router.py
@@ -137,11 +137,11 @@ class HybridEnabledStore(VectorStore):
 def router_and_stores() -> tuple[VectorStoreRouter, FakeStore, FakeStore]:
     global_store = FakeStore(
         "global",
-        search_result=[Chunk(content="global", meta={"tenant": "t"})],
+        search_result=[Chunk(content="global", meta={"tenant_id": "t"})],
     )
     silo_store = FakeStore(
         "silo",
-        search_result=[Chunk(content="silo", meta={"tenant": "t"})],
+        search_result=[Chunk(content="silo", meta={"tenant_id": "t"})],
     )
     router = VectorStoreRouter({"global": global_store, "silo": silo_store})
     return router, global_store, silo_store
@@ -261,7 +261,7 @@ def test_router_upsert_delegates_global(
     router_and_stores: tuple[VectorStoreRouter, FakeStore, FakeStore],
 ) -> None:
     router, global_store, silo_store = router_and_stores
-    chunk = Chunk(content="foo", meta={"tenant": "t"})
+    chunk = Chunk(content="foo", meta={"tenant_id": "t"})
     router.upsert_chunks([chunk])
     assert len(global_store.upsert_calls) == 1
     assert global_store.upsert_calls[0] == [chunk]
@@ -347,7 +347,7 @@ def test_router_upsert_respects_expected_tenant(
     router_and_stores: tuple[VectorStoreRouter, FakeStore, FakeStore],
 ) -> None:
     router, global_store, _ = router_and_stores
-    chunk = Chunk(content="foo", meta={"tenant": "t"})
+    chunk = Chunk(content="foo", meta={"tenant_id": "t"})
     router.upsert_chunks([chunk], tenant_id="t")
     assert len(global_store.upsert_calls) == 1
     with pytest.raises(ValueError):
@@ -390,7 +390,7 @@ def test_tenant_client_enforces_tenant_on_upsert(
     chunk = Chunk(content="foo", meta={})
     tenant_client.upsert_chunks([chunk])
     stored = global_store.upsert_calls[-1][0]
-    assert stored.meta["tenant"] == "tenant-456"
+    assert stored.meta["tenant_id"] == "tenant-456"
 
 
 def test_tenant_client_upsert_rejects_foreign_tenant(
@@ -398,7 +398,7 @@ def test_tenant_client_upsert_rejects_foreign_tenant(
 ) -> None:
     router, _, _ = router_and_stores
     tenant_client = router.for_tenant("tenant-789")
-    chunk = Chunk(content="foo", meta={"tenant": "other"})
+    chunk = Chunk(content="foo", meta={"tenant_id": "other"})
     with pytest.raises(ValueError):
         tenant_client.upsert_chunks([chunk])
 
@@ -431,7 +431,7 @@ def test_router_health_check_records_metrics(
 def test_router_hybrid_search_uses_scoped_store() -> None:
     tenant = "tenant-42"
     global_result = HybridSearchResult(
-        chunks=[Chunk(content="global", meta={"tenant": tenant})],
+        chunks=[Chunk(content="global", meta={"tenant_id": tenant})],
         vector_candidates=2,
         lexical_candidates=1,
         fused_candidates=2,
@@ -442,7 +442,7 @@ def test_router_hybrid_search_uses_scoped_store() -> None:
         lex_limit=5,
     )
     silo_result = HybridSearchResult(
-        chunks=[Chunk(content="silo", meta={"tenant": tenant})],
+        chunks=[Chunk(content="silo", meta={"tenant_id": tenant})],
         vector_candidates=1,
         lexical_candidates=1,
         fused_candidates=1,
@@ -490,7 +490,7 @@ def test_router_hybrid_search_uses_scoped_store() -> None:
 def test_router_hybrid_search_defaults_to_active_visibility() -> None:
     tenant = "tenant-vis"
     hybrid_result = HybridSearchResult(
-        chunks=[Chunk(content="doc", meta={"tenant": tenant})],
+        chunks=[Chunk(content="doc", meta={"tenant_id": tenant})],
         vector_candidates=1,
         lexical_candidates=1,
         fused_candidates=1,
@@ -515,7 +515,7 @@ def test_router_hybrid_search_defaults_to_active_visibility() -> None:
 def test_router_hybrid_search_without_visibility_flag_returns_active() -> None:
     tenant = "tenant-default"
     hybrid_result = HybridSearchResult(
-        chunks=[Chunk(content="doc", meta={"tenant": tenant})],
+        chunks=[Chunk(content="doc", meta={"tenant_id": tenant})],
         vector_candidates=1,
         lexical_candidates=1,
         fused_candidates=1,
@@ -540,7 +540,7 @@ def test_router_hybrid_search_without_visibility_flag_returns_active() -> None:
 def test_router_hybrid_search_allows_authorized_visibility() -> None:
     tenant = "tenant-auth"
     hybrid_result = HybridSearchResult(
-        chunks=[Chunk(content="doc", meta={"tenant": tenant})],
+        chunks=[Chunk(content="doc", meta={"tenant_id": tenant})],
         vector_candidates=1,
         lexical_candidates=0,
         fused_candidates=1,
@@ -570,7 +570,7 @@ def test_router_hybrid_search_allows_authorized_visibility() -> None:
 def test_router_hybrid_search_emits_retrieval_span(monkeypatch) -> None:
     tenant = "tenant-span"
     hybrid_result = HybridSearchResult(
-        chunks=[Chunk(content="doc", meta={"tenant": tenant})],
+        chunks=[Chunk(content="doc", meta={"tenant_id": tenant})],
         vector_candidates=2,
         lexical_candidates=0,
         fused_candidates=2,
@@ -609,7 +609,7 @@ def test_router_hybrid_search_emits_retrieval_span(monkeypatch) -> None:
 
 def test_router_hybrid_search_falls_back_when_not_supported() -> None:
     tenant = "tenant-99"
-    fallback_chunks = [Chunk(content="fallback", meta={"tenant": tenant})]
+    fallback_chunks = [Chunk(content="fallback", meta={"tenant_id": tenant})]
     store = FakeStore("global", search_result=fallback_chunks)
     router = VectorStoreRouter({"global": store})
 
@@ -630,7 +630,7 @@ def test_router_hybrid_search_rejects_small_candidate_pool(
 ) -> None:
     tenant = "tenant-10"
     store = FakeStore(
-        "global", search_result=[Chunk(content="x", meta={"tenant": tenant})]
+        "global", search_result=[Chunk(content="x", meta={"tenant_id": tenant})]
     )
     router = VectorStoreRouter({"global": store})
 
@@ -663,7 +663,7 @@ def test_router_hybrid_search_normalizes_small_candidate_pool(
 ) -> None:
     tenant = "tenant-11"
     hybrid_result = HybridSearchResult(
-        chunks=[Chunk(content="normalized", meta={"tenant": tenant})],
+        chunks=[Chunk(content="normalized", meta={"tenant_id": tenant})],
         vector_candidates=1,
         lexical_candidates=1,
         fused_candidates=1,
@@ -719,7 +719,7 @@ def test_router_logs_warning_when_hybrid_returns_none(
 
     store = _NullHybridStore(
         "global",
-        search_result=[Chunk(content="fallback", meta={"tenant": tenant})],
+        search_result=[Chunk(content="fallback", meta={"tenant_id": tenant})],
     )
     router = VectorStoreRouter({"global": store})
 

--- a/ai_core/tests/test_views.py
+++ b/ai_core/tests/test_views.py
@@ -166,7 +166,7 @@ def test_tenant_schema_header_match_allows_request(
     assert resp.status_code == 200
     assert resp[X_TENANT_ID_HEADER] == "tenant-header"
     assert resp[X_CASE_ID_HEADER] == "c"
-    assert resp.json()["tenant"] == "tenant-header"
+    assert resp.json()["tenant_id"] == "tenant-header"
     assert seen["tenant"] == "tenant-header"
 
 
@@ -236,12 +236,12 @@ def test_intake_persists_state_and_headers(
     assert resp[X_CASE_ID_HEADER] == "case-123"
     assert resp[X_TENANT_ID_HEADER] == tenant_header
     assert X_KEY_ALIAS_HEADER not in resp
-    assert resp.json()["tenant"] == tenant_header
+    assert resp.json()["tenant_id"] == tenant_header
 
     state = object_store.read_json(f"{tenant_header}/case-123/state.json")
-    assert state["meta"]["tenant"] == tenant_header
+    assert state["meta"]["tenant_id"] == tenant_header
     assert state["meta"]["tenant_schema"] == test_tenant_schema_name
-    assert state["meta"]["case"] == "case-123"
+    assert state["meta"]["case_id"] == "case-123"
 
 
 @pytest.mark.django_db
@@ -318,8 +318,8 @@ def test_request_logging_context_includes_metadata(monkeypatch, tmp_path):
         def run(self, state, meta):
             context = common_logging.get_log_context()
             assert context["trace_id"] == meta["trace_id"]
-            assert context["case_id"] == meta["case"]
-            assert context["tenant"] == meta["tenant"]
+            assert context["case_id"] == meta["case_id"]
+            assert context["tenant"] == meta["tenant_id"]
             assert context.get("key_alias") == meta.get("key_alias")
             logger.info("graph-run")
             return state, {"ok": True}

--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -297,9 +297,9 @@ def _prepare_request(request: Request):
     trace_id = uuid4().hex
     assert_case_active(tenant_id, case_id)
     meta = {
-        "tenant": tenant_id,
+        "tenant_id": tenant_id,
         "tenant_schema": tenant_schema,
-        "case": case_id,
+        "case_id": case_id,
         "trace_id": trace_id,
     }
     if key_alias:
@@ -383,8 +383,6 @@ def _run_graph(request: Request, graph_runner: GraphRunner) -> Response:
     merged_state = merge_state(state, incoming_state)
 
     runner_meta = dict(normalized_meta)
-    runner_meta["tenant"] = normalized_meta["tenant_id"]
-    runner_meta["case"] = normalized_meta["case_id"]
     if normalized_meta.get("tenant_schema"):
         runner_meta["tenant_schema"] = normalized_meta["tenant_schema"]
     if normalized_meta.get("key_alias"):
@@ -464,8 +462,8 @@ INTAKE_RESPONSE_EXAMPLE = OpenApiExample(
     description="Echoes the tenant metadata after the intake step persisted the workflow.",
     value={
         "received": True,
-        "tenant": "acme",
-        "case": "crm-7421",
+        "tenant_id": "acme",
+        "case_id": "crm-7421",
         "idempotent": False,
     },
     response_only=True,
@@ -1104,8 +1102,8 @@ class RagUploadView(APIView):
             safe_name = object_store.safe_filename("upload.bin")
 
         try:
-            tenant_segment = object_store.sanitize_identifier(meta["tenant"])
-            case_segment = object_store.sanitize_identifier(meta["case"])
+            tenant_segment = object_store.sanitize_identifier(meta["tenant_id"])
+            case_segment = object_store.sanitize_identifier(meta["case_id"])
         except ValueError:
             return _error_response(
                 "Request metadata was invalid.",
@@ -1215,7 +1213,7 @@ class RagIngestionRunView(APIView):
         queued_at = timezone.now().isoformat()
 
         valid_document_ids, invalid_document_ids = partition_document_ids(
-            meta["tenant"], meta["case"], normalized_document_ids
+            meta["tenant_id"], meta["case_id"], normalized_document_ids
         )
 
         # Always enqueue the task. If at least one valid ID is known, only
@@ -1226,8 +1224,8 @@ class RagIngestionRunView(APIView):
             valid_document_ids if valid_document_ids else normalized_document_ids
         )
         run_ingestion.delay(
-            meta["tenant"],
-            meta["case"],
+            meta["tenant_id"],
+            meta["case_id"],
             to_dispatch,
             resolved_profile_id,
             tenant_schema=meta["tenant_schema"],
@@ -1355,7 +1353,7 @@ class RagHardDeleteAdminView(APIView):
             "idempotent": idempotent,
         }
 
-        meta = {"trace_id": trace_id, "tenant": tenant_id}
+        meta = {"trace_id": trace_id, "tenant_id": tenant_id}
         response = Response(response_payload, status=status.HTTP_202_ACCEPTED)
         return apply_std_headers(response, meta)
 

--- a/common/celery.py
+++ b/common/celery.py
@@ -100,11 +100,11 @@ class ContextTask(Task):
         if trace_id:
             context["trace_id"] = self._normalize(trace_id)
 
-        case = meta.get("case_id") or meta.get("case")
+        case = meta.get("case_id")
         if case:
             context["case_id"] = self._normalize(case)
 
-        tenant = meta.get("tenant")
+        tenant = meta.get("tenant_id")
         if tenant:
             context["tenant"] = self._normalize(tenant)
 

--- a/noesis2/api/serializers.py
+++ b/noesis2/api/serializers.py
@@ -39,8 +39,8 @@ class IntakeResponseSerializer(IdempotentResponseSerializer):
     """Successful response returned by the agent intake endpoint."""
 
     received = serializers.BooleanField()
-    tenant = serializers.CharField()
-    case = serializers.CharField()
+    tenant_id = serializers.CharField()
+    case_id = serializers.CharField()
 
 
 class ScopeResponseSerializer(IdempotentResponseSerializer):

--- a/noesis2/tests/test_api_schema.py
+++ b/noesis2/tests/test_api_schema.py
@@ -283,8 +283,8 @@ def test_ai_core_endpoints_expose_serializers():
         "application/json"
     ]["schema"]["$ref"]
     _, intake_response_component = _extract_component(schema, intake_response_ref)
-    assert "tenant" in intake_response_component["properties"]
-    assert intake_response_component["properties"]["tenant"]["type"] == "string"
+    assert "tenant_id" in intake_response_component["properties"]
+    assert intake_response_component["properties"]["tenant_id"]["type"] == "string"
     assert intake_response_component["properties"]["idempotent"]["type"] == "boolean"
     intake_request_examples = intake_operation["requestBody"]["content"][
         "application/json"
@@ -297,7 +297,7 @@ def test_ai_core_endpoints_expose_serializers():
         "application/json"
     ].get("examples", {})
     assert any(
-        example.get("value", {}).get("tenant") == "acme"
+        example.get("value", {}).get("tenant_id") == "acme"
         for example in intake_response_examples.values()
     )
     assert any(

--- a/tests/rag/test_vector_client.py
+++ b/tests/rag/test_vector_client.py
@@ -196,7 +196,7 @@ def test_replace_chunks_normalises_embeddings(monkeypatch):
             "chunks": [
                 Chunk(
                     content="hello world",
-                    meta={"tenant": tenant, "hash": "hash-1", "source": "unit-test"},
+                    meta={"tenant_id": tenant, "hash": "hash-1", "source": "unit-test"},
                     embedding=[3.0, 4.0],
                 )
             ],
@@ -263,7 +263,7 @@ def test_hybrid_search_returns_vector_hits_with_normalised_query(monkeypatch):
     vector_row = (
         "chunk-vector",
         "vector candidate",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-vector",
         "doc-vector",
         0.12,
@@ -284,7 +284,7 @@ def test_hybrid_search_returns_vector_hits_with_normalised_query(monkeypatch):
     result = client.hybrid_search(
         "vector search",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         alpha=1.0,
         min_sim=0.0,
         top_k=1,
@@ -306,7 +306,7 @@ def test_trgm_limit_is_applied_and_yields_lexical_candidates(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.134,
@@ -323,7 +323,7 @@ def test_trgm_limit_is_applied_and_yields_lexical_candidates(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.01,
             top_k=3,
@@ -346,7 +346,7 @@ def test_lexical_fallback_populates_rows(monkeypatch):
     lexical_row = (
         "chunk-fallback",
         "ZEBRAGURKEN",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-fallback",
         "doc-fallback",
         0.096,
@@ -369,7 +369,7 @@ def test_lexical_fallback_populates_rows(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -400,7 +400,7 @@ def test_explicit_trgm_limit_fallback_uses_requested_threshold(monkeypatch):
     lexical_row = (
         "chunk-fallback",  # noqa: S105 - test data
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-fallback",
         "doc-fallback",
         0.111,
@@ -419,7 +419,7 @@ def test_explicit_trgm_limit_fallback_uses_requested_threshold(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             trgm_limit=0.05,
             alpha=0.0,
             min_sim=0.0,
@@ -455,7 +455,7 @@ def test_applies_set_limit_and_logs_applied_value(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.134,
@@ -473,7 +473,7 @@ def test_applies_set_limit_and_logs_applied_value(monkeypatch):
         client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             trgm_limit=0.05,
             alpha=0.0,
             min_sim=0.0,
@@ -500,7 +500,7 @@ def test_row_shape_mismatch_does_not_crash(monkeypatch):
     def _fake_run(_fn, *, op_name: str):
         # Return a vector row with only 5 columns to trigger padding
         return (
-            [("chunk-5", "text", {"tenant": tenant}, "hash-5", "doc-5")],
+            [("chunk-5", "text", {"tenant_id": tenant}, "hash-5", "doc-5")],
             [],
             1.2,
         )
@@ -512,7 +512,7 @@ def test_row_shape_mismatch_does_not_crash(monkeypatch):
         result = client.hybrid_search(
             "shape mismatch",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
 
@@ -534,7 +534,7 @@ def test_truncated_vector_row_populates_metadata(monkeypatch):
     truncated_row = (
         "chunk-short",
         "truncated text",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-short",
         "doc-short",
     )
@@ -547,13 +547,13 @@ def test_truncated_vector_row_populates_metadata(monkeypatch):
     result = client.hybrid_search(
         "truncate me",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         top_k=1,
     )
 
     assert len(result.chunks) == 1
     meta = result.chunks[0].meta
-    assert meta.get("tenant") == tenant
+    assert meta.get("tenant_id") == tenant
     assert meta.get("hash") == "hash-short"
     assert meta.get("id") == "doc-short"
     assert meta.get("vscore") == pytest.approx(0.0)
@@ -572,7 +572,7 @@ def test_lexical_only_scoring(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant, "case": "c1"},
+        {"tenant_id": tenant, "case_id": "c1"},
         "hash-lex",
         "doc-lex",
         0.13,
@@ -587,7 +587,7 @@ def test_lexical_only_scoring(monkeypatch):
         "only lexical",
         tenant_id=tenant,
         case_id="c1",
-        filters={"case": "c1"},
+        filters={"case_id": "c1"},
         top_k=1,
         alpha=0.0,
         min_sim=0.01,
@@ -612,7 +612,7 @@ def test_lexical_only_respects_min_sim_with_alpha(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.2,
@@ -626,7 +626,7 @@ def test_lexical_only_respects_min_sim_with_alpha(monkeypatch):
     result = client.hybrid_search(
         "only lexical",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         top_k=1,
         alpha=0.7,
         min_sim=0.15,
@@ -648,7 +648,7 @@ def test_hybrid_search_clamps_candidate_limits(monkeypatch):
     lexical_row = (
         "chunk-clamped",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-clamped",
         "doc-clamped",
         0.5,
@@ -664,7 +664,7 @@ def test_hybrid_search_clamps_candidate_limits(monkeypatch):
     result = client.hybrid_search(
         "clamp me",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         alpha=0.0,
         min_sim=0.0,
         top_k=10,
@@ -699,7 +699,7 @@ def test_upsert_retries_operational_error_once(monkeypatch):
     chunk = Chunk(
         content="retry me",
         meta={
-            "tenant": tenant,
+            "tenant_id": tenant,
             "hash": "hash-retry",
             "source": "unit-test",
             "external_id": "doc-retry",
@@ -815,7 +815,7 @@ def test_hybrid_search_recovers_when_vector_query_fails(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.42,
@@ -854,7 +854,7 @@ def test_hybrid_search_recovers_when_vector_query_fails(monkeypatch):
         result = client.hybrid_search(
             "vector fails",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -881,7 +881,7 @@ def test_hybrid_search_returns_vector_results_when_lexical_fails(monkeypatch):
     vector_row = (
         "chunk-vec",
         "vector",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-vec",
         "doc-vec",
         0.15,
@@ -923,7 +923,7 @@ def test_hybrid_search_returns_vector_results_when_lexical_fails(monkeypatch):
         result = client.hybrid_search(
             "lexical fails",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -987,7 +987,7 @@ def test_hybrid_search_raises_when_vector_and_lexical_fail(monkeypatch):
         client.hybrid_search(
             "both fail",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -1056,7 +1056,7 @@ def _insert_active_and_soft_deleted_documents(
                 0,
                 shared_text,
                 3,
-                Json({"tenant": tenant, "case": "alpha"}),
+                Json({"tenant_id": tenant, "case_id": "alpha"}),
             ),
         )
         cur.execute(
@@ -1072,8 +1072,8 @@ def _insert_active_and_soft_deleted_documents(
                 3,
                 Json(
                     {
-                        "tenant": tenant,
-                        "case": "alpha",
+                        "tenant_id": tenant,
+                        "case_id": "alpha",
                         "deleted_at": timestamp.isoformat(),
                     }
                 ),
@@ -1095,7 +1095,7 @@ def test_hybrid_search_filters_soft_deleted_documents():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1118,7 +1118,7 @@ def test_hybrid_search_rejects_visibility_filter_override_without_flag():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha", "visibility": "deleted"},
+        filters={"case_id": "alpha", "visibility": "deleted"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1140,7 +1140,7 @@ def test_hybrid_search_returns_deleted_with_default_override():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1166,7 +1166,7 @@ def test_hybrid_search_returns_all_with_default_override():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,


### PR DESCRIPTION
## Summary
- replace tenant/case metadata usage with canonical tenant_id/case_id across AI Core request handling, ingestion tasks, and vector components
- update middleware, serializers, and schema examples to emit the new metadata headers and fields consistently
- adjust tests and fixtures to cover the renamed metadata keys end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6162a6318832b8383d33665c57e98