### PR TITLE
Refactor metadata keys to canonical tenant and case ids

### DIFF
--- a/ai_core/graphs/info_intake.py
+++ b/ai_core/graphs/info_intake.py
@@ -11,7 +11,7 @@ def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
     state:
         Mutable workflow state.
     meta:
-        Context containing ``tenant``, ``case`` and ``trace_id``.
+        Context containing ``tenant_id``, ``case_id`` and ``trace_id``.
 
     Returns
     -------
@@ -23,7 +23,7 @@ def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
     new_state.setdefault("meta", meta)
     result = {
         "received": True,
-        "tenant": meta.get("tenant"),
-        "case": meta.get("case"),
+        "tenant_id": meta.get("tenant_id"),
+        "case_id": meta.get("case_id"),
     }
     return new_state, result

--- a/ai_core/graphs/system_description.py
+++ b/ai_core/graphs/system_description.py
@@ -11,6 +11,6 @@ def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
     if missing:
         return new_state, {"skipped": True, "missing": missing}
 
-    description = f"System for tenant {meta.get('tenant')} case {meta.get('case')}"
+    description = f"System for tenant {meta.get('tenant_id')} case {meta.get('case_id')}"
     new_state["description"] = description
     return new_state, {"description": description}

--- a/ai_core/infra/resp.py
+++ b/ai_core/infra/resp.py
@@ -28,8 +28,8 @@ def apply_std_headers(response: HttpResponse, meta: Meta) -> HttpResponse:
 
     header_map = {
         X_TRACE_ID_HEADER: meta.get("trace_id"),
-        X_CASE_ID_HEADER: meta.get("case"),
-        X_TENANT_ID_HEADER: meta.get("tenant"),
+        X_CASE_ID_HEADER: meta.get("case_id"),
+        X_TENANT_ID_HEADER: meta.get("tenant_id"),
         X_KEY_ALIAS_HEADER: meta.get("key_alias"),
         "traceparent": meta.get("traceparent"),
     }

--- a/ai_core/infra/tracing.py
+++ b/ai_core/infra/tracing.py
@@ -138,8 +138,10 @@ def trace(node_name: str) -> Callable[[F], F]:
             start_payload = {
                 "event": "node.start",
                 "node": node_name,
-                "tenant": meta_enriched.get("tenant"),
-                "case": meta_enriched.get("case"),
+                "tenant_id": meta_enriched.get("tenant_id")
+                or meta_enriched.get("tenant"),
+                "case_id": meta_enriched.get("case_id")
+                or meta_enriched.get("case"),
                 "trace_id": meta_enriched.get("trace_id"),
                 "prompt_version": meta_enriched.get("prompt_version"),
                 "ts": start_ts,
@@ -153,8 +155,10 @@ def trace(node_name: str) -> Callable[[F], F]:
                 end_payload = {
                     "event": "node.end",
                     "node": node_name,
-                    "tenant": meta_enriched.get("tenant"),
-                    "case": meta_enriched.get("case"),
+                    "tenant_id": meta_enriched.get("tenant_id")
+                    or meta_enriched.get("tenant"),
+                    "case_id": meta_enriched.get("case_id")
+                    or meta_enriched.get("case"),
                     "trace_id": meta_enriched.get("trace_id"),
                     "prompt_version": meta_enriched.get("prompt_version"),
                     "ts": end_ts,
@@ -171,8 +175,10 @@ def trace(node_name: str) -> Callable[[F], F]:
                         trace_id=str(trace_id),
                         node_name=node_name,
                         metadata={
-                            "tenant": meta_enriched.get("tenant"),
-                            "case": meta_enriched.get("case"),
+                            "tenant_id": meta_enriched.get("tenant_id")
+                            or meta_enriched.get("tenant"),
+                            "case_id": meta_enriched.get("case_id")
+                            or meta_enriched.get("case"),
                             "prompt_version": meta_enriched.get("prompt_version"),
                         },
                     )

--- a/ai_core/ingestion.py
+++ b/ai_core/ingestion.py
@@ -73,6 +73,8 @@ def _resolve_upload(
         fallback = make_fallback_external_id(file_path.name, stat.st_size, prefix)
         metadata["external_id"] = fallback
         sanitized_metadata = dict(metadata)
+        sanitized_metadata.pop("tenant_id", None)
+        sanitized_metadata.pop("case_id", None)
         sanitized_metadata.pop("tenant", None)
         sanitized_metadata.pop("case", None)
         object_store.write_json(
@@ -80,6 +82,8 @@ def _resolve_upload(
         )
         metadata = sanitized_metadata
 
+    metadata.pop("tenant_id", None)
+    metadata.pop("case_id", None)
     metadata.pop("tenant", None)
     metadata.pop("case", None)
 
@@ -300,6 +304,8 @@ def process_document(
         if vector_space_id:
             meta_json["vector_space_id"] = vector_space_id
         sanitized_meta_json = dict(meta_json)
+        sanitized_meta_json.pop("tenant_id", None)
+        sanitized_meta_json.pop("case_id", None)
         sanitized_meta_json.pop("tenant", None)
         sanitized_meta_json.pop("case", None)
         normalized_process = normalise_selector_value(meta_json.get("process"))
@@ -312,7 +318,11 @@ def process_document(
             sanitized_meta_json["doc_class"] = normalized_doc_class
         elif "doc_class" in sanitized_meta_json:
             sanitized_meta_json.pop("doc_class", None)
-        meta = {**sanitized_meta_json, "tenant": tenant, "case": case}
+        meta = {
+            **sanitized_meta_json,
+            "tenant_id": tenant,
+            "case_id": case,
+        }
         if tenant_schema:
             meta["tenant_schema"] = tenant_schema
         if resolved_profile_id:

--- a/ai_core/llm/client.py
+++ b/ai_core/llm/client.py
@@ -82,7 +82,7 @@ def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
     prompt:
         Prompt text which will be PII-masked before sending.
     metadata:
-        Dict containing at least ``tenant``, ``case`` and ``trace_id``.
+        Dict containing at least ``tenant_id``, ``case_id`` and ``trace_id``.
     """
 
     model_id = resolve(label)
@@ -91,8 +91,8 @@ def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
     headers = {"Authorization": f"Bearer {cfg.litellm_api_key}"}
     propagated_headers = {
         X_TRACE_ID_HEADER: metadata.get("trace_id"),
-        X_CASE_ID_HEADER: metadata.get("case"),
-        X_TENANT_ID_HEADER: metadata.get("tenant"),
+        X_CASE_ID_HEADER: metadata.get("case_id") or metadata.get("case"),
+        X_TENANT_ID_HEADER: metadata.get("tenant_id") or metadata.get("tenant"),
     }
     key_alias = metadata.get("key_alias")
     if key_alias:
@@ -105,13 +105,13 @@ def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
 
     max_retries = 3
     prompt_version = metadata.get("prompt_version") or "default"
-    case_id = metadata.get("case") or "unknown-case"
+    case_id = metadata.get("case_id") or metadata.get("case") or "unknown-case"
     idempotency_key = f"{case_id}:{label}:{prompt_version}"
     timeout = cfg.timeouts.get(label, 20)
     log_extra = {
         "trace_id": mask_value(metadata.get("trace_id")),
-        "case_id": mask_value(metadata.get("case")),
-        "tenant": mask_value(metadata.get("tenant")),
+        "case_id": mask_value(metadata.get("case_id") or metadata.get("case")),
+        "tenant_id": mask_value(metadata.get("tenant_id") or metadata.get("tenant")),
         "key_alias": mask_value(metadata.get("key_alias")),
     }
     for attempt in range(max_retries):
@@ -229,8 +229,8 @@ def call(label: str, prompt: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
 
     ledger.record(
         {
-            "tenant": metadata.get("tenant"),
-            "case": metadata.get("case"),
+            "tenant_id": metadata.get("tenant_id") or metadata.get("tenant"),
+            "case_id": metadata.get("case_id") or metadata.get("case"),
             "trace_id": metadata.get("trace_id"),
             "label": label,
             "model": model_id,

--- a/ai_core/middleware/context.py
+++ b/ai_core/middleware/context.py
@@ -76,9 +76,9 @@ class RequestContextMiddleware:
         if span_id:
             response_meta["span_id"] = span_id
         if tenant_id:
-            response_meta["tenant"] = tenant_id
+            response_meta["tenant_id"] = tenant_id
         if case_id:
-            response_meta["case"] = case_id
+            response_meta["case_id"] = case_id
         if key_alias:
             response_meta["key_alias"] = key_alias
         if idempotency_key:

--- a/ai_core/rag/filters.py
+++ b/ai_core/rag/filters.py
@@ -9,8 +9,8 @@ def strict_match(
     - When `tenant` is None, do not filter by tenant.
     - When `case` is None, do not filter by case.
     """
-    if tenant is not None and meta.get("tenant") != tenant:
+    if tenant is not None and meta.get("tenant_id") != tenant:
         return False
-    if case is not None and meta.get("case") != case:
+    if case is not None and meta.get("case_id") != case:
         return False
     return True

--- a/ai_core/rag/vector_store.py
+++ b/ai_core/rag/vector_store.py
@@ -59,7 +59,7 @@ def _emit_retrieval_span(
         return
 
     metadata: dict[str, object | None] = {
-        "tenant": tenant,
+        "tenant_id": tenant,
         "scope": scope,
         "case_id": case_id,
         "process": context.get("process"),
@@ -324,7 +324,7 @@ class VectorStoreRouter:
             logger.debug(
                 "rag.visibility.override_denied",
                 extra={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "requested": requested_visibility.value,
                     "scope": scope,
                 },
@@ -516,7 +516,7 @@ class VectorStoreRouter:
         logger.debug(
             "rag.hybrid.params",
             extra={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "scope": scope,
                 "process": validation_context.get("process"),
                 "doc_class": validation_context.get("doc_class"),
@@ -607,7 +607,7 @@ class VectorStoreRouter:
                 "rag.hybrid.router.no_result",
                 extra={
                     "scope": scope,
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "store": getattr(store, "name", scope),
                 },
             )
@@ -663,7 +663,7 @@ class VectorStoreRouter:
         chunk_list = list(chunks)
         expected_tenant = str(tenant_id).strip() if tenant_id is not None else None
         for chunk in chunk_list:
-            tenant_meta = str(chunk.meta.get("tenant") or "").strip()
+            tenant_meta = str(chunk.meta.get("tenant_id") or "").strip()
             if not tenant_meta:
                 raise ValueError("chunk metadata must include tenant")
             if expected_tenant is not None and tenant_meta != expected_tenant:
@@ -807,7 +807,7 @@ class _TenantScopedClient:
         coerced: list[Chunk] = []
         for chunk in chunk_list:
             meta = dict(chunk.meta)
-            tenant_meta_raw = meta.get("tenant")
+            tenant_meta_raw = meta.get("tenant_id")
             tenant_meta = str(tenant_meta_raw).strip() if tenant_meta_raw else ""
             if tenant_meta and tenant_meta != self._tenant_id:
                 msg = "Chunk tenant '%s' does not match scoped tenant '%s'" % (
@@ -815,7 +815,7 @@ class _TenantScopedClient:
                     self._tenant_id,
                 )
                 raise ValueError(msg)
-            meta["tenant"] = self._tenant_id
+            meta["tenant_id"] = self._tenant_id
             coerced.append(
                 Chunk(content=chunk.content, meta=meta, embedding=chunk.embedding)
             )

--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -35,8 +35,8 @@ logger = get_logger(__name__)
 
 
 def _build_path(meta: Dict[str, str], *parts: str) -> str:
-    tenant = object_store.sanitize_identifier(meta["tenant"])
-    case = object_store.sanitize_identifier(meta["case"])
+    tenant = object_store.sanitize_identifier(meta["tenant_id"])
+    case = object_store.sanitize_identifier(meta["case_id"])
     return "/".join([tenant, case, *parts])
 
 
@@ -379,8 +379,8 @@ def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
             chunk_text = f"{prefix}\n\n{body}" if body else prefix
         normalised = normalise_text(chunk_text)
         chunk_meta = {
-            "tenant": meta["tenant"],
-            "case": meta.get("case"),
+            "tenant_id": meta["tenant_id"],
+            "case_id": meta.get("case_id"),
             "source": text_path,
             "hash": content_hash,
             "external_id": external_id,
@@ -405,8 +405,8 @@ def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
     if not chunks:
         normalised = normalise_text(text)
         chunk_meta = {
-            "tenant": meta["tenant"],
-            "case": meta.get("case"),
+            "tenant_id": meta["tenant_id"],
+            "case_id": meta.get("case_id"),
             "source": text_path,
             "hash": content_hash,
             "external_id": external_id,
@@ -535,13 +535,13 @@ def upsert(
             Chunk(content=ch["content"], meta=ch["meta"], embedding=embedding)
         )
 
-    tenant_id: Optional[str] = meta.get("tenant") if meta else None
+    tenant_id: Optional[str] = meta.get("tenant_id") if meta else None
     if not tenant_id:
         tenant_id = next(
             (
-                str(chunk.meta.get("tenant"))
+                str(chunk.meta.get("tenant_id"))
                 for chunk in chunk_objs
-                if chunk.meta and chunk.meta.get("tenant")
+                if chunk.meta and chunk.meta.get("tenant_id")
             ),
             None,
         )
@@ -549,7 +549,7 @@ def upsert(
         raise ValueError("tenant_id required for upsert")
 
     for chunk in chunk_objs:
-        chunk_tenant = chunk.meta.get("tenant") if chunk.meta else None
+        chunk_tenant = chunk.meta.get("tenant_id") if chunk.meta else None
         if chunk_tenant and str(chunk_tenant) != tenant_id:
             raise ValueError("chunk tenant mismatch")
 

--- a/ai_core/tests/test_graph_retrieval_augmented_generation.py
+++ b/ai_core/tests/test_graph_retrieval_augmented_generation.py
@@ -68,7 +68,7 @@ def test_graph_normalises_tenant_alias() -> None:
         compose_node=_fake_compose,
     )
 
-    meta = {"tenant": "tenant-alias"}
+    meta = {"tenant_id": "tenant-alias"}
     state, result = graph.run({}, meta)
 
     assert meta["tenant_id"] == "tenant-alias"

--- a/ai_core/tests/test_infra.py
+++ b/ai_core/tests/test_infra.py
@@ -38,8 +38,8 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
     resp = HttpResponse("ok", status=200)
     meta = {
         "trace_id": "abc123",
-        "case": "case-1",
-        "tenant": "tenant-1",
+        "case_id": "case-1",
+        "tenant_id": "tenant-1",
         "key_alias": "alias-1",
         "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     }
@@ -55,7 +55,11 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
 
 def test_apply_std_headers_skips_missing_optional_headers():
     resp = HttpResponse("ok", status=200)
-    meta = {"trace_id": "abc123", "case": "case-1", "tenant": "tenant-1"}
+    meta = {
+        "trace_id": "abc123",
+        "case_id": "case-1",
+        "tenant_id": "tenant-1",
+    }
 
     result = apply_std_headers(resp, meta)
 
@@ -67,8 +71,8 @@ def test_apply_std_headers_skips_missing_optional_headers():
 def test_apply_std_headers_ignores_non_success_responses():
     meta = {
         "trace_id": "abc123",
-        "case": "case-1",
-        "tenant": "tenant-1",
+        "case_id": "case-1",
+        "tenant_id": "tenant-1",
         "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     }
 
@@ -116,7 +120,13 @@ def test_trace_logs_locally_when_no_keys(monkeypatch, capsys):
         return "ok"
 
     sample(
-        {}, {"tenant": "t1", "case": "c1", "trace_id": "tid", "prompt_version": "v1"}
+        {},
+        {
+            "tenant_id": "t1",
+            "case_id": "c1",
+            "trace_id": "tid",
+            "prompt_version": "v1",
+        },
     )
     lines = [line for line in capsys.readouterr().out.strip().splitlines() if line]
     assert len(lines) == 2
@@ -143,11 +153,17 @@ def test_trace_sends_to_langfuse(monkeypatch):
         return "ok"
 
     sample(
-        {}, {"tenant": "t1", "case": "c1", "trace_id": "tid", "prompt_version": "v1"}
+        {},
+        {
+            "tenant_id": "t1",
+            "case_id": "c1",
+            "trace_id": "tid",
+            "prompt_version": "v1",
+        },
     )
     assert dispatched[0]["traceId"] == "tid"
     assert dispatched[0]["name"] == "node2"
-    assert dispatched[0]["metadata"]["tenant"] == "t1"
+    assert dispatched[0]["metadata"]["tenant_id"] == "t1"
 
 
 def test_trace_skips_langfuse_without_trace_id(monkeypatch):
@@ -166,7 +182,7 @@ def test_trace_skips_langfuse_without_trace_id(monkeypatch):
     def sample(state, meta):
         return "ok"
 
-    sample({}, {"tenant": "t1", "case": "c1"})
+    sample({}, {"tenant_id": "t1", "case_id": "c1"})
 
     assert dispatched == []
 

--- a/ai_core/tests/test_rag_filters.py
+++ b/ai_core/tests/test_rag_filters.py
@@ -2,15 +2,15 @@ from ai_core.rag.filters import strict_match
 
 
 def test_strict_match_positive():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t1", "c1") is True
 
 
 def test_strict_match_negative():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t1", "c2") is False
 
 
 def test_strict_match_negative_tenant():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t2", "c1") is False

--- a/ai_core/tests/test_tasks.py
+++ b/ai_core/tests/test_tasks.py
@@ -94,7 +94,7 @@ def test_upsert_persists_chunks(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     tenant = str(uuid.uuid4())
     case = str(uuid.uuid4())
-    meta = {"tenant": tenant, "case": case, "external_id": "doc-1"}
+    meta = {"tenant_id": tenant, "case_id": case, "external_id": "doc-1"}
     vector_client.reset_default_client()
 
     raw = tasks.ingest_raw(meta, "doc.txt", b"User 123")
@@ -119,7 +119,7 @@ def test_upsert_persists_chunks(tmp_path, monkeypatch):
 
 def test_upsert_forwards_tenant_schema(monkeypatch):
     meta = {
-        "tenant": "tenant-42",
+        "tenant_id": "tenant-42",
         "tenant_schema": "schema-tenant-42",
     }
 
@@ -127,7 +127,7 @@ def test_upsert_forwards_tenant_schema(monkeypatch):
         {
             "content": "payload",
             "embedding": [0.0],
-            "meta": {"tenant": "tenant-42"},
+            "meta": {"tenant_id": "tenant-42"},
         }
     ]
 
@@ -155,7 +155,7 @@ def test_upsert_forwards_tenant_schema(monkeypatch):
 
 def test_upsert_raises_on_dimension_mismatch(monkeypatch):
     meta = {
-        "tenant": "tenant-42",
+        "tenant_id": "tenant-42",
         "embedding_profile": "standard",
         "vector_space_id": "global",
         "vector_space_dimension": 2,
@@ -167,7 +167,7 @@ def test_upsert_raises_on_dimension_mismatch(monkeypatch):
             "content": "payload",
             "embedding": [0.0],
             "meta": {
-                "tenant": "tenant-42",
+                "tenant_id": "tenant-42",
                 "embedding_profile": "standard",
                 "vector_space_id": "global",
                 "external_id": "doc-1",
@@ -234,8 +234,8 @@ def test_task_logging_context_includes_metadata(monkeypatch, tmp_path, settings)
     with capture_logs() as logs:
         tasks.ingest_raw(
             {
-                "tenant": "tenant-123",
-                "case": "case-456",
+                "tenant_id": "tenant-123",
+                "case_id": "case-456",
                 "trace_id": "trace-7890",
                 "key_alias": "alias-1234",
                 "external_id": "doc-logging",
@@ -258,12 +258,12 @@ def test_task_logging_context_includes_metadata(monkeypatch, tmp_path, settings)
 
 def test_ingest_raw_sanitizes_meta(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    meta = {"tenant": "Tenant Name", "case": "Case*ID", "external_id": "doc-1"}
+    meta = {"tenant_id": "Tenant Name", "case_id": "Case*ID", "external_id": "doc-1"}
 
     result = tasks.ingest_raw(meta, "doc.txt", b"payload")
 
-    safe_tenant = object_store.sanitize_identifier(meta["tenant"])
-    safe_case = object_store.sanitize_identifier(meta["case"])
+    safe_tenant = object_store.sanitize_identifier(meta["tenant_id"])
+    safe_case = object_store.sanitize_identifier(meta["case_id"])
     assert result["path"] == f"{safe_tenant}/{safe_case}/raw/doc.txt"
 
     stored = tmp_path / ".ai_core_store" / safe_tenant / safe_case / "raw" / "doc.txt"
@@ -272,7 +272,7 @@ def test_ingest_raw_sanitizes_meta(tmp_path, monkeypatch):
 
 def test_ingest_raw_rejects_unsafe_meta(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    meta = {"tenant": "tenant/../", "case": "case", "external_id": "doc-unsafe"}
+    meta = {"tenant_id": "tenant/../", "case_id": "case", "external_id": "doc-unsafe"}
 
     original_request = getattr(tasks.ingest_raw, "request", None)
     tasks.ingest_raw.request = SimpleNamespace(headers=None, kwargs=None)

--- a/ai_core/tests/test_vector_client.py
+++ b/ai_core/tests/test_vector_client.py
@@ -68,7 +68,7 @@ class TestPgVectorClient:
                                 "chunk-adaptive",
                                 "Lexical adaptive",
                                 {
-                                    "tenant": tenant,
+                                    "tenant_id": tenant,
                                     "hash": doc_hash,
                                     "external_id": "adaptive-doc",
                                 },
@@ -141,7 +141,7 @@ class TestPgVectorClient:
         client = vector_client.get_default_client()
         chunk = Chunk(
             content="text",
-            meta={"tenant": str(uuid.uuid4()), "external_id": "ext-1"},
+            meta={"tenant_id": str(uuid.uuid4()), "external_id": "ext-1"},
             embedding=[0.0] * vector_client.get_embedding_dim(),
         )
         with pytest.raises(ValueError):
@@ -154,9 +154,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="missing external id",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
-                "case": "case-fallback",
+                "case_id": "case-fallback",
                 "source": "example",
             },
             embedding=[0.25] + [0.0] * (vector_client.get_embedding_dim() - 1),
@@ -168,7 +168,7 @@ class TestPgVectorClient:
         results = client.search(
             "missing external id",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=1,
         )
 
@@ -208,9 +208,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="legacy",
             meta={
-                "tenant": "tenant-1",
+                "tenant_id": "tenant-1",
                 "hash": doc_hash,
-                "case": "c",
+                "case_id": "c",
                 "source": "s",
                 "external_id": "legacy-doc",
             },
@@ -226,13 +226,13 @@ class TestPgVectorClient:
 
         results = client.search(
             "legacy",
-            tenant_id=chunk.meta["tenant"],
-            filters={"case": None},
+            tenant_id=chunk.meta["tenant_id"],
+            filters={"case_id": None},
             top_k=1,
         )
         assert len(results) == 1
         assert histogram.samples
-        assert uuid.UUID(results[0].meta["tenant"])  # tenant ids are normalised
+        assert uuid.UUID(results[0].meta["tenant_id"])  # tenant ids are normalised
         assert 0.0 <= results[0].meta["score"] <= 1.0
         assert results[0].meta.get("hash") == chunk.meta["hash"]
         assert results[0].meta.get("external_id") == "legacy-doc"
@@ -261,7 +261,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="chunk-1",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
                 "source": "s",
                 "external_id": external_id,
@@ -311,7 +311,7 @@ class TestPgVectorClient:
             return Chunk(
                 content=content,
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "hash": doc_hash,
                     "source": "s",
                     "external_id": external_id,
@@ -368,7 +368,7 @@ class TestPgVectorClient:
             return Chunk(
                 content=content,
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "external_id": external_id,
                     "hash": doc_hash,
                     "source": "unit",
@@ -383,7 +383,7 @@ class TestPgVectorClient:
         initial_results = client.search(
             "original",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
         assert len(initial_results) == 1
@@ -397,7 +397,7 @@ class TestPgVectorClient:
         duplicate_results = client.search(
             "original",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
         assert len(duplicate_results) == 1
@@ -411,7 +411,7 @@ class TestPgVectorClient:
         updated_results = client.search(
             "updated",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
         assert len(updated_results) == 1
@@ -437,7 +437,7 @@ class TestPgVectorClient:
             Chunk(
                 content="Result",
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "hash": chunk_hash,
                     "source": "src",
                     "external_id": f"doc-{index}",
@@ -460,7 +460,7 @@ class TestPgVectorClient:
             Chunk(
                 content="Filtered",
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "hash": hashlib.sha256(b"doc-a").hexdigest(),
                     "source": "alpha",
                     "doctype": "contract",
@@ -471,7 +471,7 @@ class TestPgVectorClient:
             Chunk(
                 content="Filtered",
                 meta={
-                    "tenant": tenant,
+                    "tenant_id": tenant,
                     "hash": hashlib.sha256(b"doc-b").hexdigest(),
                     "source": "beta",
                     "doctype": "contract",
@@ -508,7 +508,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Boolean",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": hashlib.sha256(b"doc-bool").hexdigest(),
                 "source": "gamma",
                 "published": True,
@@ -541,7 +541,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Filter tolerant",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": "doc-filter-tolerant",
                 "source": "alpha",
             },
@@ -609,7 +609,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Lexical fallback example",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
                 "source": "lexical",
                 "external_id": "doc-lex",
@@ -642,7 +642,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "Lexical fallback example",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 top_k=3,
                 alpha=0.0,
             )
@@ -651,7 +651,7 @@ class TestPgVectorClient:
         assert result.lexical_candidates >= 1
         assert result.query_embedding_empty is True
         assert counter.value == 1.0
-        assert counter.calls == [{"tenant": tenant}]
+        assert counter.calls == [{"tenant_id": tenant}]
         assert result.chunks
         top_chunk = result.chunks[0]
         assert top_chunk.meta["vscore"] == 0.0
@@ -676,9 +676,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="ZEBRAGURKE",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
-                "case": "lexical-case",
+                "case_id": "lexical-case",
                 "source": "lexical",
                 "external_id": "lex-1",
             },
@@ -694,7 +694,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "ZEBRAGURKE",
             tenant_id=tenant,
-            filters={"case": "lexical-case"},
+            filters={"case_id": "lexical-case"},
             alpha=0.0,
             top_k=1,
         )
@@ -712,7 +712,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Cutoff candidate example",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
                 "source": "cutoff",
                 "external_id": "doc-cutoff",
@@ -739,7 +739,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "candidate cutoff",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
             alpha=0.8,
             min_sim=0.95,
@@ -749,7 +749,7 @@ class TestPgVectorClient:
         assert result.below_cutoff >= 1
         assert result.returned_after_cutoff == 0
         assert result.chunks == []
-        assert cutoff_counter.calls == [{"tenant": tenant}]
+        assert cutoff_counter.calls == [{"tenant_id": tenant}]
         assert cutoff_counter.value == float(result.below_cutoff)
 
     def test_hybrid_search_uses_similarity_fallback_when_trigram_has_no_match(
@@ -761,7 +761,7 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Dies ist ein völlig anderer Inhalt",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
                 "source": "lexical",
                 "external_id": "doc-trigram",
@@ -774,7 +774,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "zzzzzzzz",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 top_k=1,
                 alpha=0.0,
             )
@@ -883,7 +883,7 @@ class TestPgVectorClient:
                                 "chunk-fallback",
                                 "Fallback lexical",
                                 {
-                                    "tenant": tenant,
+                                    "tenant_id": tenant,
                                     "hash": doc_hash,
                                     "external_id": "fallback-doc",
                                 },
@@ -1018,7 +1018,7 @@ class TestPgVectorClient:
                             "chunk-fallback",
                             "Lexical fallback",
                             {
-                                "tenant": tenant,
+                                "tenant_id": tenant,
                                 "hash": doc_hash,
                                 "external_id": "fallback-doc",
                             },
@@ -1129,7 +1129,7 @@ class TestPgVectorClient:
                             "chunk-direct",
                             "Direct lexical",
                             {
-                                "tenant": tenant,
+                                "tenant_id": tenant,
                                 "hash": doc_hash,
                                 "external_id": "direct-doc",
                             },
@@ -1242,7 +1242,7 @@ class TestPgVectorClient:
                     (
                         "chunk-1",
                         "Vector mismatch",
-                        {"tenant": tenant},
+                        {"tenant_id": tenant},
                         "hash-1",
                         "doc-1",
                     )
@@ -1272,7 +1272,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "shape mismatch",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 top_k=3,
             )
 
@@ -1299,7 +1299,7 @@ class TestPgVectorClient:
                     (
                         "chunk-meta",
                         "Vector metadata",
-                        {"tenant": tenant},
+                        {"tenant_id": tenant},
                         "hash-meta",
                         "doc-meta",
                     )
@@ -1318,7 +1318,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "vector meta",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=1,
         )
 
@@ -1392,7 +1392,7 @@ class TestPgVectorClient:
             (
                 "lex-chunk",
                 "Lexical fallback",
-                {"tenant": tenant},
+                {"tenant_id": tenant},
                 "lex-hash",
                 "lex-doc",
                 0.9,
@@ -1418,7 +1418,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "lexical only",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=2,
         )
 
@@ -1482,7 +1482,7 @@ class TestPgVectorClient:
                         (
                             "vector-chunk",
                             "Vector candidate",
-                            {"tenant": tenant_id},
+                            {"tenant_id": tenant_id},
                             doc_hash,
                             doc_id,
                             0.12,
@@ -1560,7 +1560,7 @@ class TestPgVectorClient:
                     (
                         "chunk-cutoff",
                         "Too weak",
-                        {"tenant": tenant},
+                        {"tenant_id": tenant},
                         "hash-cutoff",
                         "doc-cutoff",
                         0.95,
@@ -1600,14 +1600,14 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "min sim cutoff",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=1,
             min_sim=0.8,
         )
 
         assert result.below_cutoff == 1
         assert result.chunks == []
-        assert cutoff_counter.calls == [{"tenant": tenant}]
+        assert cutoff_counter.calls == [{"tenant_id": tenant}]
         assert cutoff_counter.value == 1.0
 
     def test_hybrid_search_deleted_visibility_count_regression(
@@ -1636,10 +1636,10 @@ class TestPgVectorClient:
         active_chunk = Chunk(
             content="Vector candidate still active",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": active_hash,
                 "external_id": "active-doc",
-                "case": case,
+                "case_id": case,
                 "source": "example",
             },
             embedding=list(base_vector),
@@ -1647,10 +1647,10 @@ class TestPgVectorClient:
         deleted_chunk = Chunk(
             content="Vector candidate soft deleted",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": deleted_hash,
                 "external_id": "deleted-doc",
-                "case": case,
+                "case_id": case,
                 "source": "example",
                 "deleted_at": "2024-01-01T00:00:00Z",
             },
@@ -1663,7 +1663,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "   ",
             tenant_id=tenant,
-            filters={"case": case},
+            filters={"case_id": case},
             top_k=5,
             alpha=1.0,
             min_sim=0.0,
@@ -1720,7 +1720,7 @@ class TestPgVectorClient:
                     (
                         "chunk-strict",
                         "Strict candidate",
-                        {"tenant": tenant},
+                        {"tenant_id": tenant},
                         "hash-strict",
                         "doc-1",
                         0.3,
@@ -1765,9 +1765,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Trigram limit example",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
-                "case": "case-a",
+                "case_id": "case-a",
                 "source": "example",
             },
             embedding=[0.12] + [0.0] * (vector_client.get_embedding_dim() - 1),
@@ -1778,7 +1778,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "Trigram limit example",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 trgm_limit=0.42,
                 top_k=3,
             )
@@ -1798,9 +1798,9 @@ class TestPgVectorClient:
         chunk = Chunk(
             content="Lexical fallback candidate",
             meta={
-                "tenant": tenant,
+                "tenant_id": tenant,
                 "hash": doc_hash,
-                "case": "case-b",
+                "case_id": "case-b",
                 "source": "example",
             },
             embedding=[0.4] + [0.0] * (vector_client.get_embedding_dim() - 1),
@@ -1811,7 +1811,7 @@ class TestPgVectorClient:
             result = client.hybrid_search(
                 "Completely different query",
                 tenant_id=tenant,
-                filters={"case": None},
+                filters={"case_id": None},
                 alpha=0.0,
                 trgm_limit=1.0,
                 top_k=2,
@@ -1835,7 +1835,7 @@ class TestPgVectorClient:
                     (
                         "chunk-1",
                         "Vector strong",
-                        {"tenant": tenant, "case": "case-1"},
+                        {"tenant_id": tenant, "case_id": "case-1"},
                         "hash-1",
                         "doc-1",
                         0.25,
@@ -1843,7 +1843,7 @@ class TestPgVectorClient:
                     (
                         "chunk-2",
                         "Vector weak",
-                        {"tenant": tenant, "case": "case-1"},
+                        {"tenant_id": tenant, "case_id": "case-1"},
                         "hash-2",
                         "doc-2",
                         0.9,
@@ -1853,7 +1853,7 @@ class TestPgVectorClient:
                     (
                         "chunk-1",
                         "Vector strong",
-                        {"tenant": tenant, "case": "case-1"},
+                        {"tenant_id": tenant, "case_id": "case-1"},
                         "hash-1",
                         "doc-1",
                         0.8,
@@ -1861,7 +1861,7 @@ class TestPgVectorClient:
                     (
                         "chunk-2",
                         "Vector weak",
-                        {"tenant": tenant, "case": "case-1"},
+                        {"tenant_id": tenant, "case_id": "case-1"},
                         "hash-2",
                         "doc-2",
                         0.3,
@@ -1913,7 +1913,7 @@ class TestPgVectorClient:
         assert top_meta["score"] == pytest.approx(top_meta["vscore"])
         assert result.below_cutoff == 1
         assert result.returned_after_cutoff == 1
-        assert cutoff_counter.calls == [{"tenant": tenant}]
+        assert cutoff_counter.calls == [{"tenant_id": tenant}]
         assert cutoff_counter.value == 1.0
 
     def test_hybrid_search_score_fusion_alpha_zero_returned_after_cutoff(
@@ -1928,7 +1928,7 @@ class TestPgVectorClient:
                     (
                         "chunk-1",
                         "Lexical strong",
-                        {"tenant": tenant, "case": "case-2"},
+                        {"tenant_id": tenant, "case_id": "case-2"},
                         "hash-1",
                         "doc-1",
                         0.4,
@@ -1936,7 +1936,7 @@ class TestPgVectorClient:
                     (
                         "chunk-2",
                         "Lexical medium",
-                        {"tenant": tenant, "case": "case-2"},
+                        {"tenant_id": tenant, "case_id": "case-2"},
                         "hash-2",
                         "doc-2",
                         0.5,
@@ -1946,7 +1946,7 @@ class TestPgVectorClient:
                     (
                         "chunk-1",
                         "Lexical strong",
-                        {"tenant": tenant, "case": "case-2"},
+                        {"tenant_id": tenant, "case_id": "case-2"},
                         "hash-1",
                         "doc-1",
                         0.9,
@@ -1954,7 +1954,7 @@ class TestPgVectorClient:
                     (
                         "chunk-2",
                         "Lexical medium",
-                        {"tenant": tenant, "case": "case-2"},
+                        {"tenant_id": tenant, "case_id": "case-2"},
                         "hash-2",
                         "doc-2",
                         0.5,
@@ -2002,7 +2002,7 @@ class TestPgVectorClient:
                     (
                         "chunk-linear",
                         "Linear score",
-                        {"tenant": tenant},
+                        {"tenant_id": tenant},
                         "hash-linear",
                         "doc-linear",
                         0.25,
@@ -2027,7 +2027,7 @@ class TestPgVectorClient:
         result = client.hybrid_search(
             "Linear score",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=1,
             alpha=1.0,
         )

--- a/ai_core/tests/test_vector_pg_integration.py
+++ b/ai_core/tests/test_vector_pg_integration.py
@@ -21,7 +21,7 @@ def _make_chunk(tenant_id: str, ordinal: int, *, hash_id: str) -> Chunk:
     return Chunk(
         content=f"tenant-{tenant_id}-chunk-{ordinal}",
         meta={
-            "tenant": tenant_id,
+            "tenant_id": tenant_id,
             "hash": hash_id,
             "source": "integration-test",
             "external_id": f"{hash_id}-external",
@@ -65,7 +65,7 @@ def test_router_roundtrip_with_pgvector_backend(monkeypatch) -> None:
         )
         assert len(results) == len(tenant_chunks)
         assert len(results) <= 10
-        assert {chunk.meta.get("tenant") for chunk in results} == {tenant_id}
+        assert {chunk.meta.get("tenant_id") for chunk in results} == {tenant_id}
         assert all("hash" in chunk.meta for chunk in results)
         assert all(0.0 <= chunk.meta.get("score", 0.0) <= 1.0 for chunk in results)
 
@@ -75,7 +75,7 @@ def test_router_roundtrip_with_pgvector_backend(monkeypatch) -> None:
             top_k=25,
         )
         assert len(isolated_results) == len(other_chunks)
-        assert {chunk.meta.get("tenant") for chunk in isolated_results} == {
+        assert {chunk.meta.get("tenant_id") for chunk in isolated_results} == {
             other_tenant_id
         }
 

--- a/ai_core/tests/test_views.py
+++ b/ai_core/tests/test_views.py
@@ -169,7 +169,7 @@ def test_tenant_schema_header_match_allows_request(
     assert resp.status_code == 200
     assert resp[X_TENANT_ID_HEADER] == "tenant-header"
     assert resp[X_CASE_ID_HEADER] == "c"
-    assert resp.json()["tenant"] == "tenant-header"
+    assert resp.json()["tenant_id"] == "tenant-header"
     assert seen["tenant"] == "tenant-header"
 
 
@@ -239,12 +239,12 @@ def test_intake_persists_state_and_headers(
     assert resp[X_CASE_ID_HEADER] == "case-123"
     assert resp[X_TENANT_ID_HEADER] == tenant_header
     assert X_KEY_ALIAS_HEADER not in resp
-    assert resp.json()["tenant"] == tenant_header
+    assert resp.json()["tenant_id"] == tenant_header
 
     state = object_store.read_json(f"{tenant_header}/case-123/state.json")
-    assert state["meta"]["tenant"] == tenant_header
+    assert state["meta"]["tenant_id"] == tenant_header
     assert state["meta"]["tenant_schema"] == test_tenant_schema_name
-    assert state["meta"]["case"] == "case-123"
+    assert state["meta"]["case_id"] == "case-123"
 
 
 @pytest.mark.django_db
@@ -321,8 +321,8 @@ def test_request_logging_context_includes_metadata(monkeypatch, tmp_path):
         def run(self, state, meta):
             context = common_logging.get_log_context()
             assert context["trace_id"] == meta["trace_id"]
-            assert context["case_id"] == meta["case"]
-            assert context["tenant"] == meta["tenant"]
+            assert context["case_id"] == meta["case_id"]
+            assert context["tenant"] == meta["tenant_id"]
             assert context.get("key_alias") == meta.get("key_alias")
             logger.info("graph-run")
             return state, {"ok": True}

--- a/ai_core/views.py
+++ b/ai_core/views.py
@@ -298,9 +298,9 @@ def _prepare_request(request: Request):
     trace_id = uuid4().hex
     assert_case_active(tenant_id, case_id)
     meta = {
-        "tenant": tenant_id,
+        "tenant_id": tenant_id,
         "tenant_schema": tenant_schema,
-        "case": case_id,
+        "case_id": case_id,
         "trace_id": trace_id,
     }
     if key_alias:
@@ -398,8 +398,8 @@ def _run_graph(request: Request, graph_runner: GraphRunner) -> Response:
     merged_state = merge_state(state, incoming_state)
 
     runner_meta = dict(normalized_meta)
-    runner_meta["tenant"] = normalized_meta["tenant_id"]
-    runner_meta["case"] = normalized_meta["case_id"]
+    runner_meta["tenant_id"] = normalized_meta["tenant_id"]
+    runner_meta["case_id"] = normalized_meta["case_id"]
     if normalized_meta.get("tenant_schema"):
         runner_meta["tenant_schema"] = normalized_meta["tenant_schema"]
     if normalized_meta.get("key_alias"):
@@ -1119,8 +1119,8 @@ class RagUploadView(APIView):
             safe_name = object_store.safe_filename("upload.bin")
 
         try:
-            tenant_segment = object_store.sanitize_identifier(meta["tenant"])
-            case_segment = object_store.sanitize_identifier(meta["case"])
+            tenant_segment = object_store.sanitize_identifier(meta["tenant_id"])
+            case_segment = object_store.sanitize_identifier(meta["case_id"])
         except ValueError:
             return _error_response(
                 "Request metadata was invalid.",
@@ -1230,7 +1230,7 @@ class RagIngestionRunView(APIView):
         queued_at = timezone.now().isoformat()
 
         valid_document_ids, invalid_document_ids = partition_document_ids(
-            meta["tenant"], meta["case"], normalized_document_ids
+            meta["tenant_id"], meta["case_id"], normalized_document_ids
         )
 
         # Always enqueue the task. If at least one valid ID is known, only
@@ -1241,8 +1241,8 @@ class RagIngestionRunView(APIView):
             valid_document_ids if valid_document_ids else normalized_document_ids
         )
         run_ingestion.delay(
-            meta["tenant"],
-            meta["case"],
+            meta["tenant_id"],
+            meta["case_id"],
             to_dispatch,
             resolved_profile_id,
             tenant_schema=meta["tenant_schema"],
@@ -1370,7 +1370,7 @@ class RagHardDeleteAdminView(APIView):
             "idempotent": idempotent,
         }
 
-        meta = {"trace_id": trace_id, "tenant": tenant_id}
+        meta = {"trace_id": trace_id, "tenant_id": tenant_id}
         response = Response(response_payload, status=status.HTTP_202_ACCEPTED)
         return apply_std_headers(response, meta)
 

--- a/common/celery.py
+++ b/common/celery.py
@@ -108,7 +108,7 @@ class ContextTask(Task):
         if case:
             context["case_id"] = self._normalize(case)
 
-        tenant = meta.get("tenant")
+        tenant = meta.get("tenant_id") or meta.get("tenant")
         if tenant:
             context["tenant"] = self._normalize(tenant)
 

--- a/tests/chaos/ingestion_faults.py
+++ b/tests/chaos/ingestion_faults.py
@@ -28,7 +28,11 @@ def test_ingestion_embed_retry_profile_and_dead_letter(monkeypatch):
     expected_delays = [30, 60, 120, 240, 300]
     recorded_delays: list[int | None] = []
     observed_events: list[dict[str, object]] = []
-    meta = {"tenant": "tenant-chaos", "case": "case-chaos", "trace_id": "trace-chaos"}
+    meta = {
+        "tenant_id": "tenant-chaos",
+        "case_id": "case-chaos",
+        "trace_id": "trace-chaos",
+    }
     request = SimpleNamespace(retries=0, headers={}, kwargs={"meta": meta})
 
     monkeypatch.setattr(embed_task, "request", request, raising=False)
@@ -73,7 +77,7 @@ def test_ingestion_upsert_hash_prevents_duplicates(tmp_path, monkeypatch):
 
     tenant = str(uuid.uuid4())
     case = str(uuid.uuid4())
-    meta = {"tenant": tenant, "case": case}
+    meta = {"tenant_id": tenant, "case_id": case}
 
     def _run_pipeline() -> int:
         raw = tasks.ingest_raw(meta, "doc.txt", b"User 123")
@@ -87,7 +91,7 @@ def test_ingestion_upsert_hash_prevents_duplicates(tmp_path, monkeypatch):
     second = _run_pipeline()
 
     client = vector_client.get_default_client()
-    results = client.search("User", {"tenant": tenant, "case": case})
+    results = client.search("User", {"tenant_id": tenant, "case_id": case})
 
     assert first == 1
     assert second == 1

--- a/tests/chaos/redis_faults.py
+++ b/tests/chaos/redis_faults.py
@@ -146,8 +146,8 @@ def _produce_agents_task(scope: dict[str, str]) -> bool:
         tracing.emit_event(  # pragma: no cover - defensive success path
             {
                 "event": "agents.queue.scheduled",
-                "tenant": scope.get("tenant_id"),
-                "case": scope.get("case_id"),
+                "tenant_id": scope.get("tenant_id"),
+                "case_id": scope.get("case_id"),
                 "trace_id": scope.get("trace_id"),
             }
         )
@@ -156,8 +156,8 @@ def _produce_agents_task(scope: dict[str, str]) -> bool:
         tracing.emit_event(
             {
                 "event": "agents.queue.backoff",
-                "tenant": scope.get("tenant_id"),
-                "case": scope.get("case_id"),
+                "tenant_id": scope.get("tenant_id"),
+                "case_id": scope.get("case_id"),
                 "trace_id": scope.get("trace_id"),
                 "error": str(exc),
             }
@@ -165,8 +165,8 @@ def _produce_agents_task(scope: dict[str, str]) -> bool:
         logger.warning(
             "agents.queue.backoff",
             error=str(exc),
-            tenant=scope.get("tenant_id"),
-            case=scope.get("case_id"),
+            tenant_id=scope.get("tenant_id"),
+            case_id=scope.get("case_id"),
         )
         return False
 

--- a/tests/rag/test_vector_client.py
+++ b/tests/rag/test_vector_client.py
@@ -196,7 +196,7 @@ def test_replace_chunks_normalises_embeddings(monkeypatch):
             "chunks": [
                 Chunk(
                     content="hello world",
-                    meta={"tenant": tenant, "hash": "hash-1", "source": "unit-test"},
+                    meta={"tenant_id": tenant, "hash": "hash-1", "source": "unit-test"},
                     embedding=[3.0, 4.0],
                 )
             ],
@@ -263,7 +263,7 @@ def test_hybrid_search_returns_vector_hits_with_normalised_query(monkeypatch):
     vector_row = (
         "chunk-vector",
         "vector candidate",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-vector",
         "doc-vector",
         0.12,
@@ -284,7 +284,7 @@ def test_hybrid_search_returns_vector_hits_with_normalised_query(monkeypatch):
     result = client.hybrid_search(
         "vector search",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         alpha=1.0,
         min_sim=0.0,
         top_k=1,
@@ -306,7 +306,7 @@ def test_trgm_limit_is_applied_and_yields_lexical_candidates(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.134,
@@ -323,7 +323,7 @@ def test_trgm_limit_is_applied_and_yields_lexical_candidates(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.01,
             top_k=3,
@@ -346,7 +346,7 @@ def test_lexical_fallback_populates_rows(monkeypatch):
     lexical_row = (
         "chunk-fallback",
         "ZEBRAGURKEN",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-fallback",
         "doc-fallback",
         0.096,
@@ -369,7 +369,7 @@ def test_lexical_fallback_populates_rows(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -400,7 +400,7 @@ def test_explicit_trgm_limit_fallback_uses_requested_threshold(monkeypatch):
     lexical_row = (
         "chunk-fallback",  # noqa: S105 - test data
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-fallback",
         "doc-fallback",
         0.111,
@@ -419,7 +419,7 @@ def test_explicit_trgm_limit_fallback_uses_requested_threshold(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             trgm_limit=0.05,
             alpha=0.0,
             min_sim=0.0,
@@ -455,7 +455,7 @@ def test_applies_set_limit_and_logs_applied_value(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.134,
@@ -473,7 +473,7 @@ def test_applies_set_limit_and_logs_applied_value(monkeypatch):
         client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             trgm_limit=0.05,
             alpha=0.0,
             min_sim=0.0,
@@ -500,7 +500,7 @@ def test_row_shape_mismatch_does_not_crash(monkeypatch):
     def _fake_run(_fn, *, op_name: str):
         # Return a vector row with only 5 columns to trigger padding
         return (
-            [("chunk-5", "text", {"tenant": tenant}, "hash-5", "doc-5")],
+            [("chunk-5", "text", {"tenant_id": tenant}, "hash-5", "doc-5")],
             [],
             1.2,
         )
@@ -512,7 +512,7 @@ def test_row_shape_mismatch_does_not_crash(monkeypatch):
         result = client.hybrid_search(
             "shape mismatch",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
 
@@ -534,7 +534,7 @@ def test_truncated_vector_row_populates_metadata(monkeypatch):
     truncated_row = (
         "chunk-short",
         "truncated text",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-short",
         "doc-short",
     )
@@ -547,13 +547,13 @@ def test_truncated_vector_row_populates_metadata(monkeypatch):
     result = client.hybrid_search(
         "truncate me",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         top_k=1,
     )
 
     assert len(result.chunks) == 1
     meta = result.chunks[0].meta
-    assert meta.get("tenant") == tenant
+    assert meta.get("tenant_id") == tenant
     assert meta.get("hash") == "hash-short"
     assert meta.get("id") == "doc-short"
     assert meta.get("vscore") == pytest.approx(0.0)
@@ -572,7 +572,7 @@ def test_lexical_only_scoring(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant, "case": "c1"},
+        {"tenant_id": tenant, "case_id": "c1"},
         "hash-lex",
         "doc-lex",
         0.13,
@@ -587,7 +587,7 @@ def test_lexical_only_scoring(monkeypatch):
         "only lexical",
         tenant_id=tenant,
         case_id="c1",
-        filters={"case": "c1"},
+        filters={"case_id": "c1"},
         top_k=1,
         alpha=0.0,
         min_sim=0.01,
@@ -612,7 +612,7 @@ def test_lexical_only_respects_min_sim_with_alpha(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.2,
@@ -626,7 +626,7 @@ def test_lexical_only_respects_min_sim_with_alpha(monkeypatch):
     result = client.hybrid_search(
         "only lexical",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         top_k=1,
         alpha=0.7,
         min_sim=0.15,
@@ -648,7 +648,7 @@ def test_hybrid_search_clamps_candidate_limits(monkeypatch):
     lexical_row = (
         "chunk-clamped",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-clamped",
         "doc-clamped",
         0.5,
@@ -664,7 +664,7 @@ def test_hybrid_search_clamps_candidate_limits(monkeypatch):
     result = client.hybrid_search(
         "clamp me",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         alpha=0.0,
         min_sim=0.0,
         top_k=10,
@@ -699,7 +699,7 @@ def test_upsert_retries_operational_error_once(monkeypatch):
     chunk = Chunk(
         content="retry me",
         meta={
-            "tenant": tenant,
+            "tenant_id": tenant,
             "hash": "hash-retry",
             "source": "unit-test",
             "external_id": "doc-retry",
@@ -815,7 +815,7 @@ def test_hybrid_search_recovers_when_vector_query_fails(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.42,
@@ -854,7 +854,7 @@ def test_hybrid_search_recovers_when_vector_query_fails(monkeypatch):
         result = client.hybrid_search(
             "vector fails",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -881,7 +881,7 @@ def test_hybrid_search_returns_vector_results_when_lexical_fails(monkeypatch):
     vector_row = (
         "chunk-vec",
         "vector",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-vec",
         "doc-vec",
         0.15,
@@ -923,7 +923,7 @@ def test_hybrid_search_returns_vector_results_when_lexical_fails(monkeypatch):
         result = client.hybrid_search(
             "lexical fails",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -987,7 +987,7 @@ def test_hybrid_search_raises_when_vector_and_lexical_fail(monkeypatch):
         client.hybrid_search(
             "both fail",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -1056,7 +1056,7 @@ def _insert_active_and_soft_deleted_documents(
                 0,
                 shared_text,
                 3,
-                Json({"tenant": tenant, "case": "alpha"}),
+                Json({"tenant_id": tenant, "case_id": "alpha"}),
             ),
         )
         cur.execute(
@@ -1072,8 +1072,8 @@ def _insert_active_and_soft_deleted_documents(
                 3,
                 Json(
                     {
-                        "tenant": tenant,
-                        "case": "alpha",
+                        "tenant_id": tenant,
+                        "case_id": "alpha",
                         "deleted_at": timestamp.isoformat(),
                     }
                 ),
@@ -1095,7 +1095,7 @@ def test_hybrid_search_filters_soft_deleted_documents():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1118,7 +1118,7 @@ def test_hybrid_search_rejects_visibility_filter_override_without_flag():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha", "visibility": "deleted"},
+        filters={"case_id": "alpha", "visibility": "deleted"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1140,7 +1140,7 @@ def test_hybrid_search_returns_deleted_with_default_override():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1166,7 +1166,7 @@ def test_hybrid_search_returns_all_with_default_override():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,


### PR DESCRIPTION
## Summary
- standardize ingestion and vector metadata dictionaries to use the canonical `tenant_id` and `case_id` keys
- propagate the canonical identifiers through view meta normalization, graph responses, and tracing/LLM integrations
- update unit tests and supporting helpers to assert against the renamed metadata keys

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'InternalToolError' from 'ai_core.tool_contracts')*

------
https://chatgpt.com/codex/tasks/task_e_68e621c7c238832b8617c870b65bf8cb