### PR TITLE
Refactor metadata keys to tenant_id and case_id

### DIFF
--- a/ai_core/graphs/info_intake.py
+++ b/ai_core/graphs/info_intake.py
@@ -11,7 +11,7 @@ def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
     state:
         Mutable workflow state.
     meta:
-        Context containing ``tenant``, ``case`` and ``trace_id``.
+        Context containing ``tenant_id``, ``case_id`` and ``trace_id``.
 
     Returns
     -------
@@ -23,7 +23,7 @@ def run(state: Dict, meta: Dict) -> Tuple[Dict, Dict]:
     new_state.setdefault("meta", meta)
     result = {
         "received": True,
-        "tenant": meta.get("tenant"),
-        "case": meta.get("case"),
+        "tenant_id": meta.get("tenant_id"),
+        "case_id": meta.get("case_id"),
     }
     return new_state, result

--- a/ai_core/graphs/retrieval_augmented_generation.py
+++ b/ai_core/graphs/retrieval_augmented_generation.py
@@ -48,7 +48,7 @@ def _ensure_mutable_meta(
 
 
 def _build_tool_context(meta: MutableMapping[str, Any]) -> ToolContext:
-    tenant_raw = meta.get("tenant_id") or meta.get("tenant")
+    tenant_raw = meta.get("tenant_id")
     tenant_text = str(tenant_raw or "").strip()
     if not tenant_text:
         raise ContextError(
@@ -62,7 +62,7 @@ def _build_tool_context(meta: MutableMapping[str, Any]) -> ToolContext:
         str(tenant_schema_raw).strip() if tenant_schema_raw is not None else None
     )
 
-    case_raw = meta.get("case_id") or meta.get("case")
+    case_raw = meta.get("case_id")
     case_id = str(case_raw).strip() if case_raw is not None else None
     if not case_id:
         raise ContextError("case_id is required for retrieval graphs", field="case_id")

--- a/ai_core/infra/resp.py
+++ b/ai_core/infra/resp.py
@@ -28,8 +28,8 @@ def apply_std_headers(response: HttpResponse, meta: Meta) -> HttpResponse:
 
     header_map = {
         X_TRACE_ID_HEADER: meta.get("trace_id"),
-        X_CASE_ID_HEADER: meta.get("case"),
-        X_TENANT_ID_HEADER: meta.get("tenant"),
+        X_CASE_ID_HEADER: meta.get("case_id"),
+        X_TENANT_ID_HEADER: meta.get("tenant_id"),
         X_KEY_ALIAS_HEADER: meta.get("key_alias"),
         "traceparent": meta.get("traceparent"),
     }

--- a/ai_core/middleware/context.py
+++ b/ai_core/middleware/context.py
@@ -76,9 +76,9 @@ class RequestContextMiddleware:
         if span_id:
             response_meta["span_id"] = span_id
         if tenant_id:
-            response_meta["tenant"] = tenant_id
+            response_meta["tenant_id"] = tenant_id
         if case_id:
-            response_meta["case"] = case_id
+            response_meta["case_id"] = case_id
         if key_alias:
             response_meta["key_alias"] = key_alias
         if idempotency_key:

--- a/ai_core/rag/filters.py
+++ b/ai_core/rag/filters.py
@@ -9,8 +9,8 @@ def strict_match(
     - When `tenant` is None, do not filter by tenant.
     - When `case` is None, do not filter by case.
     """
-    if tenant is not None and meta.get("tenant") != tenant:
+    if tenant is not None and meta.get("tenant_id") != tenant:
         return False
-    if case is not None and meta.get("case") != case:
+    if case is not None and meta.get("case_id") != case:
         return False
     return True

--- a/ai_core/rag/vector_store.py
+++ b/ai_core/rag/vector_store.py
@@ -663,12 +663,12 @@ class VectorStoreRouter:
         chunk_list = list(chunks)
         expected_tenant = str(tenant_id).strip() if tenant_id is not None else None
         for chunk in chunk_list:
-            tenant_meta = str(chunk.meta.get("tenant") or "").strip()
+            tenant_meta = str(chunk.meta.get("tenant_id") or "").strip()
             if not tenant_meta:
-                raise ValueError("chunk metadata must include tenant")
+                raise ValueError("chunk metadata must include tenant_id")
             if expected_tenant is not None and tenant_meta != expected_tenant:
                 raise ValueError(
-                    "Chunk tenant '%s' does not match expected tenant '%s'"
+                    "Chunk tenant_id '%s' does not match expected tenant '%s'"
                     % (tenant_meta, expected_tenant)
                 )
         logger.debug("Upserting chunks", extra={"scope": target_scope})
@@ -807,15 +807,15 @@ class _TenantScopedClient:
         coerced: list[Chunk] = []
         for chunk in chunk_list:
             meta = dict(chunk.meta)
-            tenant_meta_raw = meta.get("tenant")
+            tenant_meta_raw = meta.get("tenant_id")
             tenant_meta = str(tenant_meta_raw).strip() if tenant_meta_raw else ""
             if tenant_meta and tenant_meta != self._tenant_id:
-                msg = "Chunk tenant '%s' does not match scoped tenant '%s'" % (
+                msg = "Chunk tenant_id '%s' does not match scoped tenant '%s'" % (
                     tenant_meta,
                     self._tenant_id,
                 )
                 raise ValueError(msg)
-            meta["tenant"] = self._tenant_id
+            meta["tenant_id"] = self._tenant_id
             coerced.append(
                 Chunk(content=chunk.content, meta=meta, embedding=chunk.embedding)
             )

--- a/ai_core/tasks.py
+++ b/ai_core/tasks.py
@@ -35,8 +35,8 @@ logger = get_logger(__name__)
 
 
 def _build_path(meta: Dict[str, str], *parts: str) -> str:
-    tenant = object_store.sanitize_identifier(meta["tenant"])
-    case = object_store.sanitize_identifier(meta["case"])
+    tenant = object_store.sanitize_identifier(meta["tenant_id"])
+    case = object_store.sanitize_identifier(meta["case_id"])
     return "/".join([tenant, case, *parts])
 
 
@@ -52,8 +52,8 @@ def log_ingestion_run_start(
     vector_space_id: Optional[str] = None,
 ) -> None:
     extra = {
-        "tenant": tenant,
-        "case": case,
+        "tenant_id": tenant,
+        "case_id": case,
         "run_id": run_id,
         "doc_count": doc_count,
     }
@@ -91,8 +91,8 @@ def log_ingestion_run_end(
     vector_space_id: Optional[str] = None,
 ) -> None:
     extra = {
-        "tenant": tenant,
-        "case": case,
+        "tenant_id": tenant,
+        "case_id": case,
         "run_id": run_id,
         "doc_count": doc_count,
         "inserted": inserted,
@@ -379,8 +379,8 @@ def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
             chunk_text = f"{prefix}\n\n{body}" if body else prefix
         normalised = normalise_text(chunk_text)
         chunk_meta = {
-            "tenant": meta["tenant"],
-            "case": meta.get("case"),
+            "tenant_id": meta["tenant_id"],
+            "case_id": meta.get("case_id"),
             "source": text_path,
             "hash": content_hash,
             "external_id": external_id,
@@ -405,8 +405,8 @@ def chunk(meta: Dict[str, str], text_path: str) -> Dict[str, str]:
     if not chunks:
         normalised = normalise_text(text)
         chunk_meta = {
-            "tenant": meta["tenant"],
-            "case": meta.get("case"),
+            "tenant_id": meta["tenant_id"],
+            "case_id": meta.get("case_id"),
             "source": text_path,
             "hash": content_hash,
             "external_id": external_id,
@@ -535,13 +535,13 @@ def upsert(
             Chunk(content=ch["content"], meta=ch["meta"], embedding=embedding)
         )
 
-    tenant_id: Optional[str] = meta.get("tenant") if meta else None
+    tenant_id: Optional[str] = meta.get("tenant_id") if meta else None
     if not tenant_id:
         tenant_id = next(
             (
-                str(chunk.meta.get("tenant"))
+                str(chunk.meta.get("tenant_id"))
                 for chunk in chunk_objs
-                if chunk.meta and chunk.meta.get("tenant")
+                if chunk.meta and chunk.meta.get("tenant_id")
             ),
             None,
         )
@@ -549,7 +549,7 @@ def upsert(
         raise ValueError("tenant_id required for upsert")
 
     for chunk in chunk_objs:
-        chunk_tenant = chunk.meta.get("tenant") if chunk.meta else None
+        chunk_tenant = chunk.meta.get("tenant_id") if chunk.meta else None
         if chunk_tenant and str(chunk_tenant) != tenant_id:
             raise ValueError("chunk tenant mismatch")
 
@@ -601,7 +601,7 @@ def ingestion_run(
     logger.info(
         "Queued ingestion run",
         extra={
-            "tenant": tenant_id,
+            "tenant_id": tenant_id,
             "case_id": case_id,
             "document_ids": document_ids,
             "priority": priority,

--- a/ai_core/tests/test_graph_retrieval_augmented_generation.py
+++ b/ai_core/tests/test_graph_retrieval_augmented_generation.py
@@ -68,7 +68,7 @@ def test_graph_normalises_tenant_alias() -> None:
         compose_node=_fake_compose,
     )
 
-    meta = {"tenant": "tenant-alias", "case_id": "case-1"}
+    meta = {"tenant_id": "tenant-alias", "case_id": "case-1"}
     state, result = graph.run({}, meta)
 
     assert meta["tenant_id"] == "tenant-alias"

--- a/ai_core/tests/test_graphs.py
+++ b/ai_core/tests/test_graphs.py
@@ -5,13 +5,13 @@ from ai_core.graphs import (
     system_description,
 )
 
-META = {"tenant": "t1", "case": "c1", "trace_id": "tr"}
+META = {"tenant_id": "t1", "case_id": "c1", "trace_id": "tr"}
 
 
 def test_info_intake_adds_meta():
     state, result = info_intake.run({}, META)
     assert state["meta"] == META
-    assert result["tenant"] == META["tenant"]
+    assert result["tenant_id"] == META["tenant_id"]
 
 
 def test_scope_check_never_creates_draft():

--- a/ai_core/tests/test_infra.py
+++ b/ai_core/tests/test_infra.py
@@ -38,8 +38,8 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
     resp = HttpResponse("ok", status=200)
     meta = {
         "trace_id": "abc123",
-        "case": "case-1",
-        "tenant": "tenant-1",
+        "case_id": "case-1",
+        "tenant_id": "tenant-1",
         "key_alias": "alias-1",
         "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     }
@@ -55,7 +55,11 @@ def test_apply_std_headers_sets_metadata_headers_for_success():
 
 def test_apply_std_headers_skips_missing_optional_headers():
     resp = HttpResponse("ok", status=200)
-    meta = {"trace_id": "abc123", "case": "case-1", "tenant": "tenant-1"}
+    meta = {
+        "trace_id": "abc123",
+        "case_id": "case-1",
+        "tenant_id": "tenant-1",
+    }
 
     result = apply_std_headers(resp, meta)
 
@@ -67,8 +71,8 @@ def test_apply_std_headers_skips_missing_optional_headers():
 def test_apply_std_headers_ignores_non_success_responses():
     meta = {
         "trace_id": "abc123",
-        "case": "case-1",
-        "tenant": "tenant-1",
+        "case_id": "case-1",
+        "tenant_id": "tenant-1",
         "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     }
 

--- a/ai_core/tests/test_management_rebuild_rag_index.py
+++ b/ai_core/tests/test_management_rebuild_rag_index.py
@@ -327,7 +327,7 @@ def test_rebuild_rag_index_health_check(
         "Vector index smoke check",
         tenant_id=tenant,
         top_k=2,
-        filters={"case": case},
+        filters={"case_id": case},
     )
 
     assert len(results) == 2

--- a/ai_core/tests/test_rag_filters.py
+++ b/ai_core/tests/test_rag_filters.py
@@ -2,15 +2,15 @@ from ai_core.rag.filters import strict_match
 
 
 def test_strict_match_positive():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t1", "c1") is True
 
 
 def test_strict_match_negative():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t1", "c2") is False
 
 
 def test_strict_match_negative_tenant():
-    meta = {"tenant": "t1", "case": "c1", "source": "s1", "hash": "h1"}
+    meta = {"tenant_id": "t1", "case_id": "c1", "source": "s1", "hash": "h1"}
     assert strict_match(meta, "t2", "c1") is False

--- a/ai_core/tests/test_tasks.py
+++ b/ai_core/tests/test_tasks.py
@@ -92,7 +92,7 @@ def test_upsert_persists_chunks(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     tenant = str(uuid.uuid4())
     case = str(uuid.uuid4())
-    meta = {"tenant": tenant, "case": case, "external_id": "doc-1"}
+    meta = {"tenant_id": tenant, "case_id": case, "external_id": "doc-1"}
     vector_client.reset_default_client()
 
     raw = tasks.ingest_raw(meta, "doc.txt", b"User 123")
@@ -117,7 +117,7 @@ def test_upsert_persists_chunks(tmp_path, monkeypatch):
 
 def test_upsert_forwards_tenant_schema(monkeypatch):
     meta = {
-        "tenant": "tenant-42",
+        "tenant_id": "tenant-42",
         "tenant_schema": "schema-tenant-42",
     }
 
@@ -125,7 +125,7 @@ def test_upsert_forwards_tenant_schema(monkeypatch):
         {
             "content": "payload",
             "embedding": [0.0],
-            "meta": {"tenant": "tenant-42"},
+            "meta": {"tenant_id": "tenant-42"},
         }
     ]
 
@@ -153,7 +153,7 @@ def test_upsert_forwards_tenant_schema(monkeypatch):
 
 def test_upsert_raises_on_dimension_mismatch(monkeypatch):
     meta = {
-        "tenant": "tenant-42",
+        "tenant_id": "tenant-42",
         "embedding_profile": "standard",
         "vector_space_id": "global",
         "vector_space_dimension": 2,
@@ -165,7 +165,7 @@ def test_upsert_raises_on_dimension_mismatch(monkeypatch):
             "content": "payload",
             "embedding": [0.0],
             "meta": {
-                "tenant": "tenant-42",
+                "tenant_id": "tenant-42",
                 "embedding_profile": "standard",
                 "vector_space_id": "global",
                 "external_id": "doc-1",
@@ -232,8 +232,8 @@ def test_task_logging_context_includes_metadata(monkeypatch, tmp_path, settings)
     with capture_logs() as logs:
         tasks.ingest_raw(
             {
-                "tenant": "tenant-123",
-                "case": "case-456",
+                "tenant_id": "tenant-123",
+                "case_id": "case-456",
                 "trace_id": "trace-7890",
                 "key_alias": "alias-1234",
                 "external_id": "doc-logging",
@@ -256,12 +256,16 @@ def test_task_logging_context_includes_metadata(monkeypatch, tmp_path, settings)
 
 def test_ingest_raw_sanitizes_meta(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    meta = {"tenant": "Tenant Name", "case": "Case*ID", "external_id": "doc-1"}
+    meta = {
+        "tenant_id": "Tenant Name",
+        "case_id": "Case*ID",
+        "external_id": "doc-1",
+    }
 
     result = tasks.ingest_raw(meta, "doc.txt", b"payload")
 
-    safe_tenant = object_store.sanitize_identifier(meta["tenant"])
-    safe_case = object_store.sanitize_identifier(meta["case"])
+    safe_tenant = object_store.sanitize_identifier(meta["tenant_id"])
+    safe_case = object_store.sanitize_identifier(meta["case_id"])
     assert result["path"] == f"{safe_tenant}/{safe_case}/raw/doc.txt"
 
     stored = tmp_path / ".ai_core_store" / safe_tenant / safe_case / "raw" / "doc.txt"
@@ -270,7 +274,11 @@ def test_ingest_raw_sanitizes_meta(tmp_path, monkeypatch):
 
 def test_ingest_raw_rejects_unsafe_meta(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    meta = {"tenant": "tenant/../", "case": "case", "external_id": "doc-unsafe"}
+    meta = {
+        "tenant_id": "tenant/../",
+        "case_id": "case",
+        "external_id": "doc-unsafe",
+    }
 
     original_request = getattr(tasks.ingest_raw, "request", None)
     tasks.ingest_raw.request = SimpleNamespace(headers=None, kwargs=None)

--- a/ai_core/tests/test_vector_pg_integration.py
+++ b/ai_core/tests/test_vector_pg_integration.py
@@ -21,7 +21,7 @@ def _make_chunk(tenant_id: str, ordinal: int, *, hash_id: str) -> Chunk:
     return Chunk(
         content=f"tenant-{tenant_id}-chunk-{ordinal}",
         meta={
-            "tenant": tenant_id,
+            "tenant_id": tenant_id,
             "hash": hash_id,
             "source": "integration-test",
             "external_id": f"{hash_id}-external",
@@ -65,7 +65,7 @@ def test_router_roundtrip_with_pgvector_backend(monkeypatch) -> None:
         )
         assert len(results) == len(tenant_chunks)
         assert len(results) <= 10
-        assert {chunk.meta.get("tenant") for chunk in results} == {tenant_id}
+        assert {chunk.meta.get("tenant_id") for chunk in results} == {tenant_id}
         assert all("hash" in chunk.meta for chunk in results)
         assert all(0.0 <= chunk.meta.get("score", 0.0) <= 1.0 for chunk in results)
 
@@ -75,7 +75,7 @@ def test_router_roundtrip_with_pgvector_backend(monkeypatch) -> None:
             top_k=25,
         )
         assert len(isolated_results) == len(other_chunks)
-        assert {chunk.meta.get("tenant") for chunk in isolated_results} == {
+        assert {chunk.meta.get("tenant_id") for chunk in isolated_results} == {
             other_tenant_id
         }
 

--- a/ai_core/tests/test_views.py
+++ b/ai_core/tests/test_views.py
@@ -169,7 +169,7 @@ def test_tenant_schema_header_match_allows_request(
     assert resp.status_code == 200
     assert resp[X_TENANT_ID_HEADER] == "tenant-header"
     assert resp[X_CASE_ID_HEADER] == "c"
-    assert resp.json()["tenant"] == "tenant-header"
+    assert resp.json()["tenant_id"] == "tenant-header"
     assert seen["tenant"] == "tenant-header"
 
 
@@ -239,12 +239,12 @@ def test_intake_persists_state_and_headers(
     assert resp[X_CASE_ID_HEADER] == "case-123"
     assert resp[X_TENANT_ID_HEADER] == tenant_header
     assert X_KEY_ALIAS_HEADER not in resp
-    assert resp.json()["tenant"] == tenant_header
+    assert resp.json()["tenant_id"] == tenant_header
 
     state = object_store.read_json(f"{tenant_header}/case-123/state.json")
-    assert state["meta"]["tenant"] == tenant_header
+    assert state["meta"]["tenant_id"] == tenant_header
     assert state["meta"]["tenant_schema"] == test_tenant_schema_name
-    assert state["meta"]["case"] == "case-123"
+    assert state["meta"]["case_id"] == "case-123"
 
 
 @pytest.mark.django_db
@@ -321,8 +321,8 @@ def test_request_logging_context_includes_metadata(monkeypatch, tmp_path):
         def run(self, state, meta):
             context = common_logging.get_log_context()
             assert context["trace_id"] == meta["trace_id"]
-            assert context["case_id"] == meta["case"]
-            assert context["tenant"] == meta["tenant"]
+            assert context["case_id"] == meta["case_id"]
+            assert context["tenant"] == meta["tenant_id"]
             assert context.get("key_alias") == meta.get("key_alias")
             logger.info("graph-run")
             return state, {"ok": True}

--- a/common/celery.py
+++ b/common/celery.py
@@ -102,11 +102,11 @@ class ContextTask(Task):
         if trace_id:
             context["trace_id"] = self._normalize(trace_id)
 
-        case = meta.get("case_id") or meta.get("case")
+        case = meta.get("case_id")
         if case:
             context["case_id"] = self._normalize(case)
 
-        tenant = meta.get("tenant")
+        tenant = meta.get("tenant_id")
         if tenant:
             context["tenant"] = self._normalize(tenant)
 

--- a/noesis2/api/serializers.py
+++ b/noesis2/api/serializers.py
@@ -39,8 +39,8 @@ class IntakeResponseSerializer(IdempotentResponseSerializer):
     """Successful response returned by the agent intake endpoint."""
 
     received = serializers.BooleanField()
-    tenant = serializers.CharField()
-    case = serializers.CharField()
+    tenant_id = serializers.CharField()
+    case_id = serializers.CharField()
 
 
 class ScopeResponseSerializer(IdempotentResponseSerializer):

--- a/noesis2/tests/test_api_schema.py
+++ b/noesis2/tests/test_api_schema.py
@@ -283,8 +283,8 @@ def test_ai_core_endpoints_expose_serializers():
         "application/json"
     ]["schema"]["$ref"]
     _, intake_response_component = _extract_component(schema, intake_response_ref)
-    assert "tenant" in intake_response_component["properties"]
-    assert intake_response_component["properties"]["tenant"]["type"] == "string"
+    assert "tenant_id" in intake_response_component["properties"]
+    assert intake_response_component["properties"]["tenant_id"]["type"] == "string"
     assert intake_response_component["properties"]["idempotent"]["type"] == "boolean"
     intake_request_examples = intake_operation["requestBody"]["content"][
         "application/json"
@@ -297,7 +297,7 @@ def test_ai_core_endpoints_expose_serializers():
         "application/json"
     ].get("examples", {})
     assert any(
-        example.get("value", {}).get("tenant") == "acme"
+        example.get("value", {}).get("tenant_id") == "acme"
         for example in intake_response_examples.values()
     )
     assert any(

--- a/tests/chaos/ingestion_faults.py
+++ b/tests/chaos/ingestion_faults.py
@@ -28,7 +28,11 @@ def test_ingestion_embed_retry_profile_and_dead_letter(monkeypatch):
     expected_delays = [30, 60, 120, 240, 300]
     recorded_delays: list[int | None] = []
     observed_events: list[dict[str, object]] = []
-    meta = {"tenant": "tenant-chaos", "case": "case-chaos", "trace_id": "trace-chaos"}
+    meta = {
+        "tenant_id": "tenant-chaos",
+        "case_id": "case-chaos",
+        "trace_id": "trace-chaos",
+    }
     request = SimpleNamespace(retries=0, headers={}, kwargs={"meta": meta})
 
     monkeypatch.setattr(embed_task, "request", request, raising=False)
@@ -73,7 +77,7 @@ def test_ingestion_upsert_hash_prevents_duplicates(tmp_path, monkeypatch):
 
     tenant = str(uuid.uuid4())
     case = str(uuid.uuid4())
-    meta = {"tenant": tenant, "case": case}
+    meta = {"tenant_id": tenant, "case_id": case}
 
     def _run_pipeline() -> int:
         raw = tasks.ingest_raw(meta, "doc.txt", b"User 123")
@@ -87,7 +91,7 @@ def test_ingestion_upsert_hash_prevents_duplicates(tmp_path, monkeypatch):
     second = _run_pipeline()
 
     client = vector_client.get_default_client()
-    results = client.search("User", {"tenant": tenant, "case": case})
+    results = client.search("User", {"tenant_id": tenant, "case_id": case})
 
     assert first == 1
     assert second == 1

--- a/tests/chaos/perf_smoke.py
+++ b/tests/chaos/perf_smoke.py
@@ -72,7 +72,7 @@ def _execute_scope(case_id: str, tenant: str, tenant_schema: str) -> ScopeRespon
     """Issue a single /ai/scope/ request and record metrics."""
 
     client = Client()
-    payload = {"scope": {"topic": "chaos", "case": case_id}}
+    payload = {"scope": {"topic": "chaos", "case_id": case_id}}
     headers = {
         META_TENANT_ID_KEY: tenant,
         META_TENANT_SCHEMA_KEY: tenant_schema,

--- a/tests/chaos/redis_faults.py
+++ b/tests/chaos/redis_faults.py
@@ -147,7 +147,7 @@ def _produce_agents_task(scope: dict[str, str]) -> bool:
             {
                 "event": "agents.queue.scheduled",
                 "tenant": scope.get("tenant_id"),
-                "case": scope.get("case_id"),
+                "case_id": scope.get("case_id"),
                 "trace_id": scope.get("trace_id"),
             }
         )
@@ -157,7 +157,7 @@ def _produce_agents_task(scope: dict[str, str]) -> bool:
             {
                 "event": "agents.queue.backoff",
                 "tenant": scope.get("tenant_id"),
-                "case": scope.get("case_id"),
+                "case_id": scope.get("case_id"),
                 "trace_id": scope.get("trace_id"),
                 "error": str(exc),
             }

--- a/tests/rag/test_vector_client.py
+++ b/tests/rag/test_vector_client.py
@@ -196,7 +196,7 @@ def test_replace_chunks_normalises_embeddings(monkeypatch):
             "chunks": [
                 Chunk(
                     content="hello world",
-                    meta={"tenant": tenant, "hash": "hash-1", "source": "unit-test"},
+                    meta={"tenant_id": tenant, "hash": "hash-1", "source": "unit-test"},
                     embedding=[3.0, 4.0],
                 )
             ],
@@ -263,7 +263,7 @@ def test_hybrid_search_returns_vector_hits_with_normalised_query(monkeypatch):
     vector_row = (
         "chunk-vector",
         "vector candidate",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-vector",
         "doc-vector",
         0.12,
@@ -284,7 +284,7 @@ def test_hybrid_search_returns_vector_hits_with_normalised_query(monkeypatch):
     result = client.hybrid_search(
         "vector search",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         alpha=1.0,
         min_sim=0.0,
         top_k=1,
@@ -306,7 +306,7 @@ def test_trgm_limit_is_applied_and_yields_lexical_candidates(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.134,
@@ -323,7 +323,7 @@ def test_trgm_limit_is_applied_and_yields_lexical_candidates(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.01,
             top_k=3,
@@ -346,7 +346,7 @@ def test_lexical_fallback_populates_rows(monkeypatch):
     lexical_row = (
         "chunk-fallback",
         "ZEBRAGURKEN",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-fallback",
         "doc-fallback",
         0.096,
@@ -369,7 +369,7 @@ def test_lexical_fallback_populates_rows(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -400,7 +400,7 @@ def test_explicit_trgm_limit_fallback_uses_requested_threshold(monkeypatch):
     lexical_row = (
         "chunk-fallback",  # noqa: S105 - test data
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-fallback",
         "doc-fallback",
         0.111,
@@ -419,7 +419,7 @@ def test_explicit_trgm_limit_fallback_uses_requested_threshold(monkeypatch):
         result = client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             trgm_limit=0.05,
             alpha=0.0,
             min_sim=0.0,
@@ -455,7 +455,7 @@ def test_applies_set_limit_and_logs_applied_value(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.134,
@@ -473,7 +473,7 @@ def test_applies_set_limit_and_logs_applied_value(monkeypatch):
         client.hybrid_search(
             "zebragurke",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             trgm_limit=0.05,
             alpha=0.0,
             min_sim=0.0,
@@ -500,7 +500,7 @@ def test_row_shape_mismatch_does_not_crash(monkeypatch):
     def _fake_run(_fn, *, op_name: str):
         # Return a vector row with only 5 columns to trigger padding
         return (
-            [("chunk-5", "text", {"tenant": tenant}, "hash-5", "doc-5")],
+            [("chunk-5", "text", {"tenant_id": tenant}, "hash-5", "doc-5")],
             [],
             1.2,
         )
@@ -512,7 +512,7 @@ def test_row_shape_mismatch_does_not_crash(monkeypatch):
         result = client.hybrid_search(
             "shape mismatch",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             top_k=3,
         )
 
@@ -534,7 +534,7 @@ def test_truncated_vector_row_populates_metadata(monkeypatch):
     truncated_row = (
         "chunk-short",
         "truncated text",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-short",
         "doc-short",
     )
@@ -547,13 +547,13 @@ def test_truncated_vector_row_populates_metadata(monkeypatch):
     result = client.hybrid_search(
         "truncate me",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         top_k=1,
     )
 
     assert len(result.chunks) == 1
     meta = result.chunks[0].meta
-    assert meta.get("tenant") == tenant
+    assert meta.get("tenant_id") == tenant
     assert meta.get("hash") == "hash-short"
     assert meta.get("id") == "doc-short"
     assert meta.get("vscore") == pytest.approx(0.0)
@@ -572,7 +572,7 @@ def test_lexical_only_scoring(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant, "case": "c1"},
+        {"tenant_id": tenant, "case_id": "c1"},
         "hash-lex",
         "doc-lex",
         0.13,
@@ -587,7 +587,7 @@ def test_lexical_only_scoring(monkeypatch):
         "only lexical",
         tenant_id=tenant,
         case_id="c1",
-        filters={"case": "c1"},
+        filters={"case_id": "c1"},
         top_k=1,
         alpha=0.0,
         min_sim=0.01,
@@ -612,7 +612,7 @@ def test_lexical_only_respects_min_sim_with_alpha(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.2,
@@ -626,7 +626,7 @@ def test_lexical_only_respects_min_sim_with_alpha(monkeypatch):
     result = client.hybrid_search(
         "only lexical",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         top_k=1,
         alpha=0.7,
         min_sim=0.15,
@@ -648,7 +648,7 @@ def test_hybrid_search_clamps_candidate_limits(monkeypatch):
     lexical_row = (
         "chunk-clamped",
         "lexical match",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-clamped",
         "doc-clamped",
         0.5,
@@ -664,7 +664,7 @@ def test_hybrid_search_clamps_candidate_limits(monkeypatch):
     result = client.hybrid_search(
         "clamp me",
         tenant_id=tenant,
-        filters={"case": None},
+        filters={"case_id": None},
         alpha=0.0,
         min_sim=0.0,
         top_k=10,
@@ -699,7 +699,7 @@ def test_upsert_retries_operational_error_once(monkeypatch):
     chunk = Chunk(
         content="retry me",
         meta={
-            "tenant": tenant,
+            "tenant_id": tenant,
             "hash": "hash-retry",
             "source": "unit-test",
             "external_id": "doc-retry",
@@ -815,7 +815,7 @@ def test_hybrid_search_recovers_when_vector_query_fails(monkeypatch):
     lexical_row = (
         "chunk-lex",
         "lexical",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-lex",
         "doc-lex",
         0.42,
@@ -854,7 +854,7 @@ def test_hybrid_search_recovers_when_vector_query_fails(monkeypatch):
         result = client.hybrid_search(
             "vector fails",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -881,7 +881,7 @@ def test_hybrid_search_returns_vector_results_when_lexical_fails(monkeypatch):
     vector_row = (
         "chunk-vec",
         "vector",
-        {"tenant": tenant},
+        {"tenant_id": tenant},
         "hash-vec",
         "doc-vec",
         0.15,
@@ -923,7 +923,7 @@ def test_hybrid_search_returns_vector_results_when_lexical_fails(monkeypatch):
         result = client.hybrid_search(
             "lexical fails",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -987,7 +987,7 @@ def test_hybrid_search_raises_when_vector_and_lexical_fail(monkeypatch):
         client.hybrid_search(
             "both fail",
             tenant_id=tenant,
-            filters={"case": None},
+            filters={"case_id": None},
             alpha=0.0,
             min_sim=0.0,
             top_k=3,
@@ -1056,7 +1056,7 @@ def _insert_active_and_soft_deleted_documents(
                 0,
                 shared_text,
                 3,
-                Json({"tenant": tenant, "case": "alpha"}),
+                Json({"tenant_id": tenant, "case_id": "alpha"}),
             ),
         )
         cur.execute(
@@ -1072,8 +1072,8 @@ def _insert_active_and_soft_deleted_documents(
                 3,
                 Json(
                     {
-                        "tenant": tenant,
-                        "case": "alpha",
+                        "tenant_id": tenant,
+                        "case_id": "alpha",
                         "deleted_at": timestamp.isoformat(),
                     }
                 ),
@@ -1095,7 +1095,7 @@ def test_hybrid_search_filters_soft_deleted_documents():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1118,7 +1118,7 @@ def test_hybrid_search_rejects_visibility_filter_override_without_flag():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha", "visibility": "deleted"},
+        filters={"case_id": "alpha", "visibility": "deleted"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1140,7 +1140,7 @@ def test_hybrid_search_returns_deleted_with_default_override():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,
@@ -1166,7 +1166,7 @@ def test_hybrid_search_returns_all_with_default_override():
     result = client.hybrid_search(
         search_text,
         tenant_id=tenant,
-        filters={"case": "alpha"},
+        filters={"case_id": "alpha"},
         alpha=0.0,
         min_sim=0.0,
         top_k=5,


### PR DESCRIPTION
## Summary
- replace intake metadata usage with tenant_id and case_id across graphs, views, and serializers
- update ingestion tasks, vector routing, and celery context to expect canonical tenant/case identifiers
- align tests and fixtures with the new metadata keys for application, chaos, and schema coverage

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e649992a44832b9eb26295fc9765a8